### PR TITLE
Add test for solverdummy with adaptivity

### DIFF
--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Run adaptive python macro-micro dummy
         run: |
+          cd examples/
           python3 macro_dummy.py & python3 python-dummy/run_micro_manager_adaptivity.py
 
       - name: Run c++ macro-micro dummy
@@ -45,4 +46,5 @@ jobs:
 
       - name: Run adaptive c++ macro-micro dummy
         run: |
+          cd examples/
           python3 macro_dummy.py & python3 cpp-dummy/run_micro_manager_adaptivity.py

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -27,16 +27,19 @@ jobs:
         run: pip3 install --user .
 
       - name: Run python macro-micro dummy
+        timeout-minutes: 3
         run: |
           cd examples/
           python3 python-dummy/run_micro_manager.py & python3 macro_dummy.py
 
       - name: Run adaptive python macro-micro dummy
+        timeout-minutes: 3
         run: |
           cd examples/
           python3 python-dummy/run_micro_manager_adaptivity.py & python3 macro_dummy.py
 
       - name: Run c++ macro-micro dummy
+        timeout-minutes: 3
         run: |
           cd examples/cpp-dummy/
           pip install pybind11
@@ -45,6 +48,7 @@ jobs:
           python3 cpp-dummy/run_micro_manager.py & python3 macro_dummy.py
 
       - name: Run adaptive c++ macro-micro dummy
+        timeout-minutes: 3
         run: |
           cd examples/
           python3 cpp-dummy/run_micro_manager_adaptivity.py & python3 macro_dummy.py

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -12,20 +12,29 @@ jobs:
     runs-on: ubuntu-latest
     container: precice/precice
     steps:
+
       - name: Checkout Repository
         uses: actions/checkout@v2      
+
       - name: Install Dependencies
         run: |
           apt-get -qq update
           apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
+
       - name: Install micro-manager
         run: pip3 install --user .
+
       - name: Run python macro-micro dummy
         run: |
           cd examples/
           python3 macro_dummy.py & python3 python-dummy/run_micro_manager.py
+
+      - name: Run adaptive python macro-micro dummy
+        run: |
+          python3 macro_dummy.py & python3 python-dummy/run_micro_manager_adaptivity.py
+
       - name: Run c++ macro-micro dummy
         run: |
           cd examples/cpp-dummy/
@@ -33,3 +42,7 @@ jobs:
           c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) micro_cpp_dummy.cpp -o micro_dummy$(python3-config --extension-suffix)
           cd ../
           python3 macro_dummy.py & python3 cpp-dummy/run_micro_manager.py
+
+      - name: Run adaptive c++ macro-micro dummy
+        run: |
+          python3 macro_dummy.py & python3 cpp-dummy/run_micro_manager_adaptivity.py

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Run python macro-micro dummy
         run: |
           cd examples/
-          python3 macro_dummy.py & python3 python-dummy/run_micro_manager.py
+          python3 python-dummy/run_micro_manager.py & python3 macro_dummy.py
 
       - name: Run adaptive python macro-micro dummy
         run: |
           cd examples/
-          python3 macro_dummy.py & python3 python-dummy/run_micro_manager_adaptivity.py
+          python3 python-dummy/run_micro_manager_adaptivity.py & python3 macro_dummy.py
 
       - name: Run c++ macro-micro dummy
         run: |
@@ -42,9 +42,9 @@ jobs:
           pip install pybind11
           c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) micro_cpp_dummy.cpp -o micro_dummy$(python3-config --extension-suffix)
           cd ../
-          python3 macro_dummy.py & python3 cpp-dummy/run_micro_manager.py
+          python3 cpp-dummy/run_micro_manager.py & python3 macro_dummy.py
 
       - name: Run adaptive c++ macro-micro dummy
         run: |
           cd examples/
