### PR TITLE
Review pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A manager tool to enable two-scale macro-micro coupling using the coupling libra
 
 ## Installing the package
 
-### Using pip3
+### Option 1: Using pip
 
 It is recommended to install [micro-manager from PyPI]() by running
 
@@ -14,7 +14,7 @@ pip3 install --user micro-manager
 
 If the dependencies are not installed, then `pip` will attempt to install them for you. If you encounter problems in the direct installation, see the [dependencies section](https://github.com/precice/micro-manager#required-dependencies) below for links to installation procedures of all dependencies.
 
-### Clone this repository and use pip3
+### Option 2: Clone this repository and use pip
 
 #### Required dependencies
 
@@ -22,64 +22,111 @@ Ensure that the following dependencies are installed:
 
 * [preCICE](https://github.com/precice/precice/wiki)
 * python3 (this adapter **only supports python3**)
-* [the python language bindings for preCICE](https://github.com/precice/python-bindings)
-* [numpy](https://numpy.org/install/) and [mpi4py](https://mpi4py.readthedocs.io/en/stable/install.html)
+* [python language bindings for preCICE](https://github.com/precice/python-bindings)
+* [numpy](https://numpy.org/install/)
+* [mpi4py](https://mpi4py.readthedocs.io/en/stable/install.html)
 
 #### Build and install the manager
 
-After cloning this repository, go to the project directory `micro-manager` and run `pip3 install --user .`.
+After cloning this repository, step into the project directory `micro-manager` and run `pip3 install --user .`.
 
 ## Using the micro-manager
 
-The micro-manager facilitates two-scale coupling between a macro-scale simulation and several micro-scale simulations. The manager creates and controls a set of micro-problems and couples them to one macro-simulation using preCICE. An existing micro-simulation script needs to be converted into a library have a specific structure so that the micro-manager can create and steer the micro-problems. The micro-simulation library needs to have a class so that the micro-manager can create objects of this class for each micro-simulation and steer them till the end of the coupled simulation.
+The micro-manager facilitates two-scale coupling between a macro-scale simulation and many micro-scale simulations. The manager creates and controls a set of micro problems and couples them to one macro simulation using preCICE. 
 
-The macro-problem script is coupled to preCICE directly. Check the section [couple your code](https://precice.org/couple-your-code-overview.html) in the preCICE documentation for more details.
+To this end, an existing micro-simulation script needs to be converted into a Python library with a specific structure so that the micro manager can create and steer the micro simulations. Such a micro-simulation library needs to have a central class to represent one micro simulation. The micro manager then creates many instances of this class, one for each micro simulation, and steers them till the end of the coupled simulation.
+
+The macro-problem script, on the other hand, is coupled to preCICE directly (just as it would be volume-coupled via preCICE to any other code). The section [couple your code](https://precice.org/couple-your-code-overview.html) of the preCICE documentation gives more details.
 
 ### Steps to convert micro-simulation code to a callable library
 
-* Create a class called `MicroSimulation` which consists of all the functions of the micro-simulation. It is good practice to define class member variables in the class constructor `__init__`.
-* **Optional step**: Define a function `initialize` which computes the initial state of the micro-simulation and returns the initial values which need to be transferred to the macro-simulation. The return entity needs to be a Python dictionary having the names of the quantities being returned as the keys and the values of the quantities as the values in the dictionary.
-* Create a function named `solve` which should consist of all the solving steps for one time step of a micro-simulation or if the micro-problem is steady-state then solving until the steady-state is achieved. The `solve` function returns the quantities that need to be written to the macro-side. The return entity needs to be a Python dictionary having the names of the quantities being returned as the keys and the values of the quantities as the values in the dictionary.
-* If implicit coupling is required between the macro- and micro- problems, then you can additionally define two functions `save_checkpoint` and `revert_to_checkpoint`.
-  * `save_checkpoint` saves the state of the micro-problem such that if the implicit time-step does not convergence, then the micro-problem can be reversed to this state.
-  * `revert_to_checkpoint` reverts to the state which was saved earlier.
+* Create a class called `MicroSimulation` that consists of all functions of the micro simulation. It is good practice to define class member variables in the class constructor `__init__`.
+* **Optional**: Define a function `initialize` which computes the initial state of the micro simulation and returns initial values, which need to be transferred to the macro simulation. The return entity needs to be a Python dictionary with the names of the quantities as keys and the values of the quantities as values.
+* Create a function `solve`, which consists of all solving steps of one time step of a micro simulation or, if the micro problem is a steady-state simulation, all solving steps until the steady state is reached. The `solve` function should return the quantities that need to be communicated to the macro-side. The return entity needs to be again a Python dictionary with the names of the quantities as keys and the values of the quantities as values.
+* If implicit coupling is required between the macro and all micro problems, then you can additionally define two functions `save_checkpoint` and `revert_to_checkpoint`.
+  * `save_checkpoint` should save the current state of the micro problem.
+  * `revert_to_checkpoint` should revert to the saved state (required if the coupling loop does not convergence after a time step).
 
-You can find an example of an adapted micro-problem in the [macro-micro-dummy](https://github.com/precice/micro-manager/tree/master/examples/macro-micro-dummy) example.
+An example of an adapted micro problem as used in `/examples/macro-micro-dummy`:
 
-### Configuring the micro-manager
 
-The micro-manager is configured using a JSON file. The configuration file for the [macro-micro-dummy](https://github.com/precice/micro-manager/tree/master/examples/macro-micro-dummy) looks like:
+```python
+
+class MicroSimulation:
+
+    def __init__(self):
+        """
+        Constructor of MicroSimulation class.
+        """
+        self._dims = 3
+        self._micro_scalar_data = None
+        self._micro_vector_data = None
+        self._checkpoint = None
+
+    def initialize(self):
+        self._micro_scalar_data = 0
+        self._micro_vector_data = []
+        self._checkpoint = 0
+
+    def solve(self, macro_data, dt):
+        assert dt != 0
+        self._micro_vector_data = []
+        self._micro_scalar_data = macro_data["macro-scalar-data"]
+        for d in range(self._dims):
+            self._micro_vector_data.append(macro_data["macro-vector-data"][d])
+
+        return {"micro-scalar-data": self._micro_scalar_data.copy(),
+                "micro-vector-data": self._micro_vector_data.copy()}
+
+    def save_checkpoint(self):
+        print("Saving state of micro problem")
+        self._checkpoint = self._micro_scalar_data
+
+    def reload_checkpoint(self):
+        print("Reverting to old state of micro problem")
+        self._micro_scalar_data = self._checkpoint
+```
+
+
+
+### Configuration
+
+The micro manager is configured at runtime using a JSON file `micro-manager-config.json`. The configuration file for example in `/examples/macro-micro-dummy`:
 
 ```json
 {
-    "micro_file_name": "micro_problem",
+    "micro_file": "micro_problem",
     "coupling_params": {
-            "participant_name": "Micro-Manager",
-            "config_file_name": "precice-config.xml",
-            "macro_mesh_name": "macro-mesh",
-            "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-            "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "participant": "Micro-Manager",
+        "precice_config": "precice-config.xml",
+        "macro_mesh": "Macro-Mesh",
+        "read_data": {"Macro-Scalar-Data": "scalar", "Macro-Vector-Data": "vector"},
+        "write_data": {"Micro-Scalar-Data": "scalar", "Micro-Vector-Data": "vector"}
     },
     "simulation_params": {
-      "macro_domain_bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
-      "total_time": 10.0,
-      "timestep": 1.0,
-      "t_output": 1.0
+        "macro_domain_bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        "total_time": 10.0,
+        "timestep": 1.0,
+        "output_interval": 1.0
     }
 }
 ```
 
 The following quantities need to be configured:
 
-* `micro_file_name`: It is the path to the micro-simulation script. The `.py` of the micro-simulation script is not necessary here.
+* `micro_file`: Path to the micro-simulation script without ending `.py`.
 * `coupling_params`:
-  * `participant_name`: Name of the micro-manager as stated in the preCICE configuration.
-  * `config_file_name`: Path to the preCICE XML configuration file.
-  * `macro_mesh_name`: Name of the mesh as stated in the preCICE configuration.
-  * `read_data_names`: A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as the corresponding value.
-  * `write_data_names`: A Python dictionary with the names of the data to be written to from preCICE as keys and `"scalar"` or `"vector"`  as the corresponding value.
+  * `participant`: Name of the micro manager as stated in the preCICE configuration.
+  * `precice_config`: Path to the preCICE XML configuration file.
+  * `macro_mesh`: Name of the macro mesh as stated in the preCICE configuration.
+  * `read_data`: A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as values.
+  * `write_data`: A Python dictionary with the names of the data to be written to preCICE as keys and `"scalar"` or `"vector"`  as values.
 * `simulation_params`:
   * `macro_domain_bounds`: Minimum and maximum limits of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]`.
   * `total_time`: Total simulation time.
-  * `timestep`: Initial time step of the simulation.
-  * `t_output`: Time interval at which the micro-manager outputs the data.
+  * `timestep`: Initial timestep of the simulation.
+  * `output_interval`: Time interval at which the micro-manager outputs data.
+  
+### How to run
+
+TODO

--- a/README.md
+++ b/README.md
@@ -130,3 +130,5 @@ The following quantities need to be configured:
 ### How to run
 
 TODO
+
+In parallel?

--- a/examples/macro-micro-dummy/macro_dummy.py
+++ b/examples/macro-micro-dummy/macro_dummy.py
@@ -12,7 +12,7 @@ def main():
     """
     config = Config("macro-config.json")
 
-    nv = 25
+    nv = 25 # number of vertices
 
     n = n_checkpoint = 0
     t = t_checkpoint = 0

--- a/examples/macro-micro-dummy/micro-manager-config.json
+++ b/examples/macro-micro-dummy/micro-manager-config.json
@@ -1,16 +1,16 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-            "participant_name": "Micro-Manager",
-            "config_file_name": "precice-config.xml",
-            "macro_mesh_name": "macro-mesh",
-            "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-            "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "participant_name": "Micro-Manager",
+        "config_file_name": "precice-config.xml",
+        "macro_mesh_name": "macro-mesh",
+        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
-      "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-      "total_time": 10.0,
-      "timestep": 1.0,
-      "t_output": 1.0
+        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+        "total_time": 10.0,
+        "timestep": 1.0,
+        "t_output": 1.0
     }
   }

--- a/examples/macro-micro-dummy/micro_dummy.py
+++ b/examples/macro-micro-dummy/micro_dummy.py
@@ -16,11 +16,13 @@ class MicroSimulation:
         self._checkpoint = None
 
     def initialize(self):
+        print("Initialize micro problem")
         self._micro_scalar_data = 0
         self._micro_vector_data = []
         self._checkpoint = 0
 
     def solve(self, macro_data, dt):
+        print("Solve timestep of micro problem")
         assert dt != 0
         self._micro_vector_data = []
         self._micro_scalar_data = macro_data["macro-scalar-data"]

--- a/micromanager/micromanager.py
+++ b/micromanager/micromanager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Micro manager to couple a macro code to multiple micro codes
+Micro manager to organize many micro simulations and couple them via preCICE to a macro simulation
 """
 
 import precice


### PR DESCRIPTION
I had a look over most files and tried the dummy example. Installation and running worked without problems. I like how the micro manager code is still concise and simple. And the example is good as well.

A few things below, feel free to directly push to my branch.

## General things

- Naming convention. How should we call the software? "Micro Manager"? Then in Python it should be `micro_manager`, right? In preCICE, it should become `Micro-Manager`, a folder should be called `micro-manager`, etc.
- Rename `micromanager` folder to "src" ?

## README

I already changed a few things on the fly.

- Add a visualization screenshot to the README? Sth that visualizes the many-to-one coupling. 
- The section "Using the micro manager" needs a picture.
- Under "Using the micro manager", a section "How to run" could be helpful.

## Configuration

- Suggested changes to configuration: see changes in example listed in README
- Name of micro manager (for preCICE): why not hard coding this to "Micro-Manager", I don't see a use case yet where we could want to change the name.

> `total_time`: Total simulation time.

Why not leaving this decision to preCICE?

> `timestep`: Initial timestep of the simulation.

Why initial time step? Couldn't we leave this decision to preCICE as well?

> `output_interval`: Time interval at which the micro-manager outputs data.

Didn't you want to use the export functionality of preCICE for this? Which additional data do you plan to write. If it is statistics, we should have data of every timestep?

## `/examples/macro-micro-dummy`

* Missing (just for completeness): README of example
* What is the purpose of `config.py`? Seems to be copied from the FEniCS adapter? Does the macro dummy here actually need a config? In my opinion, it could be sufficient to hard-code values here.
* preCICE config: Try to stick to the conventions as used in the tutorials.
* We need a clean script.
* We could also add temporary files to a local `.gitignore` file.

## Code

- It could be helpful to pass an ID from the micro manager to each micro simulation. Mainly to distinguish output for the moment. But this could also be helpful for more cases I could imagine.

> ...
> Solve timestep of micro problem 4
> Solve timestep of micro problem 5

- Formatting: `isDataVector` -> `is_data_vector`
- Variable names: `nms` -> `number_of_micro_simulations`
- Split content of run function into multiple private functions? (which we could then unit test, e.g. the domain decomposition)
- Add more documentation in code, e.g. how the domain decomposition works

- This seems odd, at least the "configure" here is misleading:

```python
# Configure data written to preCICE
write_data = dict()
for name in self._write_data_names.keys():
    write_data[name] = []
```

- `for v in range(nms):` -> `for micro_sim in micro_sims` ?

