### PR TITLE
Pass global IDs to micro simulations to make them unique

### DIFF
--- a/docs/micro-simulation-convert-to-library.md
+++ b/docs/micro-simulation-convert-to-library.md
@@ -14,9 +14,14 @@ Restructure your micro simulation code into a Python class with the structure gi
 
 ```python
 class MicroSimulation: # Name is fixed
-    def __init__(self):
+    def __init__(self, sim_id):
         """
         Constructor of class MicroSimulation.
+
+        Parameters
+        ----------
+        sim_id : int
+            ID of the simulation instance, that the Micro Manager has set for it.
         """
 
     def solve(self, macro_data: dict, dt: float) -> dict:

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -13,7 +13,7 @@
 #include "micro_cpp_dummy.hpp"
 
 // Constructor
-MicroSimulation::MicroSimulation() : _micro_scalar_data(0), _state(0) {}
+MicroSimulation::MicroSimulation(int sim_id) : _sim_id(sim_id), _micro_scalar_data(0), _state(0) {}
 
 // Solve
 py::dict MicroSimulation::solve(py::dict macro_data, double dt)

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -47,14 +47,15 @@ py::dict MicroSimulation::solve(py::dict macro_data, double dt)
 // This function needs to set the complete state of a micro simulation
 void MicroSimulation::set_state(py::list state)
 {
-    _micro_scalar_data = state[0].cast<double>();
-    _state = state[1].cast<double>();
+    _sim_id = state[0].cast<int>()
+    _micro_scalar_data = state[1].cast<double>();
+    _state = state[2].cast<double>();
 }
 
 // This function needs to return variables which can fully define the state of a micro simulation
 py::list MicroSimulation::get_state() const
 {
-    std::vector<double> state{_micro_scalar_data, _state};
+    std::vector<double> state{_sim_id, _micro_scalar_data, _state};
     py::list state_python = py::cast(state);
     return state_python;
 }
@@ -73,11 +74,11 @@ PYBIND11_MODULE(micro_dummy, m) {
                 return ms.get_state();
             },
             [](py::list t) { // __setstate__
-                if (t.size() != 2)
+                if (t.size() != 3)
                     throw std::runtime_error("Invalid state!");
 
                 /* Create a new C++ instance */
-                MicroSimulation ms;
+                MicroSimulation ms(0);
 
                 ms.set_state(t);
 

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -47,15 +47,14 @@ py::dict MicroSimulation::solve(py::dict macro_data, double dt)
 // This function needs to set the complete state of a micro simulation
 void MicroSimulation::set_state(py::list state)
 {
-    _sim_id = state[0].cast<int>()
-    _micro_scalar_data = state[1].cast<double>();
-    _state = state[2].cast<double>();
+    _micro_scalar_data = state[0].cast<double>();
+    _state = state[1].cast<double>();
 }
 
 // This function needs to return variables which can fully define the state of a micro simulation
 py::list MicroSimulation::get_state() const
 {
-    std::vector<double> state{_sim_id, _micro_scalar_data, _state};
+    std::vector<double> state{_micro_scalar_data, _state};
     py::list state_python = py::cast(state);
     return state_python;
 }
@@ -65,7 +64,7 @@ PYBIND11_MODULE(micro_dummy, m) {
     m.doc() = "pybind11 micro dummy plugin";
 
     py::class_<MicroSimulation>(m, "MicroSimulation")
-        .def(py::init())
+        .def(py::init<int>())
         .def("solve", &MicroSimulation::solve)
         .def("get_state", &MicroSimulation::get_state)
         .def("set_state", &MicroSimulation::set_state)
@@ -74,7 +73,7 @@ PYBIND11_MODULE(micro_dummy, m) {
                 return ms.get_state();
             },
             [](py::list t) { // __setstate__
-                if (t.size() != 3)
+                if (t.size() != 2)
                     throw std::runtime_error("Invalid state!");
 
                 /* Create a new C++ instance */

--- a/examples/cpp-dummy/micro_cpp_dummy.hpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.hpp
@@ -14,7 +14,7 @@ namespace py = pybind11;
 class MicroSimulation
 {
 public:
-    MicroSimulation();
+    MicroSimulation(int sim_id);
     // solve takes a python dict data, and the timestep dt as inputs, and returns a python dict
     py::dict solve(py::dict macro_write_data, double dt);
 
@@ -22,6 +22,7 @@ public:
     py::list get_state() const;
 
 private:
+    int _sim_id;
     double _micro_scalar_data;
     std::vector<double> _micro_vector_data;
     double _state;

--- a/examples/python-dummy/micro_dummy.py
+++ b/examples/python-dummy/micro_dummy.py
@@ -6,10 +6,11 @@ In this script we solve a dummy micro problem to just show the working of the ma
 
 class MicroSimulation:
 
-    def __init__(self):
+    def __init__(self, sim_id):
         """
         Constructor of MicroSimulation class.
         """
+        self._sim_id = sim_id
         self._dims = 3
         self._micro_scalar_data = None
         self._micro_vector_data = None

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -28,7 +28,9 @@ def create_simulation_class(micro_simulation_class):
             return self._global_id
 
         def set_global_id(self, global_id) -> None:
-            # TODO: Simulation objects have been initialized with a global ID, which we can no longer change, so change global ID here is problematic and will create a mismatch
+            # TODO: Simulation objects have been initialized with a global ID, which
+            # we can no longer change, so change global ID here is problematic and
+            # will create a mismatch.
             self._global_id = global_id
 
     return Simulation

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -21,13 +21,14 @@ def create_simulation_class(micro_simulation_class):
     """
     class Simulation(micro_simulation_class):
         def __init__(self, global_id):
-            micro_simulation_class.__init__(self)
+            micro_simulation_class.__init__(self, global_id)
             self._global_id = global_id
 
         def get_global_id(self) -> int:
             return self._global_id
 
         def set_global_id(self, global_id) -> None:
+            # TODO: Simulation objects have been initialized with a global ID, which we can no longer change, so change global ID here is problematic and will create a mismatch
             self._global_id = global_id
 
     return Simulation

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -27,10 +27,4 @@ def create_simulation_class(micro_simulation_class):
         def get_global_id(self) -> int:
             return self._global_id
 
-        def set_global_id(self, global_id) -> None:
-            # TODO: Simulation objects have been initialized with a global ID, which
-            # we can no longer change, so change global ID here is problematic and
-            # will create a mismatch.
-            self._global_id = global_id
-
     return Simulation

--- a/tests/integration/test_unit_cube/micro_dummy.py
+++ b/tests/integration/test_unit_cube/micro_dummy.py
@@ -6,10 +6,11 @@ In this script we solve a dummy micro problem to just show the working of the ma
 
 class MicroSimulation:
 
-    def __init__(self):
+    def __init__(self, sim_id):
         """
         Constructor of MicroSimulation class.
         """
+        self._sim_id = sim_id
         self._micro_scalar_data = None
         self._micro_vector_data = None
         self._checkpoint = None

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -5,7 +5,7 @@ import micro_manager
 
 
 class MicroSimulation:
-    def __init__(self):
+    def __init__(self, sim_id):
         self.very_important_value = 0
 
     def initialize(self):
@@ -85,7 +85,7 @@ class TestFunctioncalls(TestCase):
         """
         manager = micro_manager.MicroManager('micro-manager-config.json')
         manager._local_number_of_sims = 4
-        manager._micro_sims = [MicroSimulation() for _ in range(4)]
+        manager._micro_sims = [MicroSimulation(i) for i in range(4)]
         manager._micro_sims_active_steps = np.zeros(4, dtype=np.int32)
 
         micro_sims_output = manager._solve_micro_simulations(self.fake_read_data)


### PR DESCRIPTION
Uniqueness of micro simulations is critical if the user wants to manipulate the creation in some way, for example, to create a certain number of micro simulations of a particular type. To allow the user to uniquely identify micro simulations, this PR makes the Micro Manager pass the global ID to the user-side MicroSimulation class.