-          python3 macro_dummy.py & python3 cpp-dummy/run_micro_manager_adaptivity.py
+          python3 cpp-dummy/run_micro_manager_adaptivity.py & python3 macro_dummy.py

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) micro_c
 The command above compiles the C++ solverdummy and creates a shared library that can be imported from python using `pybind11`. 
 - The `$(python3 -m pybind11 --includes)` part is necessary to include the correct header files for `pybind11`. 
 - The `$(python3-config --extension-suffix)` part is necessary to create the correct file extension for the shared library. For more information, see the [pybind11 documentation](https://pybind11.readthedocs.io/en/stable/compiling.html#building-manually).
+- If you have multiple versions of Python installed, you might have to replace `python3-config` with `python3.8-config` or similar.
 
 </details>
 
@@ -40,3 +41,7 @@ python cpp-dummy/run_micro_manager.py
 
 When changing the C++ solverdummy to your own solver, make sure to change the `PYBIND11_MODULE` in `micro_cpp_dummy.cpp` to the name that you want to compile to. 
 For example, if you want to import the module as `my_solver`, change the line to `PYBIND11_MODULE(my_solver, m) {`. Then, change the `micro_file_name` in `micro-manager-config.json` to `my_solver`.
+
+### Adaptivity
+
+For the case of adaptivity, the deepcopy function also has to be implemented for the C++ class. An example is provided in the `cpp-dummy` directory.

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -6,7 +6,7 @@
 //
 // c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) micro_cpp_dummy.cpp -o micro_dummy$(python3-config --extension-suffix)
 //
-// To check if python is able to import it, run: 
+// To check if python is able to import it, run:
 // python3 -c "import micro_dummy; micro_dummy.MicroSimulation(1)"
 // from the same directory
 
@@ -69,7 +69,18 @@ void MicroSimulation::reload_checkpoint()
     _micro_scalar_data = _checkpoint;
 }
 
