### PR TITLE
Create sub-heading adaptivity under simulation_params to shorten config variable names

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,23 +71,24 @@ For a 2D domain, only two values need to be set `axiswise_ranks`.
 
 ## Adaptivity
 
+{% note %} This feature is optional. {% endnote %}
+
 The Micro Manager can adaptively control micro simulations. The adaptivity strategy is taken from
 
 1. Redeker, Magnus & Eck, Christof. (2013). A fast and accurate adaptive solution strategy for two-scale models with continuous inter-scale dependencies. Journal of Computational Physics. 240. 268-283. [10.1016/j.jcp.2012.12.025](https://doi.org/10.1016/j.jcp.2012.12.025).
 
 2. Bastidas, Manuela & Bringedal, Carina & Pop, Iuliu. (2021). A two-scale iterative scheme for a phase-field model for precipitation and dissolution in porous media. Applied Mathematics and Computation. 396. 125933. [10.1016/j.amc.2020.125933](https://doi.org/10.1016/j.amc.2020.125933).
 
-To turn on adaptivity, the following options need to be set in `simulation_params`:
+To turn on adaptivity, the following options need to be set in `simulation_params` under the sub-heading `adaptivity`:
 
 Parameter | Description
 --- | ---
-`adaptivity` | Set as `True` to turn on adaptivity (`False` by default).
-`adaptivity_type` | Set to either `local` or `global`. The type of adaptivity matters when the Micro Manager is run in parallel. `local` means comparing micro simulations within a local partitioned domain for similarity. `global` means comparing micro simulations from all partitions, so over the entire domain.
-`adaptivity_data` | List of names of data which are to be used to calculate if micro-simulations are similar or not. For example `["temperature", "porosity"]`.
-`adaptivity_history_param` | History parameter $$ \Lambda $$, set as $$ \Lambda >= 0 $$.
-`adaptivity_coarsening_constant` | Coarsening constant $$ C_c $$, set as $$ C_c < 1 $$.
-`adaptivity_refining_constant` | Refining constant $$ C_r $$, set as $$ C_r >= 0 $$.
-`adaptivity_every_implicit_iteration` | If True, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.
+`type` | Set to either `local` or `global`. The type of adaptivity matters when the Micro Manager is run in parallel. `local` means comparing micro simulations within a local partitioned domain for similarity. `global` means comparing micro simulations from all partitions, so over the entire domain.
+`data` | List of names of data which are to be used to calculate if micro-simulations are similar or not. For example `["temperature", "porosity"]`.
+`history_param` | History parameter $$ \Lambda $$, set as $$ \Lambda >= 0 $$.
+`coarsening_constant` | Coarsening constant $$ C_c $$, set as $$ C_c < 1 $$.
+`refining_constant` | Refining constant $$ C_r $$, set as $$ C_r >= 0 $$.
+`<every_implicit_iteration` | If True, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.
 
 All variables are chosen from the [second publication](https://doi.org/10.1016/j.amc.2020.125933) mentioned above.
 
@@ -96,13 +97,14 @@ Example of adaptivity configuration
 ```json
 "simulation_params": {
     "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-    "adaptivity": "True",
-    "adaptivity_type": "local",
-    "adaptivity_data": ["temperature", "porosity"],
-    "adaptivity_history_param": 0.5,
-    "adaptivity_coarsening_constant": 0.3,
-    "adaptivity_refining_constant": 0.4,
-    "adaptivity_every_implicit_iteration": "True"
+    "adaptivity" {
+        "type": "local",
+        "data": ["temperature", "porosity"],
+        "history_param": 0.5,
+        "coarsening_constant": 0.3,
+        "refining_constant": 0.4,
+        "every_implicit_iteration": "True"
+    }
 }
 ```
 

--- a/examples/micro-manager-adaptivity-config.json
+++ b/examples/micro-manager-adaptivity-config.json
@@ -8,13 +8,14 @@
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "adaptivity": "True",
-        "adaptivity_type": "local",
-        "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
-        "adaptivity_history_param": 0.5,
-        "adaptivity_coarsening_constant": 0.3,
-        "adaptivity_refining_constant": 0.4,
-        "adaptivity_every_implicit_iteration": "True"
+        "adaptivity": {
+            "type": "local",
+            "data": ["macro-scalar-data", "macro-vector-data"],
+            "history_param": 0.5,
+            "coarsening_constant": 0.3,
+            "refining_constant": 0.4,
+            "every_implicit_iteration": "True"
+        }
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/examples/micro-manager-config.json
+++ b/examples/micro-manager-config.json
@@ -7,8 +7,7 @@
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "adaptivity": "False"
+        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -100,31 +100,29 @@ class Config:
             print("Domain decomposition is not specified, so the Micro Manager will expect to be run in serial.")
 
         try:
-            if data["simulation_params"]["adaptivity"] == "True":
+            if data["simulation_params"]["adaptivity"]:
                 self._adaptivity = True
-            elif data["simulation_params"]["adaptivity"] == "False":
-                self._adaptivity = False
             else:
-                raise Exception("Adaptivity can be either True or False.")
+                self._adaptivity = False
         except BaseException:
             print("Micro Manager will not adaptively run micro simulations, but instead will run all micro simulations in all time steps.")
 
         if self._adaptivity:
-            if data["simulation_params"]["adaptivity_type"] == "local":
+            if data["simulation_params"]["adaptivity"]["type"] == "local":
                 self._adaptivity_type = "local"
-            elif data["simulation_params"]["adaptivity_type"] == "global":
+            elif data["simulation_params"]["adaptivity"]["type"] == "global":
                 self._adaptivity_type = "global"
             else:
                 raise Exception("Adaptivity type can be either local or global.")
 
             exchange_data = {**self._read_data_names, **self._write_data_names}
-            for dname in data["simulation_params"]["adaptivity_data"]:
+            for dname in data["simulation_params"]["adaptivity"]["data"]:
                 self._data_for_adaptivity[dname] = exchange_data[dname]
 
-            self._adaptivity_history_param = data["simulation_params"]["adaptivity_history_param"]
-            self._adaptivity_coarsening_constant = data["simulation_params"]["adaptivity_coarsening_constant"]
-            self._adaptivity_refining_constant = data["simulation_params"]["adaptivity_refining_constant"]
-            adaptivity_every_implicit_iteration = data["simulation_params"]["adaptivity_every_implicit_iteration"]
+            self._adaptivity_history_param = data["simulation_params"]["adaptivity"]["history_param"]
+            self._adaptivity_coarsening_constant = data["simulation_params"]["adaptivity"]["coarsening_constant"]
+            self._adaptivity_refining_constant = data["simulation_params"]["adaptivity"]["refining_constant"]
+            adaptivity_every_implicit_iteration = data["simulation_params"]["adaptivity"]["every_implicit_iteration"]
 
             if adaptivity_every_implicit_iteration == "True":
                 self._adaptivity_every_implicit_iteration = True

--- a/tests/integration/test_unit_cube_dummy/micro-manager-config-adaptivity.json
+++ b/tests/integration/test_unit_cube_dummy/micro-manager-config-adaptivity.json
@@ -8,13 +8,14 @@
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-        "adaptivity": "True",
-        "adaptivity_type": "local",
-        "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
-        "adaptivity_history_param": 0.5,
-        "adaptivity_coarsening_constant": 0.3,
-        "adaptivity_refining_constant": 0.4,
-        "adaptivity_every_implicit_iteration": "True"
+        "adaptivity": {
+            "type": "local",
+            "data": ["macro-scalar-data", "macro-vector-data"],
+            "history_param": 0.5,
+            "coarsening_constant": 0.3,
+            "refining_constant": 0.4,
+            "every_implicit_iteration": "True"
+        }
     },
     "diagnostics": {
       "output_micro_sim_solve_time": "True"

--- a/tests/integration/test_unit_cube_dummy/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube_dummy/micro-manager-config-parallel-1.json
@@ -8,8 +8,7 @@
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-	    "axiswise_ranks": [1, 1, 2],
-	    "adaptivity": "False"
+	    "axiswise_ranks": [1, 1, 2]
     },
     "diagnostics": {
         "output_micro_sim_solve_time": "True"

--- a/tests/integration/test_unit_cube_dummy/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube_dummy/micro-manager-config-parallel-2.json
@@ -8,8 +8,7 @@
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-	    "axiswise_ranks": [1, 2, 3],
-	    "adaptivity": "False"
+	    "axiswise_ranks": [1, 2, 3]
     },
     "diagnostics": {
         "output_micro_sim_solve_time": "True"

--- a/tests/unit/micro-manager-unit-test-adaptivity-config.json
+++ b/tests/unit/micro-manager-unit-test-adaptivity-config.json
@@ -8,12 +8,13 @@
     },
     "simulation_params": {
         "macro_domain_bounds": [],
-        "adaptivity": "True",
-        "adaptivity_type": "local",
-        "adaptivity_data": [],
-        "adaptivity_history_param": 0.5,
-        "adaptivity_coarsening_constant": 0.3,
-        "adaptivity_refining_constant": 0.4,
-        "adaptivity_every_implicit_iteration": "False"
+        "adaptivity": {
+            "type": "local",
+            "data": [],
+            "history_param": 0.5,
+            "coarsening_constant": 0.3,
+            "refining_constant": 0.4,
+            "every_implicit_iteration": "False"
+        }
     }
 }

--- a/tests/unit/micro-manager-unit-test-adaptivity-config.json
+++ b/tests/unit/micro-manager-unit-test-adaptivity-config.json
@@ -15,7 +15,7 @@
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
             "every_implicit_iteration": "False",
-            "_similarity_measure": "L1"
+            "similarity_measure": "L1"
         }
     }
 }

--- a/tests/unit/micro-manager-unit-test-config.json
+++ b/tests/unit/micro-manager-unit-test-config.json
@@ -8,13 +8,14 @@
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "adaptivity": "True",
-        "adaptivity_type": "local",
-        "adaptivity_data": ["macro-scalar-data", "macro-vector-data"],
-        "adaptivity_history_param": 0.5,
-        "adaptivity_coarsening_constant": 0.3,
-        "adaptivity_refining_constant": 0.4,
-        "adaptivity_every_implicit_iteration": "False"
+        "adaptivity": {
+            "type": "local",
+            "data": ["macro-scalar-data", "macro-vector-data"],
+            "history_param": 0.5,
+            "coarsening_constant": 0.3,
+            "refining_constant": 0.4,
+            "every_implicit_iteration": "False"
+        }
     },
     "diagnostics": {
       "micro_output_n": 10,


### PR DESCRIPTION
As stated in the title of the PR.