### PR TITLE
Reintroduce initialize function in the micro simulation API

### DIFF
--- a/docs/micro-simulation-convert-to-library.md
+++ b/docs/micro-simulation-convert-to-library.md
@@ -24,6 +24,16 @@ class MicroSimulation: # Name is fixed
             ID of the simulation instance, that the Micro Manager has set for it.
         """
 
+    def initialize(self) -> dict:
+        """
+        Initialize the micro simulation and return initial data which will be used in computing adaptivity before the first time step.
+
+        Returns
+        -------
+        initial_data : dict
+            Dictionary with names of initial data as keys and the initial data itself as values.
+        """
+
     def solve(self, macro_data: dict, dt: float) -> dict:
         """
         Solve one time step of the micro simulation for transient problems or solve until steady state for steady-state problems.

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -104,6 +104,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         is_sim_active = self._update_active_sims(similarity_dists, is_sim_active_nm1)
 
+        self._logger.info("is_sim_active: {}".format(is_sim_active))
+
         is_sim_active, sim_is_associated_to = self._update_inactive_sims(
             similarity_dists, is_sim_active_nm1, sim_is_associated_to_nm1, micro_sims)
 

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -104,8 +104,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         is_sim_active = self._update_active_sims(similarity_dists, is_sim_active_nm1)
 
-        self._logger.info("is_sim_active: {}".format(is_sim_active))
-
         is_sim_active, sim_is_associated_to = self._update_inactive_sims(
             similarity_dists, is_sim_active_nm1, sim_is_associated_to_nm1, micro_sims)
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -347,7 +347,7 @@ class MicroManager:
         if hasattr(micro_problem, 'initialize') and callable(getattr(micro_problem, 'initialize')):
             if self._is_adaptivity_on:
                 self._micro_sims_init = True