-PYBIND11_MODULE(micro_dummy, m) {
+// For adaptivity only: Need to be able to deepcopy the object
+MicroSimulation MicroSimulation::__deepcopy__(py::dict memo)
+{
+    MicroSimulation new_sim(_sim_id);
+    new_sim._micro_scalar_data = _micro_scalar_data;
+    new_sim._micro_vector_data = _micro_vector_data;
+    new_sim._checkpoint = _checkpoint;
+    return new_sim;
+}
+
+PYBIND11_MODULE(micro_dummy, m)
+{
     // optional docstring
     m.doc() = "pybind11 micro dummy plugin";
 
@@ -78,5 +89,6 @@ PYBIND11_MODULE(micro_dummy, m) {
         .def("initialize", &MicroSimulation::initialize)
         .def("solve", &MicroSimulation::solve)
         .def("save_checkpoint", &MicroSimulation::save_checkpoint)
-        .def("reload_checkpoint", &MicroSimulation::reload_checkpoint);
+        .def("reload_checkpoint", &MicroSimulation::reload_checkpoint)
+        .def("__deepcopy__", &MicroSimulation::__deepcopy__);
 }

--- a/examples/cpp-dummy/micro_cpp_dummy.hpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.hpp
@@ -20,6 +20,7 @@ public:
     py::dict solve(py::dict macro_write_data, double dt);
     void save_checkpoint();
     void reload_checkpoint();
+    MicroSimulation __deepcopy__(py::dict memo);
 
 private:
     int _sim_id;

--- a/examples/cpp-dummy/run_micro_manager_adaptivity.py
+++ b/examples/cpp-dummy/run_micro_manager_adaptivity.py
@@ -1,0 +1,11 @@
+"""
+Script to run the Micro Manager
+"""
+
+from micro_manager import MicroManager
+
+manager = MicroManager("../micro-manager-adaptivity-config.json")
+
+manager.initialize()
+
+manager.solve()

--- a/examples/macro_dummy.py
+++ b/examples/macro_dummy.py
@@ -83,6 +83,10 @@ def main():
         for i in range(nv):
             for d in range(interface.get_dimensions()):
                 write_vector_data[i, d] = read_vector_data[i, d]
+                if t>1: # to trigger adaptivity after some time
+                    # ensure that the data is different from the previous time step
+                    # previously inactive microsimulations will be activated
+                    write_vector_data[i, d] += np.random.randint(0, 10) 
 
         for name, dim in write_data_names.items():
             if dim == 0:

--- a/examples/macro_dummy.py
+++ b/examples/macro_dummy.py
@@ -83,10 +83,10 @@ def main():
         for i in range(nv):
             for d in range(interface.get_dimensions()):
                 write_vector_data[i, d] = read_vector_data[i, d]
-                if t>1: # to trigger adaptivity after some time
+                if t > 1:  # to trigger adaptivity after some time
                     # ensure that the data is different from the previous time step
                     # previously inactive microsimulations will be activated
-                    write_vector_data[i, d] += np.random.randint(0, 10) 
+                    write_vector_data[i, d] += np.random.randint(0, 10)
 
         for name, dim in write_data_names.items():
             if dim == 0:

--- a/examples/micro-manager-adaptivity-config.json
+++ b/examples/micro-manager-adaptivity-config.json
@@ -1,0 +1,21 @@
+{
+    "micro_file_name": "micro_dummy",
+    "coupling_params": {
+        "config_file_name": "./precice-config.xml",
+        "macro_mesh_name": "macro-mesh",
+        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+    },
+    "simulation_params": {
+        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+        "adaptivity": "True",        
+        "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
+        "adaptivity_history_param": 0.5,
+        "adaptivity_coarsening_constant": 0.3,
+        "adaptivity_refining_constant": 0.4,
+        "adaptivity_every_implicit_iteration": "True"
+    },
+    "diagnostics": {
+      "output_micro_sim_solve_time": "True"
+    }
+}

--- a/examples/micro-manager-adaptivity-config.json
+++ b/examples/micro-manager-adaptivity-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "./precice-config.xml",
+        "config_file_name": "./precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/examples/precice-config-adaptivity.xml
+++ b/examples/precice-config-adaptivity.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+
+    <log>
+	<sink type="stream" output="stdout"  filter= "%Severity% > debug" enabled="true" />
+    </log>
+  
+  <solver-interface experimental="true" dimensions="3">
+    
+    <data:scalar name="macro-scalar-data"/>
+    <data:vector name="macro-vector-data"/>
+    <data:scalar name="micro-scalar-data"/>
+    <data:vector name="micro-vector-data"/>
+    <data:scalar name="micro_sim_time"/>
+    <data:scalar name="active_state"/>
+    <data:scalar name="active_steps"/>
+
+    <mesh name="macro-mesh">
+       <use-data name="macro-scalar-data"/>
+       <use-data name="macro-vector-data"/>
+       <use-data name="micro-scalar-data"/>
+       <use-data name="micro-vector-data"/>
+       <use-data name="micro_sim_time"/>
+       <use-data name="active_state"/>
+       <use-data name="active_steps"/>
+    </mesh>
+
+    <participant name="Macro-dummy">
+      <use-mesh name="macro-mesh" provide="yes"/>
+      <read-data name="micro-scalar-data" mesh="macro-mesh"/>
+      <read-data name="micro-vector-data" mesh="macro-mesh"/>
+      <write-data name="macro-scalar-data" mesh="macro-mesh"/>
+      <write-data name="macro-vector-data" mesh="macro-mesh"/>
+    </participant>
+
+    <participant name="Micro-Manager">
+      <use-mesh name="macro-mesh" from="Macro-dummy" direct-access="true" safety-factor="0.0"/>
+      <read-data name="macro-scalar-data" mesh="macro-mesh"/>
+      <read-data name="macro-vector-data" mesh="macro-mesh"/>
+      <write-data name="micro-scalar-data" mesh="macro-mesh"/>
+      <write-data name="micro-vector-data" mesh="macro-mesh"/>
+      <write-data name="micro_sim_time" mesh="macro-mesh"/>
+      <write-data name="active_state" mesh="macro-mesh"/>
+      <write-data name="active_steps" mesh="macro-mesh"/>
+    </participant>
+
+    <m2n:sockets from="Micro-Manager" to="Macro-dummy"/>
+
+    <coupling-scheme:serial-implicit>
+       <participants first="Macro-dummy" second="Micro-Manager"/>
+       <max-time value="3.0"/>
+       <time-window-size value="1.0"/>
+       <max-iterations value="5"/>
+       <exchange data="micro-scalar-data" mesh="macro-mesh" from="Micro-Manager" to="Macro-dummy" initialize="yes"/>
+       <exchange data="micro-vector-data" mesh="macro-mesh" from="Micro-Manager" to="Macro-dummy" initialize="yes"/>
+       <exchange data="macro-scalar-data" mesh="macro-mesh" from="Macro-dummy" to="Micro-Manager"/>
+       <exchange data="macro-vector-data" mesh="macro-mesh" from="Macro-dummy" to="Micro-Manager"/>
+       <relative-convergence-measure limit="1e-5" data="macro-scalar-data" mesh="macro-mesh"/>
+       <relative-convergence-measure limit="1e-5" data="micro-scalar-data" mesh="macro-mesh"/>
+    </coupling-scheme:serial-implicit>
+
+  </solver-interface>
+</precice-configuration>

--- a/examples/python-dummy/run_micro_manager_adaptivity.py
+++ b/examples/python-dummy/run_micro_manager_adaptivity.py
@@ -1,0 +1,11 @@
+"""
+Script to run the Micro Manager
+"""
+
+from micro_manager import MicroManager
+
+manager = MicroManager("../micro-manager-adaptivity-config.json")
+
+manager.initialize()
+
+manager.solve()


### PR DESCRIPTION
Closes #28 
This PR adds tests for the solverdummies in python and c++ with adaptivity.
At the moment, there is a new `precice-config-adaptivity.xml`, `micro-manager-adaptivity-config.json` and `run_micro_manager_adaptivity.py`. I would prefer a different way that does not add so many new files to the solverdummies as they should be easy to navigate.

This PR also adds a `__deepcopy__()` function to the c++ solverdummies which is required for [deepcopy support](https://pybind11.readthedocs.io/en/latest/advanced/classes.html#deepcopy-support) of pybind11 classes.