### PR TITLE
Fix bug in adaptivity association step

### DIFF
--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -196,7 +196,7 @@ class AdaptiveController:
             self,
             similarity_dists: np.ndarray,
             micro_sim_states: np.ndarray,
-            micro_sims: list) -> None:
+            micro_sims: list) -> list:
         """
         Associate inactive micro simulations to most similar active micro simulation.
 
@@ -209,6 +209,8 @@ class AdaptiveController:
         micro_sims : list
             List of objects of class MicroProblem, which are the micro simulations
         """
+        _micro_sims = micro_sims.copy()
+
         active_sim_ids = np.where(micro_sim_states == 1)[0]
         inactive_sim_ids = np.where(micro_sim_states == 0)[0]
 
@@ -220,11 +222,13 @@ class AdaptiveController:
                 if similarity_dists[inactive_id, active_id] < dist_min:
                     most_similar_active_id = active_id
                     dist_min = similarity_dists[inactive_id, active_id]
-            micro_sims[inactive_id].is_most_similar_to(most_similar_active_id)
+            _micro_sims[inactive_id].is_most_similar_to(most_similar_active_id)
 
             # Effectively kill the micro sim object associated to the inactive ID
-            micro_sims[inactive_id] = None
+            _micro_sims[inactive_id] = None
 
             # Make a copy of the micro sim object associated to the active ID and add
             # it at the correct location in the list micro_sims
-            micro_sims[inactive_id] = deepcopy(micro_sims[most_similar_active_id])
+            _micro_sims[inactive_id] = deepcopy(micro_sims[most_similar_active_id])
+
+            return _micro_sims

--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -3,6 +3,7 @@ Functionality for adaptive initialization and control of micro simulations
 """
 import numpy as np
 import sys
+from copy import deepcopy
 
 
 class AdaptiveController:
@@ -220,3 +221,10 @@ class AdaptiveController:
                     most_similar_active_id = active_id
                     dist_min = similarity_dists[inactive_id, active_id]
             micro_sims[inactive_id].is_most_similar_to(most_similar_active_id)
+
+            # Effectively kill the micro sim object associated to the inactive ID
+            micro_sims[inactive_id] = None
+
+            # Make a copy of the micro sim object associated to the active ID and add
+            # it at the correct location in the list micro_sims
+            micro_sims[inactive_id] = deepcopy(micro_sims[most_similar_active_id])

--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -222,13 +222,20 @@ class AdaptiveController:
                 if similarity_dists[inactive_id, active_id] < dist_min:
                     most_similar_active_id = active_id
                     dist_min = similarity_dists[inactive_id, active_id]
-            _micro_sims[inactive_id].is_most_similar_to(most_similar_active_id)
 
-            # Effectively kill the micro sim object associated to the inactive ID
-            _micro_sims[inactive_id] = None
+            # Only copy active micro sim object if the inactive sim is associated to a
+            # different active micro sim than in t_{n-1}
+            if most_similar_active_id != _micro_sims[inactive_id].get_most_similar_active_id():
+                # Effectively kill the micro sim object associated to the inactive ID
+                _micro_sims[inactive_id] = None
 
-            # Make a copy of the micro sim object associated to the active ID and add
-            # it at the correct location in the list micro_sims
-            _micro_sims[inactive_id] = deepcopy(micro_sims[most_similar_active_id])
+                # Make a copy of the micro sim object associated to the active ID and add
+                # it at the correct location in the list micro_sims
+                _micro_sims[inactive_id] = deepcopy(micro_sims[most_similar_active_id])
 
-            return _micro_sims
+                # Redo the deactivation and association step because an active sim object
+                # has been copied over, so its properties are still those of an active sim
+                _micro_sims[inactive_id].deactivate()
+                _micro_sims[inactive_id].is_most_similar_to(most_similar_active_id)
+
+        return _micro_sims

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -361,7 +361,7 @@ class MicroManager:
 
     def compute_adaptivity(self, similarity_dists_nm1: np.ndarray, micro_sim_states_nm1: np.ndarray):
         """
-        Compute adaptivity based on similartiy distances and micro simulation states from t_{n-1}
+        Compute adaptivity based on similarity distances and micro simulation states from t_{n-1}
 
         Parameters
         ----------
@@ -391,7 +391,7 @@ class MicroManager:
         micro_sim_states_n = self._adaptivity_controller.update_inactive_micro_sims(
             similarity_dists_n, micro_sim_states_n, self._micro_sims)
 
-        self._adaptivity_controller.associate_inactive_to_active(
+        self._micro_sims = self._adaptivity_controller.associate_inactive_to_active(
             similarity_dists_n, micro_sim_states_n, self._micro_sims)
 
         assert np.any(micro_sim_states_n), "There are no active simulations, which is not possible."

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -50,7 +50,7 @@
 
     <coupling-scheme:serial-explicit>
        <participants first="Micro-Manager" second="macro-cube"/>
-       <max-time value="10.0"/>
+       <max-time value="2.0"/>
        <time-window-size value="1.0"/>
        <exchange data="micro-scalar-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>
        <exchange data="micro-vector-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>

--- a/tests/integration/test_adaptivity/precice-config.xml
+++ b/tests/integration/test_adaptivity/precice-config.xml
@@ -50,7 +50,7 @@
 
     <coupling-scheme:serial-explicit>
        <participants first="Micro-Manager" second="macro-cube"/>
-       <max-time value="2.0"/>
+       <max-time value="5.0"/>
        <time-window-size value="1.0"/>
        <exchange data="micro-scalar-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>
        <exchange data="micro-vector-data" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube"/>


### PR DESCRIPTION
When an inactive micro simulation is associated to an active micro simulation, the micro simulation object of the active simulation needs to copied over to the inactive simulation entry. This was not done before. If this is not done, when the inactive simulation is activated again, it will calculate the state from when it was deactivated, which could have been multiple time steps before.