-                initial_micro_output = self._micro_sims[0].initialize()  # Get initial data from first simulation
+                initial_micro_output = self._micro_sims[0].initialize()  # Call initialize() of the first simulation
                 if initial_micro_output is None:  # Check if the detected initialize() method returns any data
                     if self._rank == 0:
                         warn("The initialize() call of the Micro simulation has not returned any initial data."
@@ -355,8 +355,8 @@ class MicroManager:
                         self._micro_sims_init = False
                 else:
                     # Save initial data from first micro simulation as we anyway have it
-                    for name in self._adaptivity_micro_data_names:
-                        self._data_for_adaptivity[name][i] = initial_micro_output[name]
+                    for name in initial_micro_output.keys():
+                        self._data_for_adaptivity[name][0] = initial_micro_output[name]
 
                     # Gather initial data from the rest of the micro simulations
                     for i in range(1, self._local_number_of_sims):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -348,10 +348,9 @@ class MicroManager:
                 self._micro_sims_init = True
                 initial_micro_output = self._micro_sims[0].initialize()  # Call initialize() of the first simulation
                 if initial_micro_output is None:  # Check if the detected initialize() method returns any data
-                    if self._rank == 0:
-                        warn("The initialize() call of the Micro simulation has not returned any initial data."
-                             " The initialize call is stopped.")
-                        self._micro_sims_init = False
+                    warn("The initialize() call of the Micro simulation has not returned any initial data."
+                         " The initialize call is stopped.")
+                    self._micro_sims_init = False
                 else:
                     # Save initial data from first micro simulation as we anyway have it
                     for name in initial_micro_output.keys():
@@ -363,7 +362,7 @@ class MicroManager:
                         for name in self._adaptivity_micro_data_names:
                             self._data_for_adaptivity[name][i] = initial_micro_output[name]
             else:
-                print("Micro simulation has the method initialize(), but it is not called, because adaptivity is off.")
+                self._logger.info("Micro simulation has the method initialize(), but it is not called, because adaptivity is off.")
 
         self._micro_sims_have_output = False
         if hasattr(micro_problem, 'output') and callable(getattr(micro_problem, 'output')):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -362,7 +362,8 @@ class MicroManager:
                         for name in self._adaptivity_micro_data_names:
                             self._data_for_adaptivity[name][i] = initial_micro_output[name]
             else:
-                self._logger.info("Micro simulation has the method initialize(), but it is not called, because adaptivity is off.")
+                self._logger.info(
+                    "Micro simulation has the method initialize(), but it is not called, because adaptivity is off.")
 
         self._micro_sims_have_output = False
         if hasattr(micro_problem, 'output') and callable(getattr(micro_problem, 'output')):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -135,6 +135,10 @@ class MicroManager:
         """
         t, n = 0, 0
         t_checkpoint, n_checkpoint = 0, 0
+        similarity_dists_cp = None
+        is_sim_active_cp = None
+        sim_is_associated_to_cp = None
+        sim_states_cp = [None] * self._local_number_of_sims
 
         if self._is_adaptivity_on:
             similarity_dists = np.zeros(
@@ -152,17 +156,6 @@ class MicroManager:
                 # Compute adaptivity based on initial data of micro sims
                 similarity_dists, is_sim_active, sim_is_associated_to = self._adaptivity_controller.compute_adaptivity(
                     self._dt, self._micro_sims, similarity_dists, is_sim_active, sim_is_associated_to, self._data_for_adaptivity)
-
-                if self._adaptivity_type == "local":
-                    active_sim_ids = np.where(is_sim_active)[0]
-                elif self._adaptivity_type == "global":
-                    active_sim_ids = np.where(
-                        is_sim_active[self._global_ids_of_local_sims[0]:self._global_ids_of_local_sims[-1] + 1])[0]
-
-        similarity_dists_cp = None
-        is_sim_active_cp = None
-        sim_is_associated_to_cp = None
-        sim_states_cp = [None] * self._local_number_of_sims
 
         while self._participant.is_coupling_ongoing():
             # Write a checkpoint

--- a/tests/unit/precice.py
+++ b/tests/unit/precice.py
@@ -1,4 +1,4 @@
-# This file mocks pyprecice, the Python bindings for preCICE, and is used _only_ for unit testing the Micro Manager.
+# This file mocks pyprecice, the Python bindings for preCICE, and is used _only_ for testing the Micro Manager.
 from typing import Any
 import numpy as np
 

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -13,7 +13,7 @@ class TestGlobalAdaptivity(TestCase):
 
     def test_update_inactive_sims_global_adaptivity(self):
         """
-        Test functionality to update inactive simulations in a particular setting, for a global adaptivity setting.
+        Test functionality to update inactive simulations in a particular setting.
         Run this test in parallel using MPI with 2 ranks.
         """
         if self._rank == 0:
@@ -76,7 +76,7 @@ class TestGlobalAdaptivity(TestCase):
 
     def test_update_all_active_sims_global_adaptivity(self):
         """
-        Test functionality to calculate adaptivity when all simulations are active, for a global adaptivity setting.
+        Test functionality to calculate adaptivity when all simulations are active.
         Run this test in parallel using MPI with 2 ranks.
         """
         if self._rank == 0:
@@ -133,7 +133,7 @@ class TestGlobalAdaptivity(TestCase):
 
     def test_communicate_micro_output(self):
         """
-        Test functionality to communicate micro output from active sims to their associated inactive sims, for a global adaptivity setting.
+        Test functionality to communicate micro output from active sims to their associated inactive sims.
         Run this test in parallel using MPI with 2 ranks.
         """
         output_0 = {"data0.1": 1.0, "data0.2": [1.0, 2.0]}


### PR DESCRIPTION
The `initialize()` function is reintroduced as an optionally function that the micro simulation library can have. If the function exists, the Micro Manager calls it. The function is expected to return data, otherwise it does not have any purpose from the perspective of the coupling. The data returned from the function is checked for matching names with the data given for adaptivity. If matched, the adaptivity functionality is called based on this data *before* the coupling starts.