### PR TITLE
Allow empty micro manager instances instead of crashing

### DIFF
--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Run macro-micro dummy
         run: |
           cd examples/macro-micro-dummy/
-          python3 macro_dummy.py & micro_manager micro-manager-config.json
+          python3 macro_dummy.py & python3 run_micro_manager.py

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Run macro-micro dummy
         run: |
           cd examples/macro-micro-dummy/
-          python3 macro_dummy.py & python3 run_micro_manager.py
+          python3 macro_dummy.py & micro_manager micro-manager-config.json

--- a/examples/macro-micro-dummy/run_micro_manager.py
+++ b/examples/macro-micro-dummy/run_micro_manager.py
@@ -4,6 +4,8 @@ Script to run the Micro Manager
 
 from micro_manager import MicroManager
 
-manager = MicroManager("micro-manager-config.json")
+manager = MicroManager("./micro-manager-config.json")
 
-manager.run()
+manager.initialize()
+
+manager.solve()

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -226,18 +226,25 @@ class MicroManager:
                 micro_sims_output.append(micro_sims[i].solve(micro_sims_input[i], dt))
 
             write_data = dict()
-            for name in micro_sims_output[0]:
-                write_data[name] = []
+            if len(micro_sims_output) > 0:
+                for name in micro_sims_output[0]:
+                    write_data[name] = []
 
-            for dic in micro_sims_output:
-                for name, values in dic.items():
-                    write_data[name].append(values)
+                for dic in micro_sims_output:
+                    for name, values in dic.items():
+                        write_data[name].append(values)
 
