### PR TITLE
Change branches to run tests on push

### DIFF
--- a/.github/workflows/check-pep8.yml
+++ b/.github/workflows/check-pep8.yml
@@ -2,7 +2,8 @@ name: autopep8
 on:
   push:
     branches:
-      - "*"
+      - main
+      - develop
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/run-adaptivity-test.yml
+++ b/.github/workflows/run-adaptivity-test.yml
@@ -2,8 +2,8 @@ name: Run tests for adaptivity
 on:
   push:
     branches:
-      - "main"
-      - "develop"
+      - main
+      - develop
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/run-adaptivity-test.yml
+++ b/.github/workflows/run-adaptivity-test.yml
@@ -2,7 +2,8 @@ name: Run tests for adaptivity
 on:
   push:
     branches:
-      - "*"
+      - "main"
+      - "develop"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -2,7 +2,8 @@ name: Run macro-micro dummy case
 on:
   push:
     branches:
-      - "*"
+      - "main"
+      - "develop"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -2,8 +2,8 @@ name: Run macro-micro dummy case
 on:
   push:
     branches:
-      - "main"
-      - "develop"
+      - main
+      - develop
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
This PR changes on which branches the tests are being run. When its `"*"` the tests are run twice for each PR. Therefore only testing on each push for `develop` and `main` is preferred.
The changed is discussed in #37