### PR TITLE
Add local variant of adaptive control strategy

### DIFF
--- a/.github/workflows/run-adaptivity-test.yml
+++ b/.github/workflows/run-adaptivity-test.yml
@@ -1,0 +1,30 @@
+name: Run integration test for adaptivity
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+jobs:  
+  run_test_adaptivity:
+    name: Test adaptivity
+    runs-on: ubuntu-latest
+    container: precice/precice
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2      
+      - name: Install Dependencies
+        run: |
+          apt-get -qq update
+          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Install pyprecice
+        run: pip3 install --user pyprecice
+      - name: Install micro-manager
+        run: pip3 install --user .
+      - name: Run macro-micro dummy
+        run: |
+          cd tests/integration/test_adaptivity/
+          python3 macro_solver.py & micro_manager micro-manager-config.json

--- a/.github/workflows/run-adaptivity-test.yml
+++ b/.github/workflows/run-adaptivity-test.yml
@@ -20,11 +20,9 @@ jobs:
           apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
-      - name: Install pyprecice
-        run: pip3 install --user pyprecice
       - name: Install micro-manager
         run: pip3 install --user .
-      - name: Run macro-micro dummy
+      - name: Run adaptivity test
         run: |
           cd tests/integration/test_adaptivity/
-          python3 macro_solver.py & micro_manager micro-manager-config.json
+          python3 macro_solver.py & python3 run_micro_manager.py

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -20,8 +20,6 @@ jobs:
           apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
-      - name: Install pyprecice
-        run: pip3 install --user pyprecice
       - name: Install micro-manager
         run: pip3 install --user .
       - name: Run macro-micro dummy

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 
 # Building artifacts
 build
+micro_manager_precice.egg-info/
 micro_manager.egg-info/
 
 # Packaging artifacts

--- a/README.md
+++ b/README.md
@@ -137,9 +137,28 @@ The Micro Manager is capable of generating diagnostics type output of the micro 
   * `data_from_micro_sims`: A Python dictionary with the names of the data from the micro simulation to be written to VTK files as keys and `"scalar"` or `"vector"`  as values.
   * `output_micro_sim_solve_time`: When `True`, the Manager writes the wall clock time of the `solve()` function of each micro simulation to the VTK output.
 
+The Micro Manager can adaptively initialize micro simulations. The adaptivity strategy is taken from two publications:
+
+1. Redeker, Magnus & Eck, Christof. (2013). A fast and accurate adaptive solution strategy for two-scale models with continuous inter-scale dependencies. Journal of Computational Physics. 240. 268-283. 10.1016/j.jcp.2012.12.025.
+
+2. Bastidas, Manuela & Bringedal, Carina & Pop, Iuliu. (2021). A two-scale iterative scheme for a phase-field model for precipitation and dissolution in porous media. Applied Mathematics and Computation. 396. 125933. 10.1016/j.amc.2020.125933.
+
+To turn on adaptivity, the following options need to be set in `simulation_params`:
+
+* `adaptivity`: Set as `True`.
+* `adaptivity_data`: List of names of data which are to be used to calculate if two micro-simulations are similar or not. For example `["macro-scalar-data", "macro-vector-data"]`
+* `adaptivity_history_param`: History parameter $\Lambda$, set as $\Lambda >= 0$.
+* `adaptivity_coarsening_constant`: Coarsening constant $C_c$, set as $C_c < 1$.
+* `adaptivity_refining_constant`: Refining constant $C_r$, set as $C_r >= 0$.
+
+All variables names are chosen to be same as the second publication mentioned above.
+
 #### Changes to preCICE configuration file
 
