### PR TITLE
Move to a relative path configuration

### DIFF
--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Run python macro-micro dummy
         timeout-minutes: 3
         working-directory: micro-manager/examples
-        run: python3 python-dummy/run_micro_manager.py --config ../micro-manager-config.json & python3 macro_dummy.py
+        run: python3 python-dummy/run_micro_manager.py --config ./micro-manager-config.json & python3 macro_dummy.py
 
       - name: Run adaptive python macro-micro dummy
         timeout-minutes: 3
         working-directory: micro-manager/examples
-        run: python3 python-dummy/run_micro_manager.py --config ../micro-manager-adaptivity-config.json & python3 macro_dummy.py
+        run: python3 python-dummy/run_micro_manager.py --config ./micro-manager-adaptivity-config.json & python3 macro_dummy.py
 
       - name: Run c++ macro-micro dummy
         timeout-minutes: 3
@@ -50,9 +50,9 @@ jobs:
           pip install pybind11
           c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) micro_cpp_dummy.cpp -o micro_dummy$(python3-config --extension-suffix)
           cd ../
-          python3 cpp-dummy/run_micro_manager.py --config ../micro-manager-config.json & python3 macro_dummy.py
+          python3 cpp-dummy/run_micro_manager.py --config ./micro-manager-config.json & python3 macro_dummy.py
 
       - name: Run adaptive c++ macro-micro dummy
         timeout-minutes: 3
         working-directory: micro-manager/examples
-        run: python3 cpp-dummy/run_micro_manager.py --config ../micro-manager-adaptivity-config.json & python3 macro_dummy.py
+        run: python3 cpp-dummy/run_micro_manager.py --config ./micro-manager-adaptivity-config.json & python3 macro_dummy.py

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Run python macro-micro dummy
         timeout-minutes: 3
         working-directory: micro-manager/examples
-        run: python3 python-dummy/run_micro_manager.py --config ./micro-manager-config.json & python3 macro_dummy.py
+        run: python3 python-dummy/run_micro_manager.py --config micro-manager-config.json & python3 macro_dummy.py
 
       - name: Run adaptive python macro-micro dummy
         timeout-minutes: 3
         working-directory: micro-manager/examples
-        run: python3 python-dummy/run_micro_manager.py --config ./micro-manager-adaptivity-config.json & python3 macro_dummy.py
+        run: python3 python-dummy/run_micro_manager.py --config micro-manager-adaptivity-config.json & python3 macro_dummy.py
 
       - name: Run c++ macro-micro dummy
         timeout-minutes: 3
@@ -50,9 +50,9 @@ jobs:
           pip install pybind11
           c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) micro_cpp_dummy.cpp -o micro_dummy$(python3-config --extension-suffix)
           cd ../
-          python3 cpp-dummy/run_micro_manager.py --config ./micro-manager-config.json & python3 macro_dummy.py
+          python3 cpp-dummy/run_micro_manager.py --config micro-manager-config.json & python3 macro_dummy.py
 
       - name: Run adaptive c++ macro-micro dummy
         timeout-minutes: 3
         working-directory: micro-manager/examples
-        run: python3 cpp-dummy/run_micro_manager.py --config ./micro-manager-adaptivity-config.json & python3 macro_dummy.py
+        run: python3 cpp-dummy/run_micro_manager.py --config micro-manager-adaptivity-config.json & python3 macro_dummy.py

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,13 +27,13 @@ The Micro Manager is configured at runtime using a JSON file. An example configu
 
 There are three main sections in the configuration file, the `coupling_params`, the `simulation_params` and the optional `diagnostics`.
 
-The file containing the Python importable micro simulation class is specified in the `micro_file_name` parameter.
+The path to the file containing the Python importable micro simulation class is specified in the `micro_file_name` parameter relative to the current working directory.
 
 ## Coupling Parameters
 
 Parameter | Description
 --- | ---
-`config_file_name` |  Path to the preCICE XML configuration file.
+`config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
 `macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
 `read_data_names` |  A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
 `write_data_names` |  A Python dictionary with the names of the data to be written to preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ The Micro Manager is configured at runtime using a JSON file. An example configu
 
 There are three main sections in the configuration file, the `coupling_params`, the `simulation_params` and the optional `diagnostics`.
 
-The path to the file containing the Python importable micro simulation class is specified in the `micro_file_name` parameter relative to the current working directory.
+The path to the file containing the Python importable micro simulation class is specified in the `micro_file_name` parameter. If the file is not in the working directory, give the relative path.
 
 ## Coupling Parameters
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -5,7 +5,7 @@ keywords: tooling, macro-micro, two-scale
 summary: Run the Micro Manager from the terminal with a configuration file as input argument or from a Python script.
 ---
 
-The Micro Manager is run directly from the terminal by providing the configuration file as an input argument in the following way
+The Micro Manager is run directly from the terminal by providing the path to the configuration file as an input argument in the following way
 
 ```bash
 micro_manager micro-manager-config.json

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,8 @@ python macro-dummy.py
 python python-dummy/run_micro_manager.py
 ```
 
+Note that running `micro_manager micro-manager-config.json` from the terminal will not work, as the path in the configuration file is relative to the current working directory. See [#36](https://github.com/precice/micro-manager/issues/36) for more information.
+
 ## C++
 The C++ solverdummies have to be compiled first using [`pybind11`](https://pybind11.readthedocs.io/en/stable/index.html). To do so, install `pybind11` using `pip`:
 
@@ -25,7 +27,7 @@ c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) micro_c
 <details>
 <summary>Explanation</summary>
 
-The command above compiles the C++ solverdummy and creates a shared library that can be imported from python using `pybind11`. 
+The command above compiles the C++ solverdummy and creates a shared library that can be imported from python using `pybind11`.
 - The `$(python3 -m pybind11 --includes)` part is necessary to include the correct header files for `pybind11`. 
 - The `$(python3-config --extension-suffix)` part is necessary to create the correct file extension for the shared library. For more information, see the [pybind11 documentation](https://pybind11.readthedocs.io/en/stable/compiling.html#building-manually).
 - If you have multiple versions of Python installed, you might have to replace `python3-config` with `python3.8-config` or similar.
@@ -39,7 +41,7 @@ python macro_dummy.py
 python cpp-dummy/run_micro_manager.py
 ```
 
-When changing the C++ solverdummy to your own solver, make sure to change the `PYBIND11_MODULE` in `micro_cpp_dummy.cpp` to the name that you want to compile to. 
+When changing the C++ solverdummy to your own solver, make sure to change the `PYBIND11_MODULE` in `micro_cpp_dummy.cpp` to the name that you want to compile to.
 For example, if you want to import the module as `my_solver`, change the line to `PYBIND11_MODULE(my_solver, m) {`. Then, change the `micro_file_name` in `micro-manager-config.json` to `my_solver`.
 
 ### Adaptivity

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -55,7 +55,7 @@ class Config:
         config_filename : string
             Name of the JSON configuration file
         """
-        folder = os.path.dirname(os.path.join(os.getcwd(), os.path.dirname(sys.argv[0]), config_filename))
+        folder = os.path.dirname(os.path.join(os.getcwd(), config_filename))
         path = os.path.join(folder, os.path.basename(config_filename))
         with open(path, "r") as read_file:
             data = json.load(read_file)


### PR DESCRIPTION
Closes #36

This PR removes `os.path.dirname(sys.argv[0])` as part of the folder path, moving from a absolute to a relative path in the micro-manager configuration.