### PR TITLE
Add pickling support to C++ solver dummy

### DIFF
--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -69,6 +69,19 @@ void MicroSimulation::reload_checkpoint()
     _micro_scalar_data = _checkpoint;
 }
 
+// This function is not relevant for the Micro Manager but is important for serialization of the micro simulation object
+void MicroSimulation::setState(double micro_scalar_data, double checkpoint)
+{
+    _micro_scalar_data = micro_scalar_data;
+    _checkpoint = checkpoint;
+}
+
+std::tuple<double, double> MicroSimulation::getState()
+{
+    return {_sim_id, _micro_scalar_data, _checkpoint};
+}
+
+
 PYBIND11_MODULE(micro_dummy, m) {
     // optional docstring
     m.doc() = "pybind11 micro dummy plugin";
@@ -78,5 +91,22 @@ PYBIND11_MODULE(micro_dummy, m) {
         .def("initialize", &MicroSimulation::initialize)
         .def("solve", &MicroSimulation::solve)
         .def("save_checkpoint", &MicroSimulation::save_checkpoint)
-        .def("reload_checkpoint", &MicroSimulation::reload_checkpoint);
+        .def("reload_checkpoint", &MicroSimulation::reload_checkpoint)
+        .def(py::pickle(
+            [](const MicroSimulation &ms) { // __getstate__
+                /* Return a tuple that fully encodes the state of the object */
+                return py::make_tuple(ms.getState());
+            },
+            [](py::tuple t) { // __setstate__
+                if (t.size() != 3)
+                    throw std::runtime_error("Invalid state!");
+                
+                /* Create a new C++ instance */
+                MicroSimulation ms(t[0]);
+
+                ms.setState(t[1].cast<double>(), t[2].cast<double>());
+
+                return ms;
+            }
+        ));
 }

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -69,14 +69,16 @@ void MicroSimulation::reload_checkpoint()
     _micro_scalar_data = _checkpoint;
 }
 
-// This function is not relevant for the Micro Manager but is important for serialization of the micro simulation object
+// This function needs to set the complete state of a micro simulation
 void MicroSimulation::setState(double micro_scalar_data, double checkpoint)
 {
     _micro_scalar_data = micro_scalar_data;
     _checkpoint = checkpoint;
 }
 
-std::tuple<double, double> MicroSimulation::getState()
+
+// This function needs to return variables which can fully define the state of a micro simulation
+std::tuple<double, double, double> MicroSimulation::getState() const
 {
     return {_sim_id, _micro_scalar_data, _checkpoint};
 }
@@ -102,7 +104,7 @@ PYBIND11_MODULE(micro_dummy, m) {
                     throw std::runtime_error("Invalid state!");
                 
                 /* Create a new C++ instance */
-                MicroSimulation ms(t[0]);
+                MicroSimulation ms(t[0].cast<double>());
 
                 ms.setState(t[1].cast<double>(), t[2].cast<double>());
 

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -78,7 +78,10 @@ void MicroSimulation::setState(double micro_scalar_data, double checkpoint)
 
 
 // This function needs to return variables which can fully define the state of a micro simulation
-std::tuple<double, double, double> MicroSimulation::getState() const
+py::tuple MicroSimulation::getState() const
+{
+    return py::make_tuple(_sim_id, _micro_scalar_data, _checkpoint);
+}
 {
     return {_sim_id, _micro_scalar_data, _checkpoint};
 }

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -76,16 +76,11 @@ void MicroSimulation::setState(double micro_scalar_data, double checkpoint)
     _checkpoint = checkpoint;
 }
 
-
 // This function needs to return variables which can fully define the state of a micro simulation
 py::tuple MicroSimulation::getState() const
 {
     return py::make_tuple(_sim_id, _micro_scalar_data, _checkpoint);
 }
-{
-    return {_sim_id, _micro_scalar_data, _checkpoint};
-}
-
 
 PYBIND11_MODULE(micro_dummy, m) {
     // optional docstring

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -95,7 +95,7 @@ PYBIND11_MODULE(micro_dummy, m) {
         .def(py::pickle(
             [](const MicroSimulation &ms) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                return py::make_tuple(ms.getState());
+                return ms.getState();
             },
             [](py::tuple t) { // __setstate__
                 if (t.size() != 3)

--- a/examples/cpp-dummy/micro_cpp_dummy.hpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.hpp
@@ -22,7 +22,7 @@ public:
     void reload_checkpoint();
 
     void setState(double micro_scalar_data, double checkpoint);
-    std::tuple<double, double> getState();
+    std::tuple<double, double, double> getState() const;
 
 private:
     int _sim_id;

--- a/examples/cpp-dummy/micro_cpp_dummy.hpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.hpp
@@ -21,6 +21,9 @@ public:
     void save_checkpoint();
     void reload_checkpoint();
 
+    void setState(double micro_scalar_data, double checkpoint);
+    std::tuple<double, double> getState();
+
 private:
     int _sim_id;
     double _micro_scalar_data;

--- a/examples/cpp-dummy/micro_cpp_dummy.hpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.hpp
@@ -22,7 +22,7 @@ public:
     void reload_checkpoint();
 
     void setState(double micro_scalar_data, double checkpoint);
-    std::tuple<double, double, double> getState() const;
+    py::tuple<double, double, double> getState() const;
 
 private:
     int _sim_id;

--- a/examples/cpp-dummy/micro_cpp_dummy.hpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.hpp
@@ -22,7 +22,7 @@ public:
     void reload_checkpoint();
 
     void setState(double micro_scalar_data, double checkpoint);
-    py::tuple<double, double, double> getState() const;
+    py::tuple getState() const;
 
 private:
     int _sim_id;


### PR DESCRIPTION
This PR adds functionality to allow for pickling and unpickling of the C++ micro simulation code in the C++ solver dummy. This is based on the [pickling support documentation of pybind11](https://pybind11.readthedocs.io/en/latest/advanced/classes.html#pickling-support).