-The Micro Manager relies on the [export functionality](https://precice.org/configuration-export.html#enabling-exporters) of preCICE to write diagnostics data output. If the option `diagnotics: data_from_micro_sims` is configured, the corresponding export tag also needs to be set in the preCICE XML configuration script.
+The Micro Manager relies on the [export functionality](https://precice.org/configuration-export.html#enabling-exporters) of preCICE to write diagnostics data output.
+
+* If the option `diagnotics: data_from_micro_sims` is configured, the corresponding export tag also needs to be set in the preCICE XML configuration script.
+* If adaptivity is turned on, the Micro Manager will attempt to write a scalar data set `active_state` to preCICE. Add this data set to the preCICE configuration file.
 
 ### Running the Micro Manager
 

--- a/examples/macro-micro-dummy/micro-manager-config.json
+++ b/examples/macro-micro-dummy/micro-manager-config.json
@@ -9,7 +9,7 @@
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
         "adaptivity": "True",
-        "adaptivity_data": ["macro-scalar_data", "micro_scalar_data"],
+        "adaptivity_data": ["macro-scalar-data", "micro-scalar-data"],
         "adaptivity_history_param": 0.5,
         "adaptivity_coarsening_constant": 0.5,
         "adaptivity_refining_constant": 0.5

--- a/examples/macro-micro-dummy/micro-manager-config.json
+++ b/examples/macro-micro-dummy/micro-manager-config.json
@@ -7,7 +7,12 @@
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]
+        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+        "adaptivity": "True",
+        "adaptivity_data": ["macro-scalar_data", "micro_scalar_data"],
+        "adaptivity_history_param": 0.5,
+        "adaptivity_coarsening_constant": 0.5,
+        "adaptivity_refining_constant": 0.5
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/examples/macro-micro-dummy/micro-manager-config.json
+++ b/examples/macro-micro-dummy/micro-manager-config.json
@@ -8,11 +8,7 @@
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "adaptivity": "True",
-        "adaptivity_data": ["macro-scalar-data", "micro-scalar-data"],
-        "adaptivity_history_param": 0.5,
-        "adaptivity_coarsening_constant": 0.5,
-        "adaptivity_refining_constant": 0.5
+        "adaptivity": "False"
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/examples/macro-micro-dummy/micro_dummy.py
+++ b/examples/macro-micro-dummy/micro_dummy.py
@@ -26,9 +26,9 @@ class MicroSimulation:
         print("Solve timestep of micro problem ({})".format(self._sim_id))
         assert dt != 0
         self._micro_vector_data = []
-        self._micro_scalar_data = macro_data["macro-scalar-data"]
+        self._micro_scalar_data = macro_data["macro-scalar-data"] + 1
         for d in range(self._dims):
-            self._micro_vector_data.append(macro_data["macro-vector-data"][d])
+            self._micro_vector_data.append(macro_data["macro-vector-data"][d] + 1)
 
         return {"micro-scalar-data": self._micro_scalar_data.copy(),
                 "micro-vector-data": self._micro_vector_data.copy()}

--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -157,13 +157,13 @@ class AdaptiveController:
         micro_sims : list
             List of objects of class MicroProblem, which are the micro simulations
         """
-        active_sim_ids = np.where(micro_sim_states == 1)
-        inactive_sim_ids = np.where(micro_sim_states == 0)
+        active_sim_ids = np.where(micro_sim_states == 1)[0]
+        inactive_sim_ids = np.where(micro_sim_states == 0)[0]
 
         # Associate inactive micro sims to active micro sims
-        for id_1 in inactive_sim_ids[0]:
+        for id_1 in inactive_sim_ids:
             dist_min = sys.float_info.max
-            for id_2 in active_sim_ids[0]:
+            for id_2 in active_sim_ids:
                 # Find most similar active sim for every inactive sim
                 if similarity_dists[id_1, id_2] < dist_min:
                     micro_id = id_2

--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -1,0 +1,93 @@
+"""
+Functionality for adaptive initialization and control of micro simulations
+"""
+import numpy as np
+from math import exp
+
+class AdaptiveController:
+    def __init__(self, configurator) -> None:
+        # Names of data to be used for adaptivity computation
+        self._hist_param = configurator.get_adaptivity_hist_param()
+        self._refine_const = configurator.get_adaptivity_refining_const()
+        self._coarse_const = configurator.get_adaptivity_coarsening_const()
+
+    def get_similarity_dists(self, dt, similarity_dists_nm1, data):
+        """
+
+        Returns
+        -------
+
+        """
+        if data.ndim == 1:
+            number_of_micro_sims = len(data)
+            dim = 0
+        elif data.ndim == 2:
+            number_of_micro_sims, dim = data.shape
+
+        micro_ids = list(range(number_of_micro_sims))
+        similarity_dists = np.zeros((number_of_micro_sims, number_of_micro_sims))
+        for id_1 in micro_ids:
+            for id_2 in micro_ids:
+                if id_1 != id_2:
+                    if dim:
+                        for d in dim:
+                            data_diff += abs(data[id_1, d] - data[id_2, d])
+                    else:
+                        data_diff = abs(data[id_1] - data[id_2])
+                    
+                    similarity_dists[id_1, id_2] = exp(-self._hist_param * self._dt) * similarity_dists_nm1[id_1, id_2] + dt * data_diff)
+                else:
+                    similarity_dists[id_1, id_2] = 0.0
+
+        return similarity_dists
+
+    def update_active_micro_simulations(self, similarity_dists, micro_sim_states):
+        ref_tol = self._refine_const * np.amax(similarity_dists)
+        coarse_tol = self._coarse_const * ref_tol
+
+        number_of_micro_sims, _ = similarity_dists.shape
+
+        # Update the set of active micro sims
+        for id_1 in range(number_of_micro_sims):
+            if micro_sim_states[id_1]:  # if id_1 sim is active
+                for id_2 in range(number_of_micro_sims):
+                    if micro_sim_states[id_2]:  # if id_2 is active
+                        if id_1 != id_2:
+                            # If active sim is similar to another active sim,
+                            # deactivate it
+                            if similarity_dists[id_1, id_2] < coarse_tol:
+                                print("sim {} and sim {} are similar, so deactivating {}".format(id_1, id_2, id_1))
+                                self._micro_sims[id_1].deactivate()
+                                micro_sim_states[id_1] = 0
+                                break
+
+        return micro_sim_states
+
+    def update_inactive_micro_simulations(self, similarity_dists, micro_sim_states):
+        ref_tol = self._refine_const * np.amax(similarity_dists)
+
+        number_of_micro_sims, _ = similarity_dists.shape
+
+        # Update the set of inactive micro sims
+        dists = []
+        for id_1 in range(number_of_micro_sims):
+            if not micro_sim_states[id_1]:
+                for id_2 in range(number_of_micro_sims):
+                    if micro_sim_states[id_2]:
+                        dists.append(similarity_dists[id_1, id_2])
+                # If inactive sim is not similar to any active sim, activate it
+                if min(dists) > ref_tol:
+                    self._micro_sims[id_1].activate()
+                dists = []
+
+    def associate_inactive_to_active(self, similarity_dists, micro_sims):
+        # Associate inactive micro sims to active micro sims
+        micro_id = 0
+        for id_1 in self._inactive_ids:
+            dist_min = 100
+            for id_2 in self._active_ids:
+                # Find most similar active sim for every inactive sim
+                if similarity_dists[id_1, id_2] < dist_min:
+                    micro_id = id_2
+                    dist_min = similarity_dists[id_1, id_2]
+            micro_sims[id_1].is_most_similar_to(micro_id)

--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -2,7 +2,6 @@
 Functionality for adaptive initialization and control of micro simulations
 """
 import numpy as np
-from math import exp
 import sys
 
 class AdaptiveController:
@@ -35,9 +34,10 @@ class AdaptiveController:
         similarity_dists = np.zeros((number_of_micro_sims, number_of_micro_sims))
         for id_1 in micro_ids:
             for id_2 in micro_ids:
+                data_diff = 0
                 if id_1 != id_2:
                     if dim:
-                        for d in dim:
+                        for d in range(dim):
                             data_diff += abs(data[id_1, d] - data[id_2, d])
                     else:
                         data_diff = abs(data[id_1] - data[id_2])
@@ -48,51 +48,64 @@ class AdaptiveController:
 
         return similarity_dists
 
-    def update_active_micro_simulations(self, similarity_dists, micro_sim_states):
+    def update_active_micro_sims(self, similarity_dists, micro_sim_states, micro_sims):
         ref_tol = self._refine_const * np.amax(similarity_dists)
         coarse_tol = self._coarse_const * ref_tol
 
         number_of_micro_sims, _ = similarity_dists.shape
 
+        _micro_sim_states = np.copy(micro_sim_states)
+
         # Update the set of active micro sims
         for id_1 in range(number_of_micro_sims):
-            if micro_sim_states[id_1]:  # if id_1 sim is active
+            if _micro_sim_states[id_1]:  # if id_1 sim is active
                 for id_2 in range(number_of_micro_sims):
-                    if micro_sim_states[id_2]:  # if id_2 is active
+                    if _micro_sim_states[id_2]:  # if id_2 is active
                         if id_1 != id_2:
                             # If active sim is similar to another active sim,
                             # deactivate it
                             if similarity_dists[id_1, id_2] < coarse_tol:
                                 print("sim {} and sim {} are similar, so deactivating {}".format(id_1, id_2, id_1))
-                                self._micro_sims[id_1].deactivate()
-                                micro_sim_states[id_1] = 0
+                                micro_sims[id_1].deactivate()
+                                _micro_sim_states[id_1] = 0
                                 break
 
-        return micro_sim_states
+        return _micro_sim_states
 
-    def update_inactive_micro_simulations(self, similarity_dists, micro_sim_states):
+    def update_inactive_micro_sims(self, similarity_dists, micro_sim_states, micro_sims):
         ref_tol = self._refine_const * np.amax(similarity_dists)
 
         number_of_micro_sims, _ = similarity_dists.shape
 
+        _micro_sim_states = np.copy(micro_sim_states)
+
+        if not np.any(_micro_sim_states):
+            _micro_sim_states[0] = 1  # If all sims are inactive, activate the first one (a random choice)
+
         # Update the set of inactive micro sims
         dists = []
         for id_1 in range(number_of_micro_sims):
-            if not micro_sim_states[id_1]:
+            if not _micro_sim_states[id_1]:  # if id_1 is inactive
                 for id_2 in range(number_of_micro_sims):
-                    if micro_sim_states[id_2]:
+                    if _micro_sim_states[id_2]:  # if id_2 is active
                         dists.append(similarity_dists[id_1, id_2])
                 # If inactive sim is not similar to any active sim, activate it
                 if min(dists) > ref_tol:
-                    self._micro_sims[id_1].activate()
+                    micro_sims[id_1].activate()
+                    _micro_sim_states[id_1] = 1
                 dists = []
+        
+        return _micro_sim_states
 
-    def associate_inactive_to_active(self, similarity_dists, micro_sims):
+    def associate_inactive_to_active(self, similarity_dists, micro_sim_states, micro_sims):
         # Associate inactive micro sims to active micro sims
         micro_id = 0
-        for id_1 in self._inactive_ids:
+        active_sim_indices = np.where(micro_sim_states == 1)[0]
+        inactive_sim_indices = np.where(micro_sim_states == 0)[0]
+
+        for id_1 in inactive_sim_indices:
             dist_min = sys.float_info.max
-            for id_2 in self._active_ids:
+            for id_2 in active_sim_indices:
                 # Find most similar active sim for every inactive sim
                 if similarity_dists[id_1, id_2] < dist_min:
                     micro_id = id_2

--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -67,7 +67,6 @@ class AdaptiveController:
                             # If active sim is similar to another active sim,
                             # deactivate it
                             if similarity_dists[id_1, id_2] < coarse_tol:
-                                print("sim {} and sim {} are similar, so DEACTIVATING {}".format(id_1, id_2, id_1))
                                 micro_sims[id_1].deactivate()
                                 _micro_sim_states[id_1] = 0
                                 break
@@ -83,20 +82,16 @@ class AdaptiveController:
 
         if not np.any(_micro_sim_states):
             _micro_sim_states[0] = 1  # If all sims are inactive, activate the first one (a random choice)
-            print("No active sims, so ID 0 is activated.")
 
         # Update the set of inactive micro sims
         for id_1 in range(number_of_micro_sims):
             dists = []
             if not _micro_sim_states[id_1]:  # if id_1 is inactive
-                print("Running comparison for inactive id = {}".format(id_1))
                 for id_2 in range(number_of_micro_sims):
                     if _micro_sim_states[id_2]:  # if id_2 is active
                         dists.append(similarity_dists[id_1, id_2])
                 # If inactive sim is not similar to any active sim, activate it
-                print("Min distance for micro sim {} is {}, as compared to tolerance {}".format(id_1, min(dists), ref_tol))
                 if min(dists) > ref_tol:
-                    print("ACTIVATING micro sim {}".format(id_1))
                     micro_sims[id_1].activate()
                     _micro_sim_states[id_1] = 1
 

--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -11,7 +11,21 @@ class AdaptiveController:
         self._refine_const = configurator.get_adaptivity_refining_const()
         self._coarse_const = configurator.get_adaptivity_coarsening_const()
 
-    def get_similarity_dists(self, dt, similarity_dists, data):
+    def get_active_and_inactive_ids(self, micro_sim_ids, micro_sim_states):
+        """
+        
+        """
+        active_sim_ids = []
+        inactive_sim_ids = []
+        for id in micro_sim_ids:
+            if micro_sim_states[id] == 1:
+                active_sim_ids.append(id)
+            elif micro_sim_states[id] == 0:
+                inactive_sim_ids.append(id)
+        
+        return active_sim_ids, inactive_sim_ids
+
+    def get_similarity_dists(self, dt, micro_sim_ids, similarity_dists, data):
         """
         Calculate metric which determines if two micro simulations are similar enough to have one of them deactivated.
 
@@ -24,44 +38,40 @@ class AdaptiveController:
         """
         _similarity_dists = np.copy(similarity_dists)
 
-        # print("Similarity dists before calc = {}".format(_similarity_dists))
-
         if data.ndim == 1:
-            number_of_micro_sims = len(data)
             dim = 0
         elif data.ndim == 2:
-            number_of_micro_sims, dim = data.shape
+            _, dim = data.shape
 
-        micro_ids = list(range(number_of_micro_sims))
-        for id_1 in micro_ids:
-            for id_2 in micro_ids:
+        counter_1 = 0
+        for id_1 in micro_sim_ids:
+            counter_2 = 0
+            for id_2 in micro_sim_ids:
                 data_diff = 0
                 if id_1 != id_2:
                     if dim:
                         for d in range(dim):
-                            data_diff += abs(data[id_1, d] - data[id_2, d])
+                            data_diff += abs(data[counter_1, d] - data[counter_2, d])
                     else:
-                        data_diff = abs(data[id_1] - data[id_2])
+                        data_diff = abs(data[counter_1] - data[counter_2])
 
                     _similarity_dists[id_1, id_2] += dt * data_diff
                 else:
-                    _similarity_dists[id_1, id_2] = 0.0
-
-        # print("Similarity dists after calc = {}".format(_similarity_dists))
+                    _similarity_dists[id_1, id_2] = 0
+                counter_2 += 1
+            counter_1 += 1
 
         return _similarity_dists
 
-    def update_active_micro_sims(self, similarity_dists, micro_sim_states, micro_sims):
+    def update_active_micro_sims(self, micro_sim_ids, similarity_dists, micro_sim_states, micro_sims):
         coarse_tol = self._coarse_const * self._refine_const * np.amax(similarity_dists)
-
-        number_of_micro_sims, _ = similarity_dists.shape
 
         _micro_sim_states = np.copy(micro_sim_states)
 
         # Update the set of active micro sims
-        for id_1 in range(number_of_micro_sims):
+        for id_1 in micro_sim_ids:
             if _micro_sim_states[id_1]:  # if id_1 sim is active
-                for id_2 in range(number_of_micro_sims):
+                for id_2 in micro_sim_ids:
                     if _micro_sim_states[id_2]:  # if id_2 is active
                         if id_1 != id_2:  # don't compare active sim to itself
                             # If active sim is similar to another active sim,
@@ -73,21 +83,19 @@ class AdaptiveController:
 
         return _micro_sim_states
 
-    def update_inactive_micro_sims(self, similarity_dists, micro_sim_states, micro_sims):
+    def update_inactive_micro_sims(self, micro_sim_ids, similarity_dists, micro_sim_states, micro_sims):
         ref_tol = self._refine_const * np.amax(similarity_dists)
-
-        number_of_micro_sims, _ = similarity_dists.shape
 
         _micro_sim_states = np.copy(micro_sim_states)
 
         if not np.any(_micro_sim_states):
-            _micro_sim_states[0] = 1  # If all sims are inactive, activate the first one (a random choice)
+            _micro_sim_states[micro_sim_ids[0]] = 1  # If all sims are inactive, activate the first one (a random choice)
 
         # Update the set of inactive micro sims
-        for id_1 in range(number_of_micro_sims):
+        for id_1 in micro_sim_ids:
             dists = []
             if not _micro_sim_states[id_1]:  # if id_1 is inactive
-                for id_2 in range(number_of_micro_sims):
+                for id_2 in micro_sim_ids:
                     if _micro_sim_states[id_2]:  # if id_2 is active
                         dists.append(similarity_dists[id_1, id_2])
                 # If inactive sim is not similar to any active sim, activate it
@@ -97,18 +105,16 @@ class AdaptiveController:
 
         return _micro_sim_states
 
-    def associate_inactive_to_active(self, similarity_dists, micro_sim_states, micro_sims):
+    def associate_inactive_to_active(self, micro_sim_ids, similarity_dists, micro_sim_states, micro_sims):
+        """
+        
+        """
+        active_sim_ids, inactive_sim_ids = self.get_active_and_inactive_ids(micro_sim_ids, micro_sim_states)
+        
         # Associate inactive micro sims to active micro sims
-        micro_id = 0
-        active_sim_indices = np.where(micro_sim_states == 1)[0]
-        inactive_sim_indices = np.where(micro_sim_states == 0)[0]
-
-        # print("Active sim indices in association = {}".format(active_sim_indices))
-        # print("Inactive sim indices in association = {}".format(inactive_sim_indices))
-
-        for id_1 in inactive_sim_indices:
+        for id_1 in inactive_sim_ids:
             dist_min = sys.float_info.max
-            for id_2 in active_sim_indices:
+            for id_2 in active_sim_ids:
                 # Find most similar active sim for every inactive sim
                 if similarity_dists[id_1, id_2] < dist_min:
                     micro_id = id_2

--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -4,6 +4,7 @@ Functionality for adaptive initialization and control of micro simulations
 import numpy as np
 import sys
 
+
 class AdaptiveController:
     def __init__(self, configurator) -> None:
         # Names of data to be used for adaptivity computation
@@ -41,7 +42,7 @@ class AdaptiveController:
                             data_diff += abs(data[id_1, d] - data[id_2, d])
                     else:
                         data_diff = abs(data[id_1] - data[id_2])
-                    
+
                     similarity_dists[id_1, id_2] += dt * data_diff
                 else:
                     similarity_dists[id_1, id_2] = 0.0
@@ -94,7 +95,7 @@ class AdaptiveController:
                     micro_sims[id_1].activate()
                     _micro_sim_states[id_1] = 1
                 dists = []
-        
+
         return _micro_sim_states
 
     def associate_inactive_to_active(self, similarity_dists, micro_sim_states, micro_sims):

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -35,6 +35,12 @@ class Config:
 
         self._output_micro_sim_time = False
 
+        self._adaptivity = False
+        self._data_for_adaptivity = dict()
+        self._adaptivity_history_param = 0.5
+        self._adaptivity_coarsening_constant = 0.5
+        self._adaptivity_refining_constant = 0.5
+
         self.read_json(config_filename)
 
     def read_json(self, config_filename):
@@ -96,6 +102,21 @@ class Config:
         except BaseException:
             print("Output interval of micro simulations not specified, if output is available then it will be called "
                   "in every time window.")
+
+        try:
+            self._adaptivity = data["simulation_params"]["adaptivity"]
+
+            data_for_adaptivity = data["simulation_params"]["adaptivity_data"]
+            exchange_data = {**self._read_data_names, **self._write_data_names}
+            for dname in data_for_adaptivity:
+                self._data_for_adaptivity[dname] = exchange_data[dname]
+
+            self._adaptivity_history_param = data["simulation_params"]["adaptivity_history_param"]
+            self._adaptivity_coarsening_constant = data["simulation_params"]["adaptivity_coarsening_constant"]
+            self._adaptivity_refining_constant = data["simulation_params"]["adaptivity_refining_constant"]
+        except BaseException:
+            print("Micro Manager will not adaptively run micro simulations, but instead will run all micro simulations "
+                  "in all time steps.")
 
         try:
             diagnostics_data_names = data["diagnostics"]["data_from_micro_sims"]
@@ -212,3 +233,48 @@ class Config:
             True if micro simulation solve time is required.
         """
         return self._output_micro_sim_time
+
+    def turn_on_adaptivity(self):
+        """
+
+        Returns
+        -------
+
+        """
+        return self._adaptivity
+
+    def get_data_for_adaptivity(self):
+        """
+
+        Returns
+        -------
+
+        """
+        return self._data_for_adaptivity
+
+    def get_adaptivity_hist_param(self):
+        """
+
+        Returns
+        -------
+
+        """
+        return self._adaptivity_history_param
+
+    def get_adaptivity_coarsening_const(self):
+        """
+
+        Returns
+        -------
+
+        """
+        return self._adaptivity_coarsening_constant
+
+    def get_adaptivity_refining_const(self):
+        """
+
+        Returns
+        -------
+
+        """
+        return self._adaptivity_refining_constant

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -106,9 +106,8 @@ class Config:
         try:
             self._adaptivity = data["simulation_params"]["adaptivity"]
 
-            data_for_adaptivity = data["simulation_params"]["adaptivity_data"]
             exchange_data = {**self._read_data_names, **self._write_data_names}
-            for dname in data_for_adaptivity:
+            for dname in data["simulation_params"]["adaptivity_data"]:
                 self._data_for_adaptivity[dname] = exchange_data[dname]
 
             self._adaptivity_history_param = data["simulation_params"]["adaptivity_history_param"]

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -113,6 +113,8 @@ class Config:
             self._adaptivity_history_param = data["simulation_params"]["adaptivity_history_param"]
             self._adaptivity_coarsening_constant = data["simulation_params"]["adaptivity_coarsening_constant"]
             self._adaptivity_refining_constant = data["simulation_params"]["adaptivity_refining_constant"]
+
+            self._write_data_names["active_state"] = False
         except BaseException:
             print("Micro Manager will not adaptively run micro simulations, but instead will run all micro simulations "
                   "in all time steps.")

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -357,7 +357,7 @@ class MicroManager:
                         self._write_data_ids[dname], [], np.array([]))
 
     def solve_micro_simulations(self, micro_sims_input: dict, similarity_dists_nm1: np.ndarray,
-                                micro_sim_states_nm1: np.ndarray) -> tuple[list, np.ndarray, np.ndarray]:
+                                micro_sim_states_nm1: np.ndarray):
         """
         Solve all micro simulations using the data read from preCICE and assemble the micro simulations outputs in a list of dicts
         format.

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -126,10 +126,10 @@ class MicroManager:
         self._similarity_dists_cp = None
         self._is_adaptivity_on = config.turn_on_adaptivity()
 
-        adaptivity_data_names = config.get_data_for_adaptivity()  # Names of data to be used for adaptivity computation
-        self._adaptivity_macro_data_names = dict()
-        self._adaptivity_micro_data_names = dict()
-        for name, is_data_vector in adaptivity_data_names.items():
+        self._adaptivity_data_names = config.get_data_for_adaptivity()  # Names of data to be used for adaptivity computation
+        self._adaptivity_macro_data_names = dict()  # Names of macro data to be used for adaptivity computation
+        self._adaptivity_micro_data_names = dict()  # Names of micro data to be used for adaptivity computation
+        for name, is_data_vector in self._adaptivity_data_names.items():
             if name in self._read_data_names:
                 self._adaptivity_macro_data_names[name] = is_data_vector
             if name in self._write_data_names:
@@ -143,8 +143,6 @@ class MicroManager:
         self._active_ids_cp = []  # List of ids of micro simulations which are active in time t_{n-1}
         self._inactive_ids = None  # List of ids of micro simulations which are inactive at time t_n
         self._inactive_ids_cp = None  # List of ids of micro simulations which are inactive in time t_{n-1}
-
-
 
     def calculate_scalar_similarity_dists(self, similarity_dists_nm1, scalar_data):
         """
@@ -480,7 +478,7 @@ class MicroManager:
             micro_sims_output[i] = self._micro_sims[i].solve(micro_sims_input[i], self._dt)
             end_time = time.time()
 
-            for name in self._adaptivity_data_names:
+            for name in self._adaptivity_micro_data_names:
                 self._exchange_data[name][i] = micro_sims_output[i][name]  # Collect micro sim output for adaptivity
 
             if self._is_micro_solve_time_required:

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -153,8 +153,8 @@ class MicroManager:
             for id_2 in micro_ids:
                 if id_1 != id_2:
                     similarity_dists[id_1, id_2] += exp(-self._adap_hist_param * self._dt) * \
-                                                          similarity_dists_nm1[id_1, id_2] + \
-                                                          self._dt * abs(scalar_data[id_1] - scalar_data[id_2])
+                        similarity_dists_nm1[id_1, id_2] + \
+                        self._dt * abs(scalar_data[id_1] - scalar_data[id_2])
                 else:
                     similarity_dists[id_1, id_2] = 0.0
                 micro_ids.remove(id_1)
@@ -183,7 +183,7 @@ class MicroManager:
                     for d in dims:
                         data_diff += abs(vector_data[id_1, d] - vector_data[id_2, d])
                     similarity_dists[id_1, id_2] += exp(-self._adap_hist_param * self._dt) * \
-                                                    similarity_dists_nm1[id_1, id_2] + self._dt * data_diff
+                        similarity_dists_nm1[id_1, id_2] + self._dt * data_diff
                 else:
                     similarity_dists[id_1, id_2] = 0.0
                 micro_ids.remove(id_1)
@@ -200,7 +200,8 @@ class MicroManager:
         # Update the set of active micro sims
         for id_1 in self._active_ids:
             for id_2 in self._active_ids:
-                if similarity_dists[id_1, id_2] < coarse_tol:  # If active sim is similar to another active sim, deactivate it
+                # If active sim is similar to another active sim, deactivate it
+                if similarity_dists[id_1, id_2] < coarse_tol:
                     self._micro_sims[id_1].deactivate()
                     self._active_ids.remove(id_1)
                     self._inactive_ids.append(id_1)
@@ -210,7 +211,8 @@ class MicroManager:
         for id_1 in self._inactive_ids:
             for id_2 in self._active_ids:
                 similarity_dists.append(similarity_dists[id_1, id_2])
-            if min(similarity_dists) > ref_tol:  # If inactive sim is not similar to any active sim, activate it
+            # If inactive sim is not similar to any active sim, activate it
+            if min(similarity_dists) > ref_tol:
                 self._micro_sims[id_1].activate()
                 self._inactive_ids.remove(id_1)
                 self._active_ids.append(id_1)
@@ -220,7 +222,8 @@ class MicroManager:
         similarity_d, micro_id = 100, 0
         for id_1 in self._inactive_ids:
             for id_2 in self._active_ids:
-                if similarity_dists[id_1, id_2] < similarity_d:  # Find most similar active sim for every inactive sim
+                # Find most similar active sim for every inactive sim
+                if similarity_dists[id_1, id_2] < similarity_d:
                     micro_id = id_2
             self._micro_sims[id_1].is_most_similar_to(micro_id)
 
@@ -378,12 +381,13 @@ class MicroManager:
             if is_data_vector:
                 read_data.update({name: self._interface.read_block_vector_data(self._read_data_ids[name],
                                                                                self._mesh_vertex_ids)})
-                self._exchange_data[name] = self._interface.read_block_vector_data(self._read_data_ids[name], self._mesh_vertex_ids)
+                self._exchange_data[name] = self._interface.read_block_vector_data(self._read_data_ids[name],
+                                                                                   self._mesh_vertex_ids)
             else:
                 read_data.update({name: self._interface.read_block_scalar_data(self._read_data_ids[name],
                                                                                self._mesh_vertex_ids)})
-                self._exchange_data[name] = self._interface.read_block_scalar_data(self._read_data_ids[name], self._mesh_vertex_ids)
-
+                self._exchange_data[name] = self._interface.read_block_scalar_data(self._read_data_ids[name],
+                                                                                   self._mesh_vertex_ids)
 
         return [dict(zip(read_data, t)) for t in zip(*read_data.values())]
 
@@ -439,10 +443,10 @@ class MicroManager:
         for name, is_data_vector in self._adaptivity_data_names:
             if is_data_vector:
                 self._similarity_dists = self.calculate_vector_similarity_dists(self._similarity_dists_nm1,
-                                                                                 self._exchange_data[name])
+                                                                                self._exchange_data[name])
             else:
                 self._similarity_dists = self.calculate_scalar_similarity_dists(self._similarity_dists_nm1,
-                                                                                 self._exchange_data[name])
+                                                                                self._exchange_data[name])
 
         micro_sims_output = list(range(self._number_of_micro_simulations))
         # Solve all active micro simulations

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Micro manager to organize many micro simulations and couple them via preCICE to a macro simulation
+Micro Manager: a tool to organize many micro simulations and couple them via preCICE to a macro simulation
 """
 
 import argparse
@@ -125,12 +125,17 @@ class MicroManager:
         self._similarity_dists_nm1 = None
         self._similarity_dists_cp = None
         self._is_adaptivity_on = config.turn_on_adaptivity()
-        self._adaptivity_data_names = config.get_data_for_adaptivity()  # Names of data to be used for adaptivity computation
+
+        adaptivity_data_names = config.get_data_for_adaptivity()  # Names of data to be used for adaptivity computation
+        self._adaptivity_macro_data_names = dict()
+        self._adaptivity_micro_data_names = dict()
+        for name, is_data_vector in adaptivity_data_names.items():
+            if name in self._read_data_names:
+                self._adaptivity_macro_data_names[name] = is_data_vector
+            if name in self._write_data_names:
+                self._adaptivity_micro_data_names[name] = is_data_vector
 
         self._exchange_data = dict()
-        for name, _ in self._adaptivity_data_names.items():
-            self._exchange_data[name] = []
-
         self._adap_hist_param = config.get_adaptivity_hist_param()
         self._refine_const = config.get_adaptivity_refining_const()
         self._coarse_const = config.get_adaptivity_coarsening_const()
@@ -139,6 +144,8 @@ class MicroManager:
         self._inactive_ids = None  # List of ids of micro simulations which are inactive at time t_n
         self._inactive_ids_cp = None  # List of ids of micro simulations which are inactive in time t_{n-1}
 
+
+
     def calculate_scalar_similarity_dists(self, similarity_dists_nm1, scalar_data):
         """
 
@@ -146,9 +153,8 @@ class MicroManager:
         -------
 
         """
-        nms = scalar_data.shape
-        micro_ids = list(range(nms))
-        similarity_dists = list(range(nms))
+        micro_ids = list(range(len(scalar_data)))
+        similarity_dists = np.zeros((self._number_of_micro_simulations, self._number_of_micro_simulations))
         for id_1 in micro_ids:
             for id_2 in micro_ids:
                 if id_1 != id_2:
@@ -157,7 +163,7 @@ class MicroManager:
                         self._dt * abs(scalar_data[id_1] - scalar_data[id_2])
                 else:
                     similarity_dists[id_1, id_2] = 0.0
-                micro_ids.remove(id_1)
+            micro_ids.remove(id_1)
 
         return similarity_dists
 
@@ -175,18 +181,18 @@ class MicroManager:
         """
         nms, dim = vector_data.shape
         micro_ids = list(range(nms))
-        similarity_dists = list(range(nms))
+        similarity_dists = np.zeros((self._number_of_micro_simulations, self._number_of_micro_simulations))
         for id_1 in micro_ids:
             for id_2 in micro_ids:
                 if id_1 != id_2:
                     data_diff = 0
-                    for d in dims:
+                    for d in dim:
                         data_diff += abs(vector_data[id_1, d] - vector_data[id_2, d])
                     similarity_dists[id_1, id_2] += exp(-self._adap_hist_param * self._dt) * \
                         similarity_dists_nm1[id_1, id_2] + self._dt * data_diff
                 else:
                     similarity_dists[id_1, id_2] = 0.0
-                micro_ids.remove(id_1)
+            micro_ids.remove(id_1)
 
         return similarity_dists
 
@@ -194,7 +200,12 @@ class MicroManager:
         """
 
         """
-        print("similarity_dists = {}".format(similarity_dists))
+        # If max of similarity dist is zero, it is the first iteration, all micro simulations are then active.
+        if np.amax(similarity_dists) == 0:
+            self._active_ids = list(range(self._number_of_micro_simulations))
+            self._inactive_ids = []
+            return
+
         ref_tol = self._refine_const * np.amax(similarity_dists)
         coarse_tol = self._coarse_const * ref_tol
 
@@ -206,26 +217,31 @@ class MicroManager:
                     self._micro_sims[id_1].deactivate()
                     self._active_ids.remove(id_1)
                     self._inactive_ids.append(id_1)
+                    break
+
+        if not self._active_ids:  # If there are no active simulations, then all simulations are activated.
+            self._active_ids = list(range(self._number_of_micro_simulations))
 
         # Update the set of inactive micro sims
-        similarity_dists = []
+        dists = []
         for id_1 in self._inactive_ids:
             for id_2 in self._active_ids:
-                similarity_dists.append(similarity_dists[id_1, id_2])
+                dists.append(similarity_dists[id_1, id_2])
             # If inactive sim is not similar to any active sim, activate it
-            if min(similarity_dists) > ref_tol:
+            if min(dists) > ref_tol:
                 self._micro_sims[id_1].activate()
                 self._inactive_ids.remove(id_1)
                 self._active_ids.append(id_1)
-            similarity_dists = []
+            dists = []
 
         # Associate inactive micro sims to active micro sims
-        similarity_d, micro_id = 100, 0
+        dist_min, micro_id = 100, 0
         for id_1 in self._inactive_ids:
             for id_2 in self._active_ids:
                 # Find most similar active sim for every inactive sim
-                if similarity_dists[id_1, id_2] < similarity_d:
+                if similarity_dists[id_1, id_2] < dist_min:
                     micro_id = id_2
+                    dist_min = similarity_dists[id_1, id_2]
             self._micro_sims[id_1].is_most_similar_to(micro_id)
 
     def decompose_macro_domain(self, macro_bounds):
@@ -298,6 +314,9 @@ class MicroManager:
 
         self._similarity_dists_nm1 = np.zeros((self._number_of_micro_simulations, self._number_of_micro_simulations))
         self._inactive_ids = list(range(self._number_of_micro_simulations))  # All micro sims are inactive at the start
+
+        for name, _ in self._adaptivity_data_names.items():
+            self._exchange_data[name] = list(range(self._number_of_micro_simulations))
 
         if self._number_of_micro_simulations == 0:
             if self._is_parallel:
@@ -382,13 +401,15 @@ class MicroManager:
             if is_data_vector:
                 read_data.update({name: self._interface.read_block_vector_data(self._read_data_ids[name],
                                                                                self._mesh_vertex_ids)})
-                self._exchange_data[name] = self._interface.read_block_vector_data(self._read_data_ids[name],
-                                                                                   self._mesh_vertex_ids)
+                if name in self._adaptivity_macro_data_names:
+                    self._exchange_data[name] = self._interface.read_block_vector_data(self._read_data_ids[name],
+                                                                                       self._mesh_vertex_ids)
             else:
                 read_data.update({name: self._interface.read_block_scalar_data(self._read_data_ids[name],
                                                                                self._mesh_vertex_ids)})
-                self._exchange_data[name] = self._interface.read_block_scalar_data(self._read_data_ids[name],
-                                                                                   self._mesh_vertex_ids)
+                if name in self._adaptivity_macro_data_names:
+                    self._exchange_data[name] = self._interface.read_block_scalar_data(self._read_data_ids[name],
+                                                                                       self._mesh_vertex_ids)
 
         return [dict(zip(read_data, t)) for t in zip(*read_data.values())]
 
@@ -459,8 +480,8 @@ class MicroManager:
             micro_sims_output[i] = self._micro_sims[i].solve(micro_sims_input[i], self._dt)
             end_time = time.time()
 
-            for name, values in micro_sims_output[i].items():
-                self._exchange_data[name][i] = values  # Collect micro sim output for adaptivity
+            for name in self._adaptivity_data_names:
+                self._exchange_data[name][i] = micro_sims_output[i][name]  # Collect micro sim output for adaptivity
 
             if self._is_micro_solve_time_required:
                 micro_sims_output[i]["micro_sim_time"] = end_time - start_time

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -183,7 +183,7 @@ class MicroManager:
             for id_2 in micro_ids:
                 if id_1 != id_2:
                     data_diff = 0
-                    for d in dim:
+                    for d in range(dim):
                         data_diff += abs(vector_data[id_1, d] - vector_data[id_2, d])
                     similarity_dists[id_1, id_2] = exp(-self._adap_hist_param * self._dt) * \
                         similarity_dists_nm1[id_1, id_2] + self._dt * data_diff
@@ -197,11 +197,7 @@ class MicroManager:
         """
 
         """
-        # If max of similarity dist is zero, it is the first iteration, all micro simulations are then active.
-        if np.amax(similarity_dists) == 0:
-            self._active_ids = list(range(self._number_of_micro_simulations))
-            self._inactive_ids = []
-            return
+        print("similarity_dists at the start of calculate_adaptivity = {}".format(similarity_dists))
 
         ref_tol = self._refine_const * np.amax(similarity_dists)
         coarse_tol = self._coarse_const * ref_tol

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -128,7 +128,7 @@ class MicroManager:
         self._adaptivity_data_names = config.get_data_for_adaptivity()  # Names of data to be used for adaptivity computation
 
         self._exchange_data = dict()
-        for name, _ in self._adaptivity_data_names:
+        for name, _ in self._adaptivity_data_names.items():
             self._exchange_data[name] = []
 
         self._adap_hist_param = config.get_adaptivity_hist_param()
@@ -194,6 +194,7 @@ class MicroManager:
         """
 
         """
+        print("similarity_dists = {}".format(similarity_dists))
         ref_tol = self._refine_const * np.amax(similarity_dists)
         coarse_tol = self._coarse_const * ref_tol
 
@@ -440,13 +441,15 @@ class MicroManager:
             List of dicts in which keys are names of data and the values are the data of the output of the micro
             simulations.
         """
-        for name, is_data_vector in self._adaptivity_data_names:
+        for name, is_data_vector in self._adaptivity_data_names.items():
             if is_data_vector:
                 self._similarity_dists = self.calculate_vector_similarity_dists(self._similarity_dists_nm1,
                                                                                 self._exchange_data[name])
             else:
                 self._similarity_dists = self.calculate_scalar_similarity_dists(self._similarity_dists_nm1,
                                                                                 self._exchange_data[name])
+
+        self.calculate_adaptivity(self._similarity_dists)
 
         micro_sims_output = list(range(self._number_of_micro_simulations))
         # Solve all active micro simulations

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -391,12 +391,13 @@ class MicroManager:
             self._adaptivity_controller.associate_inactive_to_active(
                 similarity_dists_n, micro_sim_states_n, self._micro_sims)
 
-            active_sim_ids, inactive_sim_ids = self._adaptivity_controller.get_active_and_inactive_ids(
-                micro_sim_states_n)
+            active_sim_ids = np.where(micro_sim_states_n == 1)[0]
+            inactive_sim_ids = np.where(micro_sim_states_n == 0)[0]
+
         else:
             # If adaptivity is off, all micro simulations are active
-            active_sim_ids, inactive_sim_ids = self._adaptivity_controller.get_active_and_inactive_ids(
-                micro_sim_states_nm1)
+            active_sim_ids = np.where(micro_sim_states_nm1 == 1)[0]
+            inactive_sim_ids = np.where(micro_sim_states_nm1 == 0)[0]
 
         micro_sims_output = list(range(self._local_number_of_micro_sims))
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -273,7 +273,7 @@ class MicroManager:
 
         # Initialize coupling data
         if self._interface.is_action_required(precice.action_write_initial_data()):
-                self.write_data_to_precice(write_data)
+            self.write_data_to_precice(write_data)
 
         self._interface.initialize_data()
 
@@ -368,10 +368,10 @@ class MicroManager:
 
             micro_sim_states_n = self._adaptivity_controller.update_active_micro_sims(
                 similarity_dists_n, micro_sim_states_nm1, self._micro_sims)
-            
+
             micro_sim_states_n = self._adaptivity_controller.update_inactive_micro_sims(
                 similarity_dists_n, micro_sim_states_n, self._micro_sims)
-            
+
             self._adaptivity_controller.associate_inactive_to_active(
                 similarity_dists_n, micro_sim_states_n, self._micro_sims)
 
@@ -379,9 +379,6 @@ class MicroManager:
 
         active_sim_indices = np.where(micro_sim_states_n == 1)[0]
         inactive_sim_indices = np.where(micro_sim_states_n == 0)[0]
-
-        print("active_sim_indices = {}".format(active_sim_indices))
-        print("inactive_sim_indices = {}".format(inactive_sim_indices))
 
         # Solve all active micro simulations
         for i in active_sim_indices:
@@ -450,7 +447,8 @@ class MicroManager:
 
             micro_sims_input = self.read_data_from_precice()
 
-            micro_sims_output, similarity_dists, micro_sim_states = self.solve_micro_simulations(micro_sims_input, similarity_dists, micro_sim_states)
+            micro_sims_output, similarity_dists, micro_sim_states = self.solve_micro_simulations(
+                micro_sims_input, similarity_dists, micro_sim_states)
 
             self.write_data_to_precice(micro_sims_output)
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -370,7 +370,7 @@ class MicroManager:
 
             self._adaptivity_controller.associate_inactive_to_active(
                 similarity_dists_n, micro_sim_states_n, self._micro_sims)
-        
+
             active_sim_indices = np.where(micro_sim_states_n == 1)[0]
             inactive_sim_indices = np.where(micro_sim_states_n == 0)[0]
         else:
@@ -419,7 +419,7 @@ class MicroManager:
 
             if self._is_micro_solve_time_required:
                 micro_sims_output[i]["micro_sim_time"] = end_time - start_time
-            
+
         return micro_sims_output, similarity_dists_n, micro_sim_states_n
 
     def solve(self):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -214,9 +214,8 @@ class MicroManager:
                     for d in range(dim):
                         data_diff += abs(vector_data[id_1,
                                          d] - vector_data[id_2, d])
-                    similarity_dists[id_1,
-                                     id_2] = exp(-self._adap_hist_param * self._dt) * similarity_dists_nm1[id_1,
-                                                                                                           id_2] + self._dt * data_diff
+                    similarity_dists[id_1, id_2] = exp(-self._adap_hist_param * self._dt) * \
+                        similarity_dists_nm1[id_1, id_2] + self._dt * data_diff
                 else:
                     similarity_dists[id_1, id_2] = 0.0
             micro_ids.remove(id_1)

--- a/tests/integration/test_adaptivity/clean-test.sh
+++ b/tests/integration/test_adaptivity/clean-test.sh
@@ -1,0 +1,9 @@
+rm -fv *-events-summary.json
+rm -fv *-events.json
+rm -fv *.log
+rm -r -fv precice-run/
+rm -fv *.vtk
+rm -fv *.out
+rm -fv *.err
+rm -fv output/*.vtu
+rm -fv output/*.pvtu

--- a/tests/integration/test_adaptivity/macro_solver.py
+++ b/tests/integration/test_adaptivity/macro_solver.py
@@ -24,7 +24,7 @@ def main():
     write_data_names = {"macro-scalar-data": 0, "macro-vector-data": 1}
 
     # Coupling mesh - unit cube with 5 points in each direction
-    np_axis = 5
+    np_axis = 2
     x_coords, y_coords, z_coords = np.meshgrid(
         np.linspace(0, 1, np_axis),
         np.linspace(0, 1, np_axis),

--- a/tests/integration/test_adaptivity/macro_solver.py
+++ b/tests/integration/test_adaptivity/macro_solver.py
@@ -24,7 +24,7 @@ def main():
     write_data_names = {"macro-scalar-data": 0, "macro-vector-data": 1}
 
     # Coupling mesh - unit cube with 5 points in each direction
-    np_axis = 5
+    np_axis = 3
     x_coords, y_coords, z_coords = np.meshgrid(
         np.linspace(0, 1, np_axis),
         np.linspace(0, 1, np_axis),
@@ -52,9 +52,6 @@ def main():
                 write_vector_data[n, 2] = vector_value[2]
         scalar_value += 1
         vector_value = [x + 1 for x in vector_value]
-
-    print("write_scalar_data = {}".format(write_scalar_data))
-    print("write_vector_data = {}".format(write_vector_data))
 
     # Define Gauss points on entire domain as coupling mesh
     vertex_ids = interface.set_mesh_vertices(read_mesh_id, coords)

--- a/tests/integration/test_adaptivity/macro_solver.py
+++ b/tests/integration/test_adaptivity/macro_solver.py
@@ -24,7 +24,7 @@ def main():
     write_data_names = {"macro-scalar-data": 0, "macro-vector-data": 1}
 
     # Coupling mesh - unit cube with 5 points in each direction
-    np_axis = 3
+    np_axis = 5
     x_coords, y_coords, z_coords = np.meshgrid(
         np.linspace(0, 1, np_axis),
         np.linspace(0, 1, np_axis),

--- a/tests/integration/test_adaptivity/macro_solver.py
+++ b/tests/integration/test_adaptivity/macro_solver.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import precice
-from random import random
 
 
 def main():
@@ -25,7 +24,7 @@ def main():
     write_data_names = {"macro-scalar-data": 0, "macro-vector-data": 1}
 
     # Coupling mesh - unit cube with 5 points in each direction
-    np_axis = 2
+    np_axis = 5
     x_coords, y_coords, z_coords = np.meshgrid(
         np.linspace(0, 1, np_axis),
         np.linspace(0, 1, np_axis),
@@ -53,6 +52,9 @@ def main():
                 write_vector_data[n, 2] = vector_value[2]
         scalar_value += 1
         vector_value = [x + 1 for x in vector_value]
+
+    print("write_scalar_data = {}".format(write_scalar_data))
+    print("write_vector_data = {}".format(write_vector_data))
 
     # Define Gauss points on entire domain as coupling mesh
     vertex_ids = interface.set_mesh_vertices(read_mesh_id, coords)
@@ -96,11 +98,9 @@ def main():
             elif dim == 1:
                 read_vector_data = interface.read_block_vector_data(read_data_ids[name], vertex_ids)
 
-        # Set the read data as the write data
-        write_scalar_data[:] = read_scalar_data[:]
-        for i in range(nv):
-            for d in range(interface.get_dimensions()):
-                write_vector_data[i, d] = read_vector_data[i, d]
+        # Set the read data as the write data with an increment
+        write_scalar_data = read_scalar_data + 1
+        write_vector_data = read_vector_data + 1
 
         # Write data to preCICE
         for name, dim in write_data_names.items():

--- a/tests/integration/test_adaptivity/macro_solver.py
+++ b/tests/integration/test_adaptivity/macro_solver.py
@@ -24,7 +24,7 @@ def main():
     write_data_names = {"macro-scalar-data": 0, "macro-vector-data": 1}
 
     # Coupling mesh - unit cube with 5 points in each direction
-    np_axis = 2
+    np_axis = 4
     x_coords, y_coords, z_coords = np.meshgrid(
         np.linspace(0, 1, np_axis),
         np.linspace(0, 1, np_axis),

--- a/tests/integration/test_adaptivity/macro_solver.py
+++ b/tests/integration/test_adaptivity/macro_solver.py
@@ -5,6 +5,7 @@ import numpy as np
 import precice
 from random import random
 
+
 def main():
     """
     Dummy macro simulation which is coupled to a set of micro simulations via preCICE and the Micro Manager
@@ -51,7 +52,7 @@ def main():
                 write_vector_data[n, 1] = vector_value[1]
                 write_vector_data[n, 2] = vector_value[2]
         scalar_value += 1
-        vector_value = [x + 1 for x in vector_value] 
+        vector_value = [x + 1 for x in vector_value]
 
     # Define Gauss points on entire domain as coupling mesh
     vertex_ids = interface.set_mesh_vertices(read_mesh_id, coords)

--- a/tests/integration/test_adaptivity/macro_solver.py
+++ b/tests/integration/test_adaptivity/macro_solver.py
@@ -1,0 +1,128 @@
+#! /usr/bin/env python3
+#
+
+import numpy as np
+import precice
+from random import random
+
+def main():
+    """
+    Dummy macro simulation which is coupled to a set of micro simulations via preCICE and the Micro Manager
+    """
+    n = n_checkpoint = 0
+    t = t_checkpoint = 0
+
+    # preCICE setup
+    interface = precice.Interface("Macro-dummy", "precice-config.xml", 0, 1)
+
+    # define coupling meshes
+    read_mesh_name = write_mesh_name = "macro-mesh"
+    read_mesh_id = interface.get_mesh_id(read_mesh_name)
+    read_data_names = {"micro-scalar-data": 0, "micro-vector-data": 1}
+
+    write_mesh_id = interface.get_mesh_id(write_mesh_name)
+    write_data_names = {"macro-scalar-data": 0, "macro-vector-data": 1}
+
+    # Coupling mesh - unit cube with 5 points in each direction
+    np_axis = 5
+    x_coords, y_coords, z_coords = np.meshgrid(
+        np.linspace(0, 1, np_axis),
+        np.linspace(0, 1, np_axis),
+        np.linspace(0, 1, np_axis)
+    )
+
+    nv = np_axis ** interface.get_dimensions()
+    coords = np.zeros((nv, interface.get_dimensions()))
+
+    write_scalar_data = np.zeros(nv)
+    write_vector_data = np.zeros((nv, interface.get_dimensions()))
+
+    scalar_value = 1.0
+    vector_value = [2.0, 3.0, 4.0]
+    for z in range(np_axis):
+        for y in range(np_axis):
+            for x in range(np_axis):
+                n = x + y * np_axis + z * np_axis * np_axis
+                coords[n, 0] = x_coords[x, y, z]
+                coords[n, 1] = y_coords[x, y, z]
+                coords[n, 2] = z_coords[x, y, z]
+                write_scalar_data[n] = scalar_value
+                write_vector_data[n, 0] = vector_value[0]
+                write_vector_data[n, 1] = vector_value[1]
+                write_vector_data[n, 2] = vector_value[2]
+        scalar_value += 1
+        vector_value = [x + 1 for x in vector_value] 
+
+    # Define Gauss points on entire domain as coupling mesh
+    vertex_ids = interface.set_mesh_vertices(read_mesh_id, coords)
+
+    read_data_ids = dict()
+    # coupling data
+    for name, dim in read_data_names.items():
+        read_data_ids[name] = interface.get_data_id(name, read_mesh_id)
+
+    write_data_ids = dict()
+    for name, dim in write_data_names.items():
+        write_data_ids[name] = interface.get_data_id(name, write_mesh_id)
+
+    # initialize preCICE
+    dt = interface.initialize()
+
+    # Set initial data to write to preCICE
+    if interface.is_action_required(precice.action_write_initial_data()):
+        for name, dim in write_data_names.items():
+            if dim == 0:
+                interface.write_block_scalar_data(write_data_ids[name], vertex_ids, write_scalar_data)
+            elif dim == 1:
+                interface.write_block_vector_data(write_data_ids[name], vertex_ids, write_vector_data)
+        interface.mark_action_fulfilled(precice.action_write_initial_data())
+
+    interface.initialize_data()
+
+    # time loop
+    while interface.is_coupling_ongoing():
+        # write checkpoint
+        if interface.is_action_required(precice.action_write_iteration_checkpoint()):
+            print("Saving macro state")
+            t_checkpoint = t
+            n_checkpoint = n
+            interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
+
+        # Read data from preCICE
+        for name, dim in read_data_names.items():
+            if dim == 0:
+                read_scalar_data = interface.read_block_scalar_data(read_data_ids[name], vertex_ids)
+            elif dim == 1:
+                read_vector_data = interface.read_block_vector_data(read_data_ids[name], vertex_ids)
+
+        # Set the read data as the write data
+        write_scalar_data[:] = read_scalar_data[:]
+        for i in range(nv):
+            for d in range(interface.get_dimensions()):
+                write_vector_data[i, d] = read_vector_data[i, d]
+
+        # Write data to preCICE
+        for name, dim in write_data_names.items():
+            if dim == 0:
+                interface.write_block_scalar_data(write_data_ids[name], vertex_ids, write_scalar_data)
+            elif dim == 1:
+                interface.write_block_vector_data(write_data_ids[name], vertex_ids, write_vector_data)
+
+        # do the coupling
+        dt = interface.advance(dt)
+
+        # advance variables
+        n += 1
+        t += dt
+
+        if interface.is_action_required(precice.action_read_iteration_checkpoint()):
+            print("Reverting to old macro state")
+            t = t_checkpoint
+            n = n_checkpoint
+            interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
+
+    interface.finalize()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/test_adaptivity/macro_solver.py
+++ b/tests/integration/test_adaptivity/macro_solver.py
@@ -14,10 +14,10 @@ def main():
     t = t_checkpoint = 0
 
     # preCICE setup
-    interface = precice.Interface("Macro-dummy", "precice-config.xml", 0, 1)
+    interface = precice.Interface("macro-cube", "precice-config.xml", 0, 1)
 
     # define coupling meshes
-    read_mesh_name = write_mesh_name = "macro-mesh"
+    read_mesh_name = write_mesh_name = "macro-cube-mesh"
     read_mesh_id = interface.get_mesh_id(read_mesh_name)
     read_data_names = {"micro-scalar-data": 0, "micro-vector-data": 1}
 
@@ -25,7 +25,7 @@ def main():
     write_data_names = {"macro-scalar-data": 0, "macro-vector-data": 1}
 
     # Coupling mesh - unit cube with 5 points in each direction
-    np_axis = 5
+    np_axis = 2
     x_coords, y_coords, z_coords = np.meshgrid(
         np.linspace(0, 1, np_axis),
         np.linspace(0, 1, np_axis),

--- a/tests/integration/test_adaptivity/micro-manager-config.json
+++ b/tests/integration/test_adaptivity/micro-manager-config.json
@@ -2,7 +2,7 @@
     "micro_file_name": "micro_solver",
     "coupling_params": {
         "config_file_name": "precice-config.xml",
-        "macro_mesh_name": "macro-mesh",
+        "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },

--- a/tests/integration/test_adaptivity/micro-manager-config.json
+++ b/tests/integration/test_adaptivity/micro-manager-config.json
@@ -1,0 +1,20 @@
+{
+    "micro_file_name": "micro_solver",
+    "coupling_params": {
+        "config_file_name": "precice-config.xml",
+        "macro_mesh_name": "macro-mesh",
+        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+    },
+    "simulation_params": {
+        "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
+        "adaptivity": "True",
+        "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
+        "adaptivity_history_param": 0.5,
+        "adaptivity_coarsening_constant": 0.5,
+        "adaptivity_refining_constant": 0.5
+    },
+    "diagnostics": {
+      "output_micro_sim_solve_time": "True"
+    }
+}

--- a/tests/integration/test_adaptivity/micro-manager-config.json
+++ b/tests/integration/test_adaptivity/micro-manager-config.json
@@ -10,9 +10,9 @@
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
         "adaptivity": "True",
         "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
-        "adaptivity_history_param": 0.1,
+        "adaptivity_history_param": 0.5,
         "adaptivity_coarsening_constant": 0.3,
-        "adaptivity_refining_constant": 0.1
+        "adaptivity_refining_constant": 0.4
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/tests/integration/test_adaptivity/micro-manager-config.json
+++ b/tests/integration/test_adaptivity/micro-manager-config.json
@@ -12,7 +12,7 @@
         "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
         "adaptivity_history_param": 0.5,
         "adaptivity_coarsening_constant": 0.4,
-        "adaptivity_refining_constant": 0.3
+        "adaptivity_refining_constant": 0.2
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/tests/integration/test_adaptivity/micro-manager-config.json
+++ b/tests/integration/test_adaptivity/micro-manager-config.json
@@ -11,8 +11,8 @@
         "adaptivity": "True",
         "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
         "adaptivity_history_param": 0.5,
-        "adaptivity_coarsening_constant": 0.5,
-        "adaptivity_refining_constant": 0.5
+        "adaptivity_coarsening_constant": 0.4,
+        "adaptivity_refining_constant": 0.3
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/tests/integration/test_adaptivity/micro-manager-config.json
+++ b/tests/integration/test_adaptivity/micro-manager-config.json
@@ -11,8 +11,8 @@
         "adaptivity": "True",
         "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
         "adaptivity_history_param": 0.5,
-        "adaptivity_coarsening_constant": 0.4,
-        "adaptivity_refining_constant": 0.2
+        "adaptivity_coarsening_constant": 0.5,
+        "adaptivity_refining_constant": 0.5
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/tests/integration/test_adaptivity/micro-manager-config.json
+++ b/tests/integration/test_adaptivity/micro-manager-config.json
@@ -10,9 +10,9 @@
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
         "adaptivity": "True",
         "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
-        "adaptivity_history_param": 0.5,
-        "adaptivity_coarsening_constant": 0.5,
-        "adaptivity_refining_constant": 0.5
+        "adaptivity_history_param": 0.1,
+        "adaptivity_coarsening_constant": 0.3,
+        "adaptivity_refining_constant": 0.1
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/tests/integration/test_adaptivity/micro_solver.py
+++ b/tests/integration/test_adaptivity/micro_solver.py
@@ -16,13 +16,11 @@ class MicroSimulation:
         self._checkpoint = None
 
     def initialize(self):
-        # print("Initialize micro problem ({})".format(self._sim_id))
         self._micro_scalar_data = 0
         self._micro_vector_data = []
         self._checkpoint = 0
 
     def solve(self, macro_data, dt):
-        # print("Solve timestep of micro problem ({})".format(self._sim_id))
         assert dt != 0
         self._micro_vector_data = macro_data["macro-vector-data"] + 1
         self._micro_scalar_data = macro_data["macro-scalar-data"] + 1
@@ -31,9 +29,7 @@ class MicroSimulation:
                 "micro-vector-data": self._micro_vector_data.copy()}
 
     def save_checkpoint(self):
-        # print("Saving state of micro problem ({})".format(self._sim_id))
         self._checkpoint = self._micro_scalar_data
 
     def reload_checkpoint(self):
-        # print("Reverting to old state of micro problem ({})".format(self._sim_id))
         self._micro_scalar_data = self._checkpoint

--- a/tests/integration/test_adaptivity/micro_solver.py
+++ b/tests/integration/test_adaptivity/micro_solver.py
@@ -25,8 +25,8 @@ class MicroSimulation:
         self._micro_vector_data = macro_data["macro-vector-data"] + 1
         self._micro_scalar_data = macro_data["macro-scalar-data"] + 1
 
-        return {"micro-scalar-data": self._micro_scalar_data.copy(),
-                "micro-vector-data": self._micro_vector_data.copy()}
+        return {"micro-scalar-data": self._micro_scalar_data,
+                "micro-vector-data": self._micro_vector_data}
 
     def save_checkpoint(self):
         self._checkpoint = self._micro_scalar_data

--- a/tests/integration/test_adaptivity/micro_solver.py
+++ b/tests/integration/test_adaptivity/micro_solver.py
@@ -1,0 +1,39 @@
+"""
+Micro simulation
+In this script we solve a dummy micro problem to just show the working of the macro-micro coupling
+"""
+
+
+class MicroSimulation:
+
+    def __init__(self, sim_id):
+        """
+        Constructor of MicroSimulation class.
+        """
+        self._sim_id = sim_id
+        self._micro_scalar_data = None
+        self._micro_vector_data = None
+        self._checkpoint = None
+
+    def initialize(self):
+        # print("Initialize micro problem ({})".format(self._sim_id))
+        self._micro_scalar_data = 0
+        self._micro_vector_data = []
+        self._checkpoint = 0
+
+    def solve(self, macro_data, dt):
+        # print("Solve timestep of micro problem ({})".format(self._sim_id))
+        assert dt != 0
+        self._micro_vector_data = macro_data["macro-vector-data"] + 1
+        self._micro_scalar_data = macro_data["macro-scalar-data"] + 1
+
+        return {"micro-scalar-data": self._micro_scalar_data.copy(),
+                "micro-vector-data": self._micro_vector_data.copy()}
+
+    def save_checkpoint(self):
+        # print("Saving state of micro problem ({})".format(self._sim_id))
+        self._checkpoint = self._micro_scalar_data
+
+    def reload_checkpoint(self):
+        # print("Reverting to old state of micro problem ({})".format(self._sim_id))
+        self._micro_scalar_data = self._checkpoint

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -47,7 +47,7 @@
 
     <coupling-scheme:serial-explicit>
        <participants first="Micro-Manager" second="macro-cube"/>
-       <max-time value="1.0"/>
+       <max-time value="10.0"/>
        <time-window-size value="1.0"/>
        <exchange data="micro-scalar-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>
        <exchange data="micro-vector-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -37,6 +37,7 @@
       <write-data name="micro-scalar-data" mesh="macro-mesh"/>
       <write-data name="micro-vector-data" mesh="macro-mesh"/>
       <write-data name="micro_sim_time" mesh="macro-mesh"/>
+      <write-data name="active_state" mesh="macro-mesh"/>
       <export:vtu directory="output"/>
     </participant>
 

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -47,7 +47,7 @@
 
     <coupling-scheme:serial-explicit>
        <participants first="Micro-Manager" second="macro-cube"/>
-       <max-time value="10.0"/>
+       <max-time value="1.0"/>
        <time-window-size value="1.0"/>
        <exchange data="micro-scalar-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>
        <exchange data="micro-vector-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -47,7 +47,7 @@
 
     <coupling-scheme:serial-explicit>
        <participants first="Micro-Manager" second="macro-cube"/>
-       <max-time value="10.0"/>
+       <max-time value="2.0"/>
        <time-window-size value="1.0"/>
        <exchange data="micro-scalar-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>
        <exchange data="micro-vector-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -13,54 +13,56 @@
     <data:scalar name="micro-scalar-data"/>
     <data:vector name="micro-vector-data"/>
     <data:scalar name="micro_sim_time"/>
+    <data:scalar name="active_state"/>
 
-    <mesh name="macro-mesh">
+    <mesh name="macro-cube-mesh">
        <use-data name="macro-scalar-data"/>
        <use-data name="macro-vector-data"/>
        <use-data name="micro-scalar-data"/>
        <use-data name="micro-vector-data"/>
        <use-data name="micro_sim_time"/>
+       <use-data name="active_state"/>
     </mesh>
 
-    <participant name="Macro-dummy">
-      <use-mesh name="macro-mesh" provide="yes"/>
-      <read-data name="micro-scalar-data" mesh="macro-mesh"/>
-      <read-data name="micro-vector-data" mesh="macro-mesh"/>
-      <write-data name="macro-scalar-data" mesh="macro-mesh"/>
-      <write-data name="macro-vector-data" mesh="macro-mesh"/>
+    <participant name="macro-cube">
+      <use-mesh name="macro-cube-mesh" provide="yes"/>
+      <read-data name="micro-scalar-data" mesh="macro-cube-mesh"/>
+      <read-data name="micro-vector-data" mesh="macro-cube-mesh"/>
+      <write-data name="macro-scalar-data" mesh="macro-cube-mesh"/>
+      <write-data name="macro-vector-data" mesh="macro-cube-mesh"/>
     </participant>
 
     <participant name="Micro-Manager">
-      <use-mesh name="macro-mesh" from="Macro-dummy" direct-access="true" safety-factor="0.0"/>
-      <read-data name="macro-scalar-data" mesh="macro-mesh"/>
-      <read-data name="macro-vector-data" mesh="macro-mesh"/>
-      <write-data name="micro-scalar-data" mesh="macro-mesh"/>
-      <write-data name="micro-vector-data" mesh="macro-mesh"/>
-      <write-data name="micro_sim_time" mesh="macro-mesh"/>
-      <write-data name="active_state" mesh="macro-mesh"/>
+      <use-mesh name="macro-cube-mesh" from="macro-cube" direct-access="true" safety-factor="0.0"/>
+      <read-data name="macro-scalar-data" mesh="macro-cube-mesh"/>
+      <read-data name="macro-vector-data" mesh="macro-cube-mesh"/>
+      <write-data name="micro-scalar-data" mesh="macro-cube-mesh"/>
+      <write-data name="micro-vector-data" mesh="macro-cube-mesh"/>
+      <write-data name="micro_sim_time" mesh="macro-cube-mesh"/>
+      <write-data name="active_state" mesh="macro-cube-mesh"/>
       <export:vtu directory="output"/>
     </participant>
 
-    <m2n:sockets from="Micro-Manager" to="Macro-dummy"/>
+    <m2n:sockets from="Micro-Manager" to="macro-cube"/>
 
     <coupling-scheme:parallel-implicit>
-       <participants first="Macro-dummy" second="Micro-Manager"/>
-       <max-time value="5.0"/>
+       <participants first="macro-cube" second="Micro-Manager"/>
+       <max-time value="1.0"/>
        <time-window-size value="1.0"/>
-       <max-iterations value="30"/>
-       <exchange data="micro-scalar-data" mesh="macro-mesh" from="Micro-Manager" to="Macro-dummy" initialize="yes"/>
-       <exchange data="micro-vector-data" mesh="macro-mesh" from="Micro-Manager" to="Macro-dummy" initialize="yes"/>
-       <exchange data="macro-scalar-data" mesh="macro-mesh" from="Macro-dummy" to="Micro-Manager" initialize="yes"/>
-       <exchange data="macro-vector-data" mesh="macro-mesh" from="Macro-dummy" to="Micro-Manager" initialize="yes"/>
-       <relative-convergence-measure limit="1e-5" data="macro-scalar-data" mesh="macro-mesh"/>
-       <relative-convergence-measure limit="1e-5" data="macro-vector-data" mesh="macro-mesh"/>
-       <relative-convergence-measure limit="1e-5" data="micro-scalar-data" mesh="macro-mesh"/>
-       <relative-convergence-measure limit="1e-5" data="micro-vector-data" mesh="macro-mesh"/>
+       <max-iterations value="1"/>
+       <exchange data="micro-scalar-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube" initialize="yes"/>
+       <exchange data="micro-vector-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube" initialize="yes"/>
+       <exchange data="macro-scalar-data" mesh="macro-cube-mesh" from="macro-cube" to="Micro-Manager" initialize="yes"/>
+       <exchange data="macro-vector-data" mesh="macro-cube-mesh" from="macro-cube" to="Micro-Manager" initialize="yes"/>
+       <relative-convergence-measure limit="1e-5" data="macro-scalar-data" mesh="macro-cube-mesh"/>
+       <relative-convergence-measure limit="1e-5" data="macro-vector-data" mesh="macro-cube-mesh"/>
+       <relative-convergence-measure limit="1e-5" data="micro-scalar-data" mesh="macro-cube-mesh"/>
+       <relative-convergence-measure limit="1e-5" data="micro-vector-data" mesh="macro-cube-mesh"/>
        <acceleration:IQN-ILS>
-          <data name="micro-scalar-data" mesh="macro-mesh"/>
-          <data name="micro-vector-data" mesh="macro-mesh"/>
-          <data name="macro-scalar-data" mesh="macro-mesh"/>
-          <data name="macro-vector-data" mesh="macro-mesh"/>
+          <data name="micro-scalar-data" mesh="macro-cube-mesh"/>
+          <data name="micro-vector-data" mesh="macro-cube-mesh"/>
+          <data name="macro-scalar-data" mesh="macro-cube-mesh"/>
+          <data name="macro-vector-data" mesh="macro-cube-mesh"/>
           <preconditioner type="residual-sum"/>
           <initial-relaxation value="0.9"/>
           <max-used-iterations value="40"/>

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+
+    <log>
+	<sink type="stream" output="stdout"  filter= "%Severity% > debug" enabled="true" />
+    </log>
+  
+  <solver-interface experimental="true" dimensions="3">
+    
+    <data:scalar name="macro-scalar-data"/>
+    <data:vector name="macro-vector-data"/>
+    <data:scalar name="micro-scalar-data"/>
+    <data:vector name="micro-vector-data"/>
+    <data:scalar name="micro_sim_time"/>
+
+    <mesh name="macro-mesh">
+       <use-data name="macro-scalar-data"/>
+       <use-data name="macro-vector-data"/>
+       <use-data name="micro-scalar-data"/>
+       <use-data name="micro-vector-data"/>
+       <use-data name="micro_sim_time"/>
+    </mesh>
+
+    <participant name="Macro-dummy">
+      <use-mesh name="macro-mesh" provide="yes"/>
+      <read-data name="micro-scalar-data" mesh="macro-mesh"/>
+      <read-data name="micro-vector-data" mesh="macro-mesh"/>
+      <write-data name="macro-scalar-data" mesh="macro-mesh"/>
+      <write-data name="macro-vector-data" mesh="macro-mesh"/>
+    </participant>
+
+    <participant name="Micro-Manager">
+      <use-mesh name="macro-mesh" from="Macro-dummy" direct-access="true" safety-factor="0.0"/>
+      <read-data name="macro-scalar-data" mesh="macro-mesh"/>
+      <read-data name="macro-vector-data" mesh="macro-mesh"/>
+      <write-data name="micro-scalar-data" mesh="macro-mesh"/>
+      <write-data name="micro-vector-data" mesh="macro-mesh"/>
+      <write-data name="micro_sim_time" mesh="macro-mesh"/>
+      <export:vtu directory="output"/>
+    </participant>
+
+    <m2n:sockets from="Micro-Manager" to="Macro-dummy"/>
+
+    <coupling-scheme:parallel-implicit>
+       <participants first="Macro-dummy" second="Micro-Manager"/>
+       <max-time value="5.0"/>
+       <time-window-size value="1.0"/>
+       <max-iterations value="30"/>
+       <exchange data="micro-scalar-data" mesh="macro-mesh" from="Micro-Manager" to="Macro-dummy" initialize="yes"/>
+       <exchange data="micro-vector-data" mesh="macro-mesh" from="Micro-Manager" to="Macro-dummy" initialize="yes"/>
+       <exchange data="macro-scalar-data" mesh="macro-mesh" from="Macro-dummy" to="Micro-Manager" initialize="yes"/>
+       <exchange data="macro-vector-data" mesh="macro-mesh" from="Macro-dummy" to="Micro-Manager" initialize="yes"/>
+       <relative-convergence-measure limit="1e-5" data="macro-scalar-data" mesh="macro-mesh"/>
+       <relative-convergence-measure limit="1e-5" data="macro-vector-data" mesh="macro-mesh"/>
+       <relative-convergence-measure limit="1e-5" data="micro-scalar-data" mesh="macro-mesh"/>
+       <relative-convergence-measure limit="1e-5" data="micro-vector-data" mesh="macro-mesh"/>
+       <acceleration:IQN-ILS>
+          <data name="micro-scalar-data" mesh="macro-mesh"/>
+          <data name="micro-vector-data" mesh="macro-mesh"/>
+          <data name="macro-scalar-data" mesh="macro-mesh"/>
+          <data name="macro-vector-data" mesh="macro-mesh"/>
+          <preconditioner type="residual-sum"/>
+          <initial-relaxation value="0.9"/>
+          <max-used-iterations value="40"/>
+          <time-windows-reused value="20"/>
+          <filter type="QR2" limit="1e-2"/>
+       </acceleration:IQN-ILS>
+    </coupling-scheme:parallel-implicit>
+
+  </solver-interface>
+</precice-configuration>

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -45,31 +45,15 @@
 
     <m2n:sockets from="Micro-Manager" to="macro-cube"/>
 
-    <coupling-scheme:parallel-implicit>
-       <participants first="macro-cube" second="Micro-Manager"/>
-       <max-time value="1.0"/>
+    <coupling-scheme:serial-explicit>
+       <participants first="Micro-Manager" second="macro-cube"/>
+       <max-time value="10.0"/>
        <time-window-size value="1.0"/>
-       <max-iterations value="1"/>
-       <exchange data="micro-scalar-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube" initialize="yes"/>
-       <exchange data="micro-vector-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube" initialize="yes"/>
+       <exchange data="micro-scalar-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>
+       <exchange data="micro-vector-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>
        <exchange data="macro-scalar-data" mesh="macro-cube-mesh" from="macro-cube" to="Micro-Manager" initialize="yes"/>
        <exchange data="macro-vector-data" mesh="macro-cube-mesh" from="macro-cube" to="Micro-Manager" initialize="yes"/>
-       <relative-convergence-measure limit="1e-5" data="macro-scalar-data" mesh="macro-cube-mesh"/>
-       <relative-convergence-measure limit="1e-5" data="macro-vector-data" mesh="macro-cube-mesh"/>
-       <relative-convergence-measure limit="1e-5" data="micro-scalar-data" mesh="macro-cube-mesh"/>
-       <relative-convergence-measure limit="1e-5" data="micro-vector-data" mesh="macro-cube-mesh"/>
-       <acceleration:IQN-ILS>
-          <data name="micro-scalar-data" mesh="macro-cube-mesh"/>
-          <data name="micro-vector-data" mesh="macro-cube-mesh"/>
-          <data name="macro-scalar-data" mesh="macro-cube-mesh"/>
-          <data name="macro-vector-data" mesh="macro-cube-mesh"/>
-          <preconditioner type="residual-sum"/>
-          <initial-relaxation value="0.9"/>
-          <max-used-iterations value="40"/>
-          <time-windows-reused value="20"/>
-          <filter type="QR2" limit="1e-2"/>
-       </acceleration:IQN-ILS>
-    </coupling-scheme:parallel-implicit>
+    </coupling-scheme:serial-explicit>
 
   </solver-interface>
 </precice-configuration>

--- a/tests/integration/test_adaptivity/run_micro_manager.py
+++ b/tests/integration/test_adaptivity/run_micro_manager.py
@@ -1,0 +1,11 @@
+"""
+Script to run the Micro Manager
+"""
+
+from micro_manager import MicroManager
+
+manager = MicroManager("./micro-manager-config.json")
+
+manager.initialize()
+
+manager.solve()


### PR DESCRIPTION
This PR adds functionality to allow for adaptive control of micro simulations. In each time step, the manager computes a similarity distance between each pair of micro simulations to determine how similar or dissimilar they are. The active and inactive simulations are then updated using this distance. After all the micro simulations are divided into active and inactive ones, each inactive micro simulation is linked to the most similar active one.

The adaptivity concept is taken from two previous works:

- Redeker, Magnus & Eck, Christof. (2013). A fast and accurate adaptive solution strategy for two-scale models with continuous inter-scale dependencies. Journal of Computational Physics. 240. 268-283. 10.1016/j.jcp.2012.12.025. 
- Bastidas, Manuela & Bringedal, Carina & Pop, Iuliu. (2021). A two-scale iterative scheme for a phase-field model for precipitation and dissolution in porous media. Applied Mathematics and Computation. 396. 125933. 10.1016/j.amc.2020.125933. 