-            for dname, is_data_vector in write_data_names.items():
-                if is_data_vector:
-                    self._interface.write_block_vector_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
-                else:
-                    self._interface.write_block_scalar_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+                for dname, is_data_vector in write_data_names.items():
+                    if is_data_vector:
+                        self._interface.write_block_vector_data(
+                            write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+                    else:
+                        self._interface.write_block_scalar_data(
+                            write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+            else:
+                self._logger.error(
+                    "Running an empty micro manager, is this want you want? (rank: {}, coupling_mesh_bounds: {})".format(
+                        self._rank, coupling_mesh_bounds))
 
             dt = self._interface.advance(dt)
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -42,7 +42,7 @@ def create_micro_problem_class(base_micro_simulation):
 
 
 class MicroManager:
-    def __init__(self, config_filename="micro-manager-config.json"):
+    def __init__(self, rank, size, logger):
         """
         Constructor of MicroManager class.
 
@@ -51,34 +51,11 @@ class MicroManager:
         config_filename : string
             Name of the JSON configuration file (to be provided by the user)
         """
-        # MPI related variables
-        self._comm = MPI.COMM_WORLD
-        self._rank = self._comm.Get_rank()
-        self._size = self._comm.Get_size()
+        self._size = size
+        self._rank = rank
+        self._logger = logger
 
-        self._logger = logging.getLogger(__name__)
-        self._logger.setLevel(level=logging.INFO)
-        # Create file handler which logs messages
-        fh = logging.FileHandler('micro-manager.log')
-        fh.setLevel(logging.INFO)
-        # Create formater and add it to handlers
-        formatter = logging.Formatter('[' + str(self._rank) + '] %(name)s -  %(levelname)s - %(message)s')
-        fh.setFormatter(formatter)
-        # add the handlers to the logger
-        self._logger.addHandler(fh)
-
-        self._is_parallel = self._size > 1
-
-        print("Provided configuration file: {}".format(config_filename))
-        self._config = Config(config_filename)
-
-        micro_file_name = self._config.get_micro_file_name()
-        self._micro_problem = getattr(__import__(micro_file_name, fromlist=["MicroSimulation"]), "MicroSimulation")
-
-        self._interface = precice.Interface("Micro-Manager", self._config.get_config_file_name(),
-                                            self._rank, self._size)
-
-    def _decompose_macro_domain(self, macro_bounds):
+    def decompose_macro_domain(self, macro_bounds):
         """
         Decompose the macro domain equally among all ranks, if the Micro Manager is run in paralle.
 
@@ -117,64 +94,9 @@ class MicroManager:
 
         return mesh_bounds
 
-    def run(self):
-        """
-        This function is called to start running the Micro Manager. This function has all the preCICE API calls.
-        """
-        macro_mesh_id = self._interface.get_mesh_id(self._config.get_macro_mesh_name())
-
-        # Decompose the macro-domain and set the mesh access region for each partition in preCICE
-        macro_bounds = self._config.get_macro_domain_bounds()
-        assert len(macro_bounds) / 2 == self._interface.get_dimensions(), "Provided macro mesh bounds are of " \
-                                                                          "incorrect dimension"
-        coupling_mesh_bounds = self._decompose_macro_domain(macro_bounds)
-        self._interface.set_mesh_access_region(macro_mesh_id, coupling_mesh_bounds)
-
-        # Data names and ids of data written to preCICE
-        write_data_names = self._config.get_write_data_names()
-        write_data_ids = dict()
-        for name in write_data_names.keys():
-            write_data_ids[name] = self._interface.get_data_id(name, macro_mesh_id)
-
-        # Data names and ids of data read from preCICE
-        read_data_names = self._config.get_read_data_names()
-        read_data_ids = dict()
-        for name in read_data_names.keys():
-            read_data_ids[name] = self._interface.get_data_id(name, macro_mesh_id)
-
-        write_data = dict()
-        for name in write_data_names.keys():
-            write_data[name] = []
-
-        read_data = dict()
-        for name in read_data_names.keys():
-            read_data[name] = []
-
-        # initialize preCICE
-        dt = self._interface.initialize()
-
-        mesh_vertex_ids, mesh_vertex_coords = self._interface.get_mesh_vertices_and_ids(macro_mesh_id)
-        number_of_micro_simulations, _ = mesh_vertex_coords.shape
-        self._logger.info("Number of micro simulations = {}".format(number_of_micro_simulations))
-
-        nms_all_ranks = np.zeros(self._size, dtype=np.int)
-        # Gather number of micro simulations that each rank has, because this rank needs to know how many micro
-        # simulations have been created by previous ranks, so that it can set the correct IDs
-        self._comm.Allgather(np.array(number_of_micro_simulations), nms_all_ranks)
-
-        # Create all micro simulations
-        sim_id = 0
-        if self._rank != 0:
-            for i in range(self._rank - 1, -1, -1):
-                sim_id += nms_all_ranks[i]
-
-        micro_sims = []
-        for n in range(number_of_micro_simulations):
-            micro_sims.append(create_micro_problem_class(self._micro_problem)(sim_id))
-            sim_id += 1
-
+    def initialize(self, interface, micro_problem):
         # Initialize all micro simulations
-        if hasattr(self._micro_problem, 'initialize') and callable(getattr(self._micro_problem, 'initialize')):
+        if hasattr(micro_problem, 'initialize') and callable(getattr(micro_problem, 'initialize')):
             for micro_sim in micro_sims:
                 micro_sims_output = micro_sim.initialize()
                 self._logger.info("Micro simulation ({}) initialized.".format(micro_sim.get_id()))
@@ -184,96 +106,184 @@ class MicroManager:
                 else:
                     for name, is_data_vector in write_data_names.items():
                         if is_data_vector:
-                            write_data[name].append(np.zeros(self._interface.get_dimensions()))
+                            write_data[name].append(np.zeros(interface.get_dimensions()))
                         else:
                             write_data[name].append(0.0)
 
+        # initialize preCICE
+        dt = interface.initialize()
+
         # Initialize coupling data
-        if self._interface.is_action_required(precice.action_write_initial_data()):
+        if interface.is_action_required(precice.action_write_initial_data()):
             for dname, dim in write_data_names.items():
                 if dim == 1:
-                    self._interface.write_block_vector_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+                    interface.write_block_vector_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
                 elif dim == 0:
-                    self._interface.write_block_scalar_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
-            self._interface.mark_action_fulfilled(precice.action_write_initial_data())
+                    interface.write_block_scalar_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+            interface.mark_action_fulfilled(precice.action_write_initial_data())
 
-        self._interface.initialize_data()
+        interface.initialize_data()
 
-        t, n = 0, 0
-        t_checkpoint, n_checkpoint = 0, 0
-
-        while self._interface.is_coupling_ongoing():
-            # Write checkpoint
-            if self._interface.is_action_required(precice.action_write_iteration_checkpoint()):
-                for micro_sim in micro_sims:
-                    micro_sim.save_checkpoint()
-                t_checkpoint = t
-                n_checkpoint = n
-                self._interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
-
-            for name, is_data_vector in read_data_names.items():
-                if is_data_vector:
-                    read_data.update({name: self._interface.read_block_vector_data(read_data_ids[name],
-                                                                                   mesh_vertex_ids)})
-                else:
-                    read_data.update({name: self._interface.read_block_scalar_data(read_data_ids[name],
-                                                                                   mesh_vertex_ids)})
-
-            micro_sims_input = [dict(zip(read_data, t)) for t in zip(*read_data.values())]
-            micro_sims_output = []
-            for i in range(number_of_micro_simulations):
-                self._logger.info("Solving micro simulation ({})".format(micro_sims[i].get_id()))
-                micro_sims_output.append(micro_sims[i].solve(micro_sims_input[i], dt))
-
-            write_data = dict()
-            if len(micro_sims_output) > 0:
-                for name in micro_sims_output[0]:
-                    write_data[name] = []
-
-                for dic in micro_sims_output:
-                    for name, values in dic.items():
-                        write_data[name].append(values)
-
-                for dname, is_data_vector in write_data_names.items():
-                    if is_data_vector:
-                        self._interface.write_block_vector_data(
-                            write_data_ids[dname], mesh_vertex_ids, write_data[dname])
-                    else:
-                        self._interface.write_block_scalar_data(
-                            write_data_ids[dname], mesh_vertex_ids, write_data[dname])
-            else:
-                self._logger.error(
-                    "Running an empty micro manager, is this want you want? (rank: {}, coupling_mesh_bounds: {})".format(
-                        self._rank, coupling_mesh_bounds))
-
-            dt = self._interface.advance(dt)
-
-            t += dt
-            n += 1
-
-            # Revert to checkpoint if required
-            if self._interface.is_action_required(precice.action_read_iteration_checkpoint()):
-                for micro_sim in micro_sims:
-                    micro_sim.reload_checkpoint()
-                n = n_checkpoint
-                t = t_checkpoint
-                self._interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
-
-        self._interface.finalize()
+        return dt
 
 
 def main():
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+
+    logger = logging.getLogger(__name__)
+    logger.setLevel(level=logging.INFO)
+    fh = logging.FileHandler('micro-manager.log')  # Create file handler which logs messages
+    fh.setLevel(logging.INFO)
+    # Create formater and add it to handlers
+    formatter = logging.Formatter('[' + str(rank) + '] %(name)s -  %(levelname)s - %(message)s')
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)  # add the handlers to the logger
+
     parser = argparse.ArgumentParser(description='.')
-    parser.add_argument('config_file', type=str,
-                        help='Path to the config file that should be used.')
+    parser.add_argument('config_file', type=str, help='Path to the JSON config file of the manager.')
 
     args = parser.parse_args()
     path = args.config_file
     if not os.path.isabs(path):
         path = os.getcwd() + "/" + path
-    manager = MicroManager(path)
 
-    manager.run()
+    logger.info("Provided configuration file: {}".format(config_filename))
+    config = Config(path)
+
+    is_parallel = size > 1
+    is_rank_empty = False
+
+    # Define the preCICE interface
+    interface = precice.Interface("Micro-Manager", config.get_config_file_name(), rank, size)
+
+    manager = MicroManager(rank, size, logger)
+
+    micro_file_name = config.get_micro_file_name()
+    micro_problem = getattr(__import__(micro_file_name, fromlist=["MicroSimulation"]), "MicroSimulation")
+
+    macro_mesh_id = interface.get_mesh_id(config.get_macro_mesh_name())
+
+    # Data names and ids of data written to preCICE
+    write_data_names = config.get_write_data_names()
+    write_data_ids = dict()
+    for name in write_data_names.keys():
+        write_data_ids[name] = interface.get_data_id(name, macro_mesh_id)
+
+    # Data names and ids of data read from preCICE
+    read_data_names = config.get_read_data_names()
+    read_data_ids = dict()
+    for name in read_data_names.keys():
+        read_data_ids[name] = interface.get_data_id(name, macro_mesh_id)
+
+    write_data = dict()
+    for name in write_data_names.keys():
+        write_data[name] = []
+
+    read_data = dict()
+    for name in read_data_names.keys():
+        read_data[name] = []
+
+    # Decompose the macro-domain and set the mesh access region for each partition in preCICE
+    macro_bounds = config.get_macro_domain_bounds()
+    assert len(macro_bounds) / 2 == interface.get_dimensions(), "Provided macro mesh bounds are of incorrect dimension"
+    if is_parallel:
+        coupling_mesh_bounds = manager.decompose_macro_domain(macro_bounds)
+    else:
+        coupling_mesh_bounds = macro_bounds
+
+    interface.set_mesh_access_region(macro_mesh_id, coupling_mesh_bounds)
+
+    mesh_vertex_ids, mesh_vertex_coords = interface.get_mesh_vertices_and_ids(macro_mesh_id)
+    number_of_micro_simulations, _ = mesh_vertex_coords.shape
+    logger.info("Number of micro simulations = {}".format(number_of_micro_simulations))
+
+    if number_of_micro_simulations == 0:
+        if is_parallel:
+            logger.info("Rank {} has no micro simulations and hence will not do any computation.".format(rank))
+            is_rank_empty = True
+        else:
+            raise Exception("Micro Manager has no micro simulations.")
+
+    if not is_rank_empty:
+        dt = manager.initialize(interface, micro_problem)
+
+    nms_all_ranks = np.zeros(size, dtype=np.int)
+    # Gather number of micro simulations that each rank has, because this rank needs to know how many micro
+    # simulations have been created by previous ranks, so that it can set the correct IDs
+    comm.Allgather(np.array(number_of_micro_simulations), nms_all_ranks)
+
+    # Create all micro simulations
+    sim_id = 0
+    if rank != 0:
+        for i in range(rank - 1, -1, -1):
+            sim_id += nms_all_ranks[i]
+
+    micro_sims = []
+    for _ in range(number_of_micro_simulations):
+        micro_sims.append(create_micro_problem_class(micro_problem)(sim_id))
+        sim_id += 1
+
+    t, n = 0, 0
+    t_checkpoint, n_checkpoint = 0, 0
+
+    while interface.is_coupling_ongoing():
+        # Write checkpoint
+        if interface.is_action_required(precice.action_write_iteration_checkpoint()):
+            for micro_sim in micro_sims:
+                micro_sim.save_checkpoint()
+            t_checkpoint = t
+            n_checkpoint = n
+            interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
+
+        for name, is_data_vector in read_data_names.items():
+            if is_data_vector:
+                read_data.update({name: interface.read_block_vector_data(read_data_ids[name], mesh_vertex_ids)})
+            else:
+                read_data.update({name: interface.read_block_scalar_data(read_data_ids[name], mesh_vertex_ids)})
+
+        micro_sims_input = [dict(zip(read_data, t)) for t in zip(*read_data.values())]
+        micro_sims_output = []
+        for i in range(number_of_micro_simulations):
+            logger.info("Solving micro simulation ({})".format(micro_sims[i].get_id()))
+            micro_sims_output.append(micro_sims[i].solve(micro_sims_input[i], dt))
+
+        write_data = dict()
+        if not is_rank_empty:
+            for name in micro_sims_output[0]:
+                write_data[name] = []
+
+            for dic in micro_sims_output:
+                for name, values in dic.items():
+                    write_data[name].append(values)
+
+            for dname, is_data_vector in write_data_names.items():
+                if is_data_vector:
+                    interface.write_block_vector_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+                else:
+                    interface.write_block_scalar_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+        else:
+            for dname, is_data_vector in write_data_names.items():
+                if is_data_vector:
+                    interface.write_block_vector_data(write_data_ids[dname], [], np.array([]))
+                else:
+                    interface.write_block_scalar_data(write_data_ids[dname], [], np.array([]))
+
+        dt = self._interface.advance(dt)
+
+        t += dt
+        n += 1
+
+        # Revert to checkpoint if required
+        if self._interface.is_action_required(precice.action_read_iteration_checkpoint()):
+            for micro_sim in micro_sims:
+                micro_sim.reload_checkpoint()
+            n = n_checkpoint
+            t = t_checkpoint
+            self._interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
+
+    self._interface.finalize()
 
 
 if __name__ == "__main__":

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -42,7 +42,7 @@ def create_micro_problem_class(base_micro_simulation):
 
 
 class MicroManager:
-    def __init__(self, rank, size, logger):
+    def __init__(self, config_file):
         """
         Constructor of MicroManager class.
 
@@ -51,9 +51,51 @@ class MicroManager:
         config_filename : string
             Name of the JSON configuration file (to be provided by the user)
         """
-        self._size = size
-        self._rank = rank
-        self._logger = logger
+        self._comm = MPI.COMM_WORLD
+        self._rank = self._comm.Get_rank()
+        self._size = self._comm.Get_size()
+
+        self._logger = logging.getLogger(__name__)
+        self._logger.setLevel(level=logging.INFO)
+        fh = logging.FileHandler('micro-manager.log')  # Create file handler which logs messages
+        fh.setLevel(logging.INFO)
+        # Create formater and add it to handlers
+        formatter = logging.Formatter('[' + str(self._rank) + '] %(name)s -  %(levelname)s - %(message)s')
+        fh.setFormatter(formatter)
+        self._logger.addHandler(fh)  # add the handlers to the logger
+
+        self._is_parallel = self._size > 1
+
+        self._logger.info("Provided configuration file: {}".format(config_file))
+        config = Config(config_file)
+
+        # Define the preCICE interface
+        self._interface = precice.Interface("Micro-Manager", config.get_config_file_name(), self._rank, self._size)
+
+        micro_file_name = config.get_micro_file_name()
+        self._micro_problem = getattr(__import__(micro_file_name, fromlist=["MicroSimulation"]), "MicroSimulation")
+
+        self._macro_mesh_id = self._interface.get_mesh_id(config.get_macro_mesh_name())
+
+        # Data names and ids of data written to preCICE
+        self._write_data_names = config.get_write_data_names()
+        self._write_data_ids = dict()
+        for name in self._write_data_names.keys():
+            self._write_data_ids[name] = self._interface.get_data_id(name, self._macro_mesh_id)
+
+        # Data names and ids of data read from preCICE
+        self._read_data_names = config.get_read_data_names()
+        self._read_data_ids = dict()
+        for name in self._read_data_names.keys():
+            self._read_data_ids[name] = self._interface.get_data_id(name, self._macro_mesh_id)
+
+        self._macro_bounds = config.get_macro_domain_bounds()
+
+        self._number_of_micro_simulations = None
+        self._is_rank_empty = False
+        self._micro_sims = None
+        self._dt = None
+        self._mesh_vertex_ids = None
 
     def decompose_macro_domain(self, macro_bounds):
         """
@@ -94,163 +136,99 @@ class MicroManager:
 
         return mesh_bounds
 
-    def initialize(self, interface, micro_problem):
+    def initialize(self):
+        # Decompose the macro-domain and set the mesh access region for each partition in preCICE
+        assert len(
+            self._macro_bounds) / 2 == self._interface.get_dimensions(), "Provided macro mesh bounds are of " \
+                                                                         "incorrect dimension"
+        if self._is_parallel:
+            coupling_mesh_bounds = self.decompose_macro_domain(macro_bounds)
+        else:
+            coupling_mesh_bounds = self._macro_bounds
+
+        self._interface.set_mesh_access_region(self._macro_mesh_id, coupling_mesh_bounds)
+
+        # initialize preCICE
+        self._dt = self._interface.initialize()
+
+        self._mesh_vertex_ids, mesh_vertex_coords = self._interface.get_mesh_vertices_and_ids(self._macro_mesh_id)
+        self._number_of_micro_simulations, _ = mesh_vertex_coords.shape
+        self._logger.info("Number of micro simulations = {}".format(self._number_of_micro_simulations))
+
+        if self._number_of_micro_simulations == 0:
+            if self._is_parallel:
+                self._logger.info("Rank {} has no micro simulations and hence will not do any computation.".format(
+                    rank))
+                self._is_rank_empty = True
+            else:
+                raise Exception("Micro Manager has no micro simulations.")
+
+        nms_all_ranks = np.zeros(self._size, dtype=np.int)
+        # Gather number of micro simulations that each rank has, because this rank needs to know how many micro
+        # simulations have been created by previous ranks, so that it can set the correct IDs
+        self._comm.Allgather(np.array(self._number_of_micro_simulations), nms_all_ranks)
+
+        # Create all micro simulations
+        sim_id = 0
+        if self._rank != 0:
+            for i in range(self._rank - 1, -1, -1):
+                sim_id += nms_all_ranks[i]
+
+        self._micro_sims = []
+        for _ in range(self._number_of_micro_simulations):
+            self._micro_sims.append(create_micro_problem_class(self._micro_problem)(sim_id))
+            sim_id += 1
+
+        write_data = dict()
+        for name in self._write_data_names.keys():
+            write_data[name] = []
+
         # Initialize all micro simulations
-        if hasattr(micro_problem, 'initialize') and callable(getattr(micro_problem, 'initialize')):
-            for micro_sim in micro_sims:
+        if hasattr(self._micro_problem, 'initialize') and callable(getattr(self._micro_problem, 'initialize')):
+            for micro_sim in self._micro_sims:
                 micro_sims_output = micro_sim.initialize()
                 self._logger.info("Micro simulation ({}) initialized.".format(micro_sim.get_id()))
                 if micro_sims_output is not None:
                     for data_name, data in micro_sims_output.items():
                         write_data[data_name].append(data)
                 else:
-                    for name, is_data_vector in write_data_names.items():
+                    for name, is_data_vector in self._write_data_names.items():
                         if is_data_vector:
-                            write_data[name].append(np.zeros(interface.get_dimensions()))
+                            write_data[name].append(np.zeros(self._interface.get_dimensions()))
                         else:
                             write_data[name].append(0.0)
 
-        # initialize preCICE
-        dt = interface.initialize()
-
         # Initialize coupling data
-        if interface.is_action_required(precice.action_write_initial_data()):
-            for dname, dim in write_data_names.items():
+        if self._interface.is_action_required(precice.action_write_initial_data()):
+            for dname, dim in self._write_data_names.items():
                 if dim == 1:
-                    interface.write_block_vector_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+                    self._interface.write_block_vector_data(self._write_data_ids[dname], self._mesh_vertex_ids,
+                                                            write_data[dname])
                 elif dim == 0:
-                    interface.write_block_scalar_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
-            interface.mark_action_fulfilled(precice.action_write_initial_data())
+                    self._interface.write_block_scalar_data(self._write_data_ids[dname], self._mesh_vertex_ids,
+                                                            write_data[dname])
+            self._interface.mark_action_fulfilled(precice.action_write_initial_data())
 
-        interface.initialize_data()
+        self._interface.initialize_data()
 
-        return dt
+    def read_data_from_precice(self):
+        read_data = dict()
+        for name in self._read_data_names.keys():
+            read_data[name] = []
 
-
-def main():
-    comm = MPI.COMM_WORLD
-    rank = comm.Get_rank()
-    size = comm.Get_size()
-
-    logger = logging.getLogger(__name__)
-    logger.setLevel(level=logging.INFO)
-    fh = logging.FileHandler('micro-manager.log')  # Create file handler which logs messages
-    fh.setLevel(logging.INFO)
-    # Create formater and add it to handlers
-    formatter = logging.Formatter('[' + str(rank) + '] %(name)s -  %(levelname)s - %(message)s')
-    fh.setFormatter(formatter)
-    logger.addHandler(fh)  # add the handlers to the logger
-
-    parser = argparse.ArgumentParser(description='.')
-    parser.add_argument('config_file', type=str, help='Path to the JSON config file of the manager.')
-
-    args = parser.parse_args()
-    path = args.config_file
-    if not os.path.isabs(path):
-        path = os.getcwd() + "/" + path
-
-    logger.info("Provided configuration file: {}".format(config_filename))
-    config = Config(path)
-
-    is_parallel = size > 1
-    is_rank_empty = False
-
-    # Define the preCICE interface
-    interface = precice.Interface("Micro-Manager", config.get_config_file_name(), rank, size)
-
-    manager = MicroManager(rank, size, logger)
-
-    micro_file_name = config.get_micro_file_name()
-    micro_problem = getattr(__import__(micro_file_name, fromlist=["MicroSimulation"]), "MicroSimulation")
-
-    macro_mesh_id = interface.get_mesh_id(config.get_macro_mesh_name())
-
-    # Data names and ids of data written to preCICE
-    write_data_names = config.get_write_data_names()
-    write_data_ids = dict()
-    for name in write_data_names.keys():
-        write_data_ids[name] = interface.get_data_id(name, macro_mesh_id)
-
-    # Data names and ids of data read from preCICE
-    read_data_names = config.get_read_data_names()
-    read_data_ids = dict()
-    for name in read_data_names.keys():
-        read_data_ids[name] = interface.get_data_id(name, macro_mesh_id)
-
-    write_data = dict()
-    for name in write_data_names.keys():
-        write_data[name] = []
-
-    read_data = dict()
-    for name in read_data_names.keys():
-        read_data[name] = []
-
-    # Decompose the macro-domain and set the mesh access region for each partition in preCICE
-    macro_bounds = config.get_macro_domain_bounds()
-    assert len(macro_bounds) / 2 == interface.get_dimensions(), "Provided macro mesh bounds are of incorrect dimension"
-    if is_parallel:
-        coupling_mesh_bounds = manager.decompose_macro_domain(macro_bounds)
-    else:
-        coupling_mesh_bounds = macro_bounds
-
-    interface.set_mesh_access_region(macro_mesh_id, coupling_mesh_bounds)
-
-    mesh_vertex_ids, mesh_vertex_coords = interface.get_mesh_vertices_and_ids(macro_mesh_id)
-    number_of_micro_simulations, _ = mesh_vertex_coords.shape
-    logger.info("Number of micro simulations = {}".format(number_of_micro_simulations))
-
-    if number_of_micro_simulations == 0:
-        if is_parallel:
-            logger.info("Rank {} has no micro simulations and hence will not do any computation.".format(rank))
-            is_rank_empty = True
-        else:
-            raise Exception("Micro Manager has no micro simulations.")
-
-    if not is_rank_empty:
-        dt = manager.initialize(interface, micro_problem)
-
-    nms_all_ranks = np.zeros(size, dtype=np.int)
-    # Gather number of micro simulations that each rank has, because this rank needs to know how many micro
-    # simulations have been created by previous ranks, so that it can set the correct IDs
-    comm.Allgather(np.array(number_of_micro_simulations), nms_all_ranks)
-
-    # Create all micro simulations
-    sim_id = 0
-    if rank != 0:
-        for i in range(rank - 1, -1, -1):
-            sim_id += nms_all_ranks[i]
-
-    micro_sims = []
-    for _ in range(number_of_micro_simulations):
-        micro_sims.append(create_micro_problem_class(micro_problem)(sim_id))
-        sim_id += 1
-
-    t, n = 0, 0
-    t_checkpoint, n_checkpoint = 0, 0
-
-    while interface.is_coupling_ongoing():
-        # Write checkpoint
-        if interface.is_action_required(precice.action_write_iteration_checkpoint()):
-            for micro_sim in micro_sims:
-                micro_sim.save_checkpoint()
-            t_checkpoint = t
-            n_checkpoint = n
-            interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
-
-        for name, is_data_vector in read_data_names.items():
+        for name, is_data_vector in self._read_data_names.items():
             if is_data_vector:
-                read_data.update({name: interface.read_block_vector_data(read_data_ids[name], mesh_vertex_ids)})
+                read_data.update({name: self._interface.read_block_vector_data(self._read_data_ids[name],
+                                                                               self._mesh_vertex_ids)})
             else:
-                read_data.update({name: interface.read_block_scalar_data(read_data_ids[name], mesh_vertex_ids)})
+                read_data.update({name: self._interface.read_block_scalar_data(self._read_data_ids[name],
+                                                                               self._mesh_vertex_ids)})
 
-        micro_sims_input = [dict(zip(read_data, t)) for t in zip(*read_data.values())]
-        micro_sims_output = []
-        for i in range(number_of_micro_simulations):
-            logger.info("Solving micro simulation ({})".format(micro_sims[i].get_id()))
-            micro_sims_output.append(micro_sims[i].solve(micro_sims_input[i], dt))
+        return [dict(zip(read_data, t)) for t in zip(*read_data.values())]
 
+    def write_data_to_precice(self, micro_sims_output):
         write_data = dict()
-        if not is_rank_empty:
+        if not self._is_rank_empty:
             for name in micro_sims_output[0]:
                 write_data[name] = []
 
@@ -258,32 +236,77 @@ def main():
                 for name, values in dic.items():
                     write_data[name].append(values)
 
-            for dname, is_data_vector in write_data_names.items():
+            for dname, is_data_vector in self._write_data_names.items():
                 if is_data_vector:
-                    interface.write_block_vector_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+                    self._interface.write_block_vector_data(self._write_data_ids[dname], self._mesh_vertex_ids,
+                                                            write_data[dname])
                 else:
-                    interface.write_block_scalar_data(write_data_ids[dname], mesh_vertex_ids, write_data[dname])
+                    self._interface.write_block_scalar_data(self._write_data_ids[dname], self._mesh_vertex_ids,
+                                                            write_data[dname])
         else:
-            for dname, is_data_vector in write_data_names.items():
+            for dname, is_data_vector in self._write_data_names.items():
                 if is_data_vector:
-                    interface.write_block_vector_data(write_data_ids[dname], [], np.array([]))
+                    self._interface.write_block_vector_data(self._write_data_ids[dname], [], np.array([]))
                 else:
-                    interface.write_block_scalar_data(write_data_ids[dname], [], np.array([]))
+                    self._interface.write_block_scalar_data(self._write_data_ids[dname], [], np.array([]))
 
-        dt = self._interface.advance(dt)
+    def solve_micro_simulations(self, micro_sims_input):
+        micro_sims_output = []
+        for i in range(self._number_of_micro_simulations):
+            self._logger.info("Solving micro simulation ({})".format(self._micro_sims[i].get_id()))
+            micro_sims_output.append(self._micro_sims[i].solve(micro_sims_input[i], self._dt))
 
-        t += dt
-        n += 1
+        return micro_sims_output
 
-        # Revert to checkpoint if required
-        if self._interface.is_action_required(precice.action_read_iteration_checkpoint()):
-            for micro_sim in micro_sims:
-                micro_sim.reload_checkpoint()
-            n = n_checkpoint
-            t = t_checkpoint
-            self._interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
+    def solve(self):
+        t, n = 0, 0
+        t_checkpoint, n_checkpoint = 0, 0
 
-    self._interface.finalize()
+        while self._interface.is_coupling_ongoing():
+            # Write checkpoint
+            if self._interface.is_action_required(precice.action_write_iteration_checkpoint()):
+                for micro_sim in self._micro_sims:
+                    micro_sim.save_checkpoint()
+                t_checkpoint = t
+                n_checkpoint = n
+                self._interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
+
+            micro_sims_input = self.read_data_from_precice()
+
+            micro_sims_output = self.solve_micro_simulations(micro_sims_input)
+
+            self.write_data_to_precice(micro_sims_output)
+
+            self._dt = self._interface.advance(self._dt)
+
+            t += self._dt
+            n += 1
+
+            # Revert to checkpoint if required
+            if self._interface.is_action_required(precice.action_read_iteration_checkpoint()):
+                for micro_sim in self._micro_sims:
+                    micro_sim.reload_checkpoint()
+                n = n_checkpoint
+                t = t_checkpoint
+                self._interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
+
+        self._interface.finalize()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='.')
+    parser.add_argument('config_file', type=str, help='Path to the JSON config file of the manager.')
+
+    args = parser.parse_args()
+    config_file_path = args.config_file
+    if not os.path.isabs(config_file_path):
+        config_file_path = os.getcwd() + "/" + config_file_path
+
+    manager = MicroManager(config_file_path)
+
+    manager.initialize()
+
+    manager.solve()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
since the micro manager splits the mesh as a cube, we can end up with empty micro manager instances. 
E.g we have cube region but a hexagonal mesh on the other side - with enough cpu's this can result in the micro manager instances on the corners of the cube being empty.

Without this change these empty instances will crash and block the whole simulation.