### PR TITLE
Resolve bug in copy operation when inactive simulation is activated

### DIFF
--- a/micro_manager/adaptivity.py
+++ b/micro_manager/adaptivity.py
@@ -161,11 +161,17 @@ class AdaptiveController:
                 if self._check_for_activation(i, similarity_dists, _micro_sim_states):
                     associated_active_id = micro_sims[i].get_associated_active_id()
 
+                    # Get local and global ID of inactive simulation, to set it to the copied simulation later
+                    local_id = micro_sims[i].get_local_id()
+                    global_id = micro_sims[i].get_global_id()
+
                     # Effectively kill the micro sim object associated to the inactive ID
                     micro_sims[i] = None
 
                     # Make a copy of the associated active micro sim object
                     micro_sims[i] = deepcopy(micro_sims[associated_active_id])
+                    micro_sims[i].set_local_id(local_id)
+                    micro_sims[i].set_global_id(global_id)
                     _micro_sim_states[i] = 1
 
         return _micro_sim_states

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -47,6 +47,12 @@ def create_micro_problem_class(base_micro_simulation):
         def get_global_id(self):
             return self._global_id
 
+        def set_local_id(self, local_id):
+            self._local_id = local_id
+
+        def set_global_id(self, global_id):
+            self._global_id = global_id
+
         def activate(self):
             self._is_active = True
 


### PR DESCRIPTION
This PR sets local and global ID of copied active simulation to the original IDs of the previously inactive simulation. If we do not do this, the newly activated micro simulation will have the same local and global ID as the active simulation which it was copied from.

First stopped via https://github.com/precice/micro-manager/pull/29#issuecomment-1508148493