### PR TITLE
Add update-website workflow

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,22 @@
+name: Update website
+on:
+  push:
+    branches:
+      - 'develop'
+    paths:
+      - 'docs/**'
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    env:
+      WORKFLOW_FILENAME: update-submodules.yml
+    steps:
+    - name: Trigger workflow
+      run: |
+        curl \
+        --request POST \
+        --url https://api.github.com/repos/precice/precice.github.io/actions/workflows/$WORKFLOW_FILENAME/dispatches \
+        --header "authorization: token ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}" \
+        --header "Accept: application/vnd.github.v3+json" \
+        --data '{"ref":"master"}' \
+        --fail


### PR DESCRIPTION
As discussed in https://github.com/precice/precice.github.io/pull/270#issuecomment-1564091378, this PR adds a workflow that updates the preCICE website any time the documentation is updated.
The action is copied from the [openfoam adapter](https://github.com/precice/openfoam-adapter/blob/develop/.github/workflows/update-website.yml)