### PR TITLE
Remove unused import of micro simulations

### DIFF
--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -71,7 +71,6 @@ class MicroManager:
             self._size)
 
         micro_file_name = self._config.get_micro_file_name()
-        self._micro_problem = getattr(__import__(micro_file_name, fromlist=["MicroSimulation"]), "MicroSimulation")
 
         self._macro_mesh_name = self._config.get_macro_mesh_name()
 


### PR DESCRIPTION
This removes an unnecessary import of the `MicroSimulation` class that was not used. In a personal meeting, we also discussed if one of the logger level sets could be removed but on further investigation, they seem to serve slightly different purposes.