### PR TITLE
Handle crashing micro simulations

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -24,6 +24,14 @@ jobs:
           pip3 install --user .
           pip3 uninstall -y pyprecice
 
-      - name: Run unit tests
+      - name: Run micro_manager unit test
         working-directory: micro-manager/tests/unit
         run: python3 -m unittest test_micro_manager.py
+
+      - name: Run interpolation unit test
+        working-directory: micro-manager/tests/unit
+        run: python3 -m unittest test_interpolation.py
+
+      - name: Run micro simulation crash unit test
+        working-directory: micro-manager/tests/unit
+        run: python3 -m unittest test_micro_simulation_crash_handling.py

--- a/examples/python-dummy/micro_dummy.py
+++ b/examples/python-dummy/micro_dummy.py
@@ -21,13 +21,6 @@ class MicroSimulation:
         self._micro_scalar_data = macro_data["macro-scalar-data"] + 1
         for d in range(self._dims):
             self._micro_vector_data.append(macro_data["macro-vector-data"][d] + 1)
-        
-        # random simulation crash
-        import numpy as np
-        if np.random.rand() < 0.01:
-            print("Micro simulation {} crashed!".format(self._sim_id))
-            self._micro_scalar_data = 1 / 0
-            
 
         return {
             "micro-scalar-data": self._micro_scalar_data.copy(),

--- a/examples/python-dummy/micro_dummy.py
+++ b/examples/python-dummy/micro_dummy.py
@@ -21,6 +21,13 @@ class MicroSimulation:
         self._micro_scalar_data = macro_data["macro-scalar-data"] + 1
         for d in range(self._dims):
             self._micro_vector_data.append(macro_data["macro-vector-data"][d] + 1)
+        
+        # random simulation crash
+        import numpy as np
+        if np.random.rand() < 0.01:
+            print("Micro simulation {} crashed!".format(self._sim_id))
+            self._micro_scalar_data = 1 / 0
+            
 
         return {
             "micro-scalar-data": self._micro_scalar_data.copy(),

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -33,7 +33,7 @@ class Interpolation:
         assert len(all_local_coords) > 0, "No local coordinates provided."
         if len(all_local_coords) < k:
             self._logger.info(
-                "Number of neighbors {} is larger than the number of neighbors {}. Setting k to {}.".format(
+                "Number of desired neighbors k = {} is larger than the number of available neighbors {}. Setting k = {}.".format(
                     k, len(all_local_coords), len(all_local_coords)
                 )
             )

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -9,75 +9,89 @@ class Interpolation:
 
     def get_nearest_neighbor_indices_local(
         self,
-        all_local_coords,
-        inter_point,
+        all_local_coords: np.ndarray,
+        inter_point: np.ndarray,
         k: int,
-        inter_point_is_neighbor: bool = False,
     ) -> np.ndarray:
         """
         Get the indices of the k nearest neighbors of a point in a list of coordinates.
-        Note: It can be chosen whether the point itself is considered as a neighbor or not.
-        Args:
-            all_local_coords: list
-                List of coordinates of all points.
-            inter_point:
-                Coordinates of the point for which the neighbors are to be found.
-            k: int
-            inter_point_is_neighbor: bool, optional
-                Decide whether the interpolation point is considered as its own neighbor.
-                Defaults to False.
+        If inter_point is part of all_local_coords, it is only considered one time less than it occurs.
+        inter_point is expected to be in all_local_coords at most once.
 
-        Returns: np.ndarray
-            of indices of the k nearest neighbors.
+        Parameters
+        ----------
+        all_local_coords : list
+            List of coordinates of all points.
+        inter_point : list | np.ndarray
+            Coordinates of the point for which the neighbors are to be found.
+        k : int
+            Number of neighbors to consider.
+
+        Returns
+        ------
+        neighbor_indices : np.ndarray
+            Indices of the k nearest neighbors in all local points.
         """
         assert (
-            len(all_local_coords) > k
-        ), "Desired number of neighbors must be less than the number of all available neighbors."
-        if not inter_point_is_neighbor:
-            neighbors = NearestNeighbors(n_neighbors=k + 1).fit(all_local_coords)
+            len(all_local_coords) >= k
+        ), "Desired number of neighbors must be less than or equal to the number of all available neighbors."
+        # If the number of neighbors is larger than the number of all available neighbors, increase the number of neighbors
+        # to be able to delete a neighbor if it coincides with the interpolation point.
+        if len(all_local_coords) > k:
+            k += 1
+        neighbors = NearestNeighbors(n_neighbors=k).fit(all_local_coords)
 
-            dists, neighbor_indices = neighbors.kneighbors(
-                [inter_point], return_distance=True
-            )
+        dists, neighbor_indices = neighbors.kneighbors(
+            [inter_point], return_distance=True
+        )
 
-            if np.min(dists) < 1e-10:
-                argmin = np.argmin(dists)
-                neighbor_indices = np.delete(neighbor_indices, argmin)
-            else:
-                argmax = np.argmax(dists)
-                neighbor_indices = np.delete(neighbor_indices, argmax)
+        # Check whether the inter_point is also part of the neighbor list and remove it.
+        if np.min(dists) < 1e-16:
+            argmin = np.argmin(dists)
+            neighbor_indices = np.delete(neighbor_indices, argmin)
+        # If point itself is not in neighbor list, remove neighbor with largest distance
+        # to return the desired number of neighbors
         else:
-            neighbors = NearestNeighbors(n_neighbors=k).fit(all_local_coords)
-            neighbor_indices = neighbors.kneighbors(
-                [inter_point], return_distance=False
-            )
+            argmax = np.argmax(dists)
+            neighbor_indices = np.delete(neighbor_indices, argmax)
 
         return neighbor_indices
 
     def inv_dist_weighted_interp(
-        self, neighbors: list, point, values: list
-    ) -> np.ndarray:
+        self, neighbors: np.ndarray, point: np.ndarray, values
+    ):
         """
             Interpolate a value at a point using inverse distance weighting.
+            .. math::
+                f(x) = (\sum_{i=1}^{n} \frac{f_i}{\Vert x_i - x \Vert^2}) / (\sum_{j=1}^{n} \frac{1}{\Vert x_j - x \Vert^2})
 
-        Args:
-            neighbors: list
-                Coordinates at which the values are known.
-            point:
-                Coordinates at which the value is to be interpolated.
-            values: list
-                Values at the known coordinates.
+        Parameters
+        ----------
+        neighbors : np.ndarray
+            Coordinates at which the values are known.
+        point : np.ndarray
+            Coordinates at which the value is to be interpolated.
+        values :
+            Values at the known coordinates.
 
-        Returns: nd.array
+        Returns
+        -------
+        interpol_val / summed_weights :
             Value at interpolation point.
         """
         interpol_val = 0
         summed_weights = 0
+        # iterate over all neighbors
         for inx in range(len(neighbors)):
+            # compute the squared norm of the difference between interpolation point and neighbor
             norm = np.linalg.norm(np.array(neighbors[inx]) - np.array(point)) ** 2
-            if norm < 1e-10:
+            # If interpolation point is already part of the data it is returned as the interpolation result
+            # This avoids division by zero
+            if norm < 1e-16:
                 return values[inx]
+            # update interpolation value
             interpol_val += values[inx] / norm
+            # extend normalization factor
             summed_weights += 1 / norm
 
         return interpol_val / summed_weights

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -46,9 +46,7 @@ class Interpolation:
 
         return neighbor_indices
 
-    def inv_dist_weighted_interp(
-        self, neighbors: np.ndarray, point: np.ndarray, values
-    ):
+    def interpolate(self, neighbors: np.ndarray, point: np.ndarray, values):
         """
             Interpolate a value at a point using inverse distance weighting.
             .. math::

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -14,7 +14,7 @@ class Interpolation:
         k: int,
     ) -> np.ndarray:
         """
-        Get the indices of the k nearest neighbors of a point in a list of coordinates.
+        Get local indices of the k nearest neighbors of a point.
 
         Parameters
         ----------
@@ -28,12 +28,12 @@ class Interpolation:
         Returns
         ------
         neighbor_indices : np.ndarray
-            Indices of the k nearest neighbors in all local points.
+            Local indices of the k nearest neighbors in all local points.
         """
         assert len(all_local_coords) > 0, "No local coordinates provided."
         if len(all_local_coords) < k:
             self._logger.info(
-                "Number of desired neighbors k = {} is larger than the number of available neighbors {}. Setting k = {}.".format(
+                "Number of desired neighbors k = {} is larger than the number of available neighbors {}. Resetting k = {}.".format(
                     k, len(all_local_coords), len(all_local_coords)
                 )
             )
@@ -48,7 +48,7 @@ class Interpolation:
 
     def interpolate(self, neighbors: np.ndarray, point: np.ndarray, values):
         """
-            Interpolate a value at a point using inverse distance weighting.
+            Interpolate a value at a point using inverse distance weighting. (https://en.wikipedia.org/wiki/Inverse_distance_weighting)
             .. math::
                 f(x) = (\sum_{i=1}^{n} \frac{f_i}{\Vert x_i - x \Vert^2}) / (\sum_{j=1}^{n} \frac{1}{\Vert x_j - x \Vert^2})
 

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -1,0 +1,43 @@
+import numpy as np
+from scipy.interpolate import griddata as gd
+
+
+def interpolate(logger, known_coords: list, inter_coord: list , data: list)-> dict:
+    """
+    Interpolate parameters at a given vertex
+
+    Args:
+        logger : logger object
+            Logger of the micro manager
+        known_coords : list
+            List of vertices where the data is known
+        inter_coord : list
+            Vertex where the data is to be interpolated
+        data : list
+            List of dicts in which keys are names of data and the values are the data.
+
+    Returns:
+        result: dict
+            Interpolated data at inter_coord
+    """
+    result = dict()
+    assert len(known_coords) == len(data), "Number of known coordinates and data points do not match"
+
+    for params in data[0].keys():
+        # Attempt to interpolate the data
+        try:
+            result[params] = gd(known_coords, [d[params] for d in data], inter_coord, method='linear').tolist()
+            # Extrapolation is replaced by taking a nearest neighbor
+            if np.isnan(result[params]).any():
+                nearest_neighbor_pos = np.argmin(np.linalg.norm(np.array(known_coords) - np.array(inter_coord), axis=1))
+                nearest_neighbor = known_coords[nearest_neighbor_pos]
+                logger.info("Interpolation failed at macro vertex {}. Taking value of closest neighbor at macro vertex {}".format(params, inter_coord, nearest_neighbor))
+                return data[nearest_neighbor_pos]
+            return result
+        # If interpolation fails, take the value of the nearest neighbor
+        except Exception:
+                nearest_neighbor_pos = np.argmin(np.linalg.norm(np.array(known_coords) - np.array(inter_coord), axis=1))
+                nearest_neighbor = known_coords[nearest_neighbor_pos]
+                logger.info("Interpolation failed at macro vertex {}. Taking value of closest neighbor at macro vertex {}".format(params, inter_coord, nearest_neighbor))
+                return data[nearest_neighbor_pos]
+ 

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -32,7 +32,7 @@ class Interpolation:
         """
         assert (
             len(all_local_coords) > k
-        ), "Number of neighbors must be less than the number of all available neighbors."
+        ), "Desired number of neighbors must be less than the number of all available neighbors."
         if not inter_point_is_neighbor:
             neighbors = NearestNeighbors(n_neighbors=k + 1).fit(all_local_coords)
 

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -7,9 +7,9 @@ class Interpolation:
 
         self._logger = logger
 
-    def get_nearest_neighbor_indices_local(
+    def get_nearest_neighbor_indices(
         self,
-        all_local_coords: np.ndarray,
+        coords: np.ndarray,
         inter_point: np.ndarray,
         k: int,
     ) -> np.ndarray:
@@ -18,7 +18,7 @@ class Interpolation:
 
         Parameters
         ----------
-        all_local_coords : list
+        coords : list
             List of coordinates of all points.
         inter_point : list | np.ndarray
             Coordinates of the point for which the neighbors are to be found.
@@ -30,15 +30,14 @@ class Interpolation:
         neighbor_indices : np.ndarray
             Local indices of the k nearest neighbors in all local points.
         """
-        assert len(all_local_coords) > 0, "No local coordinates provided."
-        if len(all_local_coords) < k:
+        if len(coords) < k:
             self._logger.info(
                 "Number of desired neighbors k = {} is larger than the number of available neighbors {}. Resetting k = {}.".format(
-                    k, len(all_local_coords), len(all_local_coords)
+                    k, len(coords), len(coords)
                 )
             )
-            k = len(all_local_coords)
-        neighbors = NearestNeighbors(n_neighbors=k).fit(all_local_coords)
+            k = len(coords)
+        neighbors = NearestNeighbors(n_neighbors=k).fit(coords)
 
         neighbor_indices = neighbors.kneighbors(
             [inter_point], return_distance=False
@@ -68,17 +67,17 @@ class Interpolation:
         """
         interpol_val = 0
         summed_weights = 0
-        # iterate over all neighbors
+        # Iterate over all neighbors
         for inx in range(len(neighbors)):
-            # compute the squared norm of the difference between interpolation point and neighbor
+            # Compute the squared norm of the difference between interpolation point and neighbor
             norm = np.linalg.norm(np.array(neighbors[inx]) - np.array(point)) ** 2
             # If interpolation point is already part of the data it is returned as the interpolation result
             # This avoids division by zero
             if norm < 1e-16:
                 return values[inx]
-            # update interpolation value
+            # Update interpolation value
             interpol_val += values[inx] / norm
-            # extend normalization factor
+            # Extend normalization factor
             summed_weights += 1 / norm
 
         return interpol_val / summed_weights

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -74,8 +74,6 @@ class MicroManager:
             self._config.get_config_file_name(),
             self._rank,
             self._size)
-        
-        micro_file_name = self._config.get_micro_file_name()
 
         self._macro_mesh_name = self._config.get_macro_mesh_name()
 
@@ -408,7 +406,7 @@ class MicroManager:
             sim_id += 1
 
         self._micro_sims = [None] * self._local_number_of_sims  # DECLARATION
-        
+
         self._crashed_sims = [False] * self._local_number_of_sims
         self._old_micro_sims_output = [None] * self._local_number_of_sims
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -411,7 +411,7 @@ class MicroManager:
         self._micro_sims = [None] * self._local_number_of_sims  # DECLARATION
 
         # setup for simulation crashes
-        self._crashed_sims = [False] * self._local_number_of_sims
+        self._has_sim_crashed = [False] * self._local_number_of_sims
         self._neighbor_list = [None] * self._local_number_of_sims
         number_of_nearest_neighbors = int(self._local_number_of_sims * 0.25)
         self._interpolation = Interpolation(self._logger)

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -589,9 +589,8 @@ class MicroManager:
         unset_sims = np.where(none_mask)[0]
 
         for unset_sims in unset_sims:
-            self._logger.info("Micro Sim {} has previously not run. "
-                              "It will be replace with the output of the first "
-                              "micro sim that ran {}".format(unset_sims, set_sims[0][0]))
+            self._logger.info("Micro simulation {} has has crashed in the very first run attempt. "
+                              "The output of the first micro sim that ran ({}) will be used as its output.".format(unset_sims, set_sims[0][0]))
             micro_sims_output[unset_sims] = micro_sims_output[set_sims[0][0]]
         self._old_micro_sims_output = micro_sims_output
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -408,6 +408,9 @@ class MicroManager:
             sim_id += 1
 
         self._micro_sims = [None] * self._local_number_of_sims  # DECLARATION
+        
+        self._crashed_sims = [False] * self._local_number_of_sims
+        self._old_micro_sims_output = [None] * self._local_number_of_sims
 
         self._crashed_sims = [False] * self._local_number_of_sims
         self._old_micro_sims_output = [None] * self._local_number_of_sims
@@ -700,7 +703,6 @@ class MicroManager:
         for active_id in active_sim_ids:
             if micro_sims_output[active_id] is None:
                 unset_sims.append(active_id)
-
         for unset_sims in unset_sims:
             self._logger.info("Micro Sim {} has previously not run. "
                               "It will be replace with the output of the first "

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -788,8 +788,8 @@ class MicroManager:
             iter_length = active_sim_ids
         else:
             iter_length = range(len(micro_sims_input))
-        micro_sims_active_input_lists = []  # DECLARATION
-        micro_sims_active_values = []  # DECLARATION
+        micro_sims_active_input_lists = []
+        micro_sims_active_values = []
         # Turn crashed simulation macro parameters into list to use as coordinate for interpolation
         crashed_position = []  # DECLARATION
         for value in micro_sims_input[unset_sim].values():

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author_email="ishaan.desai@uni-stuttgart.de",
     license="LGPL-3.0",
     packages=find_packages(exclude=["examples"]),
-    install_requires=["pyprecice>=3.0.0.0", "numpy>=1.13.3", "mpi4py"],
+    install_requires=["pyprecice>=3.0.0.0", "numpy>=1.13.3", "scikit-learn", "mpi4py"],
     test_suite="tests",
     zip_safe=False,
 )

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -8,7 +8,8 @@
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "adaptivity": {
+        "adaptivity": "True",
+        "adaptivity_settings": {
             "type": "local",
             "data": ["macro-scalar-data", "macro-vector-data"],
             "history_param": 0.5,

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -1,0 +1,25 @@
+{
+    "micro_file_name": "test_micro_simulation_crash_handling",
+    "coupling_params": {
+        "config_file_name": "dummy-config.xml",
+        "macro_mesh_name": "dummy-macro-mesh",
+        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+    },
+    "simulation_params": {
+        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+        "adaptivity": {
+            "type": "local",
+            "data": ["macro-scalar-data", "macro-vector-data"],
+            "history_param": 0.5,
+            "coarsening_constant": 0.3,
+            "refining_constant": 0.4,
+            "every_implicit_iteration": "False",
+            "similarity_measure": "L1"
+        }
+    },
+    "diagnostics": {
+        "output_micro_sim_solve_time": "True",
+        "micro_output_n": 10
+    }
+}

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -1,0 +1,33 @@
+import numpy as np
+from unittest import TestCase
+from unittest.mock import MagicMock
+from micro_manager.interpolation import interpolate
+
+
+class TestInterpolation(TestCase):
+
+    def test_local_interpolation(self):
+        """
+        Test if local interpolation works as expected
+        """
+        micro_output = [{"vector data": [1,1,1], "scalar data": [1]}] * 4
+        micro_output.append({"vector data": [3,3,3], "scalar data": [0]})
+        micro_output.append({"vector data": [0,0,0], "scalar data": [3]})
+        coords_known = [[2,0,0],[-2,0,0], [0,2,0], [0,-2,0], [0,0,2], [0,0,-1]]
+        unknown_coord = [0,0,0]
+        expected_interpolation_result = {"vector data": np.array([1,1,1]), "scalar data": np.array([2])}
+        interpolation_result = interpolate(MagicMock(), coords_known, unknown_coord , micro_output)
+        for key in interpolation_result.keys():
+            self.assertTrue(np.allclose(interpolation_result[key], expected_interpolation_result[key]))
+        
+    def test_local_extrapolation(self):
+        micro_output = [{"vector data": [3,2,1], "scalar data": [0]},
+                        {"vector data": [3,2,1], "scalar data": [0]},
+                        {"vector data": [3,2,1], "scalar data": [0]},
+                        {"vector data": [4,3,2], "scalar data": [4]},
+                        {"vector data": [3,2,1], "scalar data": [2]}]
+        coords_known = [[0,-2,0],[0,-4,0],[0,0,2], [2,0,0],[1,0,0]]
+        unknown_coord = [0,0,0]
+        expected_interpolation_result = {"vector data": [3,2,1], "scalar data": [2]}
+        interpolation_result = interpolate(MagicMock(), coords_known, unknown_coord , micro_output)
+        self.assertDictEqual(interpolation_result, expected_interpolation_result)

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -12,18 +12,23 @@ class TestInterpolation(TestCase):
         coords = [[-2, 0, 0], [-1, 0, 0], [2, 0, 0]]
         inter_point = [1, 0, 0]
         vector_data = [[-2, -2, -2], [-1, -1, -1], [2, 2, 2]]
-        expected_vector_data = [55 / 49, 55 / 49, 55 / 49]
         scalar_data = [[-2], [-1], [2]]
-        expected_scalar_data = 55 / 49
+        expected_vector_interpolation_output = [55 / 49, 55 / 49, 55 / 49]
+        expected_scalar_interpolation_output = 55 / 49
+
         interpolation = Interpolation(MagicMock())
-        interpolated_vector_data = interpolation.inv_dist_weighted_interp(
+        interpolated_vector_data = interpolation.interpolate(
             coords, inter_point, vector_data
         )
-        interpolated_scalar_data = interpolation.inv_dist_weighted_interp(
+        interpolated_scalar_data = interpolation.interpolate(
             coords, inter_point, scalar_data
         )
-        self.assertTrue(np.allclose(interpolated_vector_data, expected_vector_data))
-        self.assertAlmostEqual(interpolated_scalar_data, expected_scalar_data)
+        self.assertTrue(
+            np.allclose(interpolated_vector_data, expected_vector_interpolation_output)
+        )
+        self.assertAlmostEqual(
+            interpolated_scalar_data, expected_scalar_interpolation_output
+        )
 
     def test_nearest_neighbor(self):
         """
@@ -34,6 +39,7 @@ class TestInterpolation(TestCase):
         inter_coord = [0, 0, 0]
         expected_nearest_neighbor_index = [4, 0, 1]
         k = 3
+
         interpolation = Interpolation(MagicMock())
         nearest_neighbor_index = interpolation.get_nearest_neighbor_indices_local(
             neighbors, inter_coord, k

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -41,7 +41,7 @@ class TestInterpolation(TestCase):
         k = 3
 
         interpolation = Interpolation(MagicMock())
-        nearest_neighbor_index = interpolation.get_nearest_neighbor_indices_local(
+        nearest_neighbor_index = interpolation.get_nearest_neighbor_indices(
             neighbors, inter_coord, k
         )
         self.assertListEqual(

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -30,27 +30,10 @@ class TestInterpolation(TestCase):
         Test if finding nearest neighbor works as expected if interpolation point
         itself is not part of neighbor coordinates.
         """
-        neighbors = [[0, 2, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0]]
+        neighbors = [[0, 2, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0], [0, 0, 0]]
         inter_coord = [0, 0, 0]
-        expected_nearest_neighbor_index = [0, 1]
-        k = 2
-        interpolation = Interpolation(MagicMock())
-        nearest_neighbor_index = interpolation.get_nearest_neighbor_indices_local(
-            neighbors, inter_coord, k
-        )
-        self.assertListEqual(
-            nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
-        )
-
-    def test_nearest_neighbor_with_point_its_own_neighbor(self):
-        """
-        Test if finding nearest neighbor works as expected when the
-        interpolation point is part of the coordinate list.
-        """
-        neighbors = [[0, 0, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0]]
-        inter_coord = [0, 0, 0]
-        expected_nearest_neighbor_index = [1, 2]
-        k = 2
+        expected_nearest_neighbor_index = [4, 0, 1]
+        k = 3
         interpolation = Interpolation(MagicMock())
         nearest_neighbor_index = interpolation.get_nearest_neighbor_indices_local(
             neighbors, inter_coord, k

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -1,33 +1,80 @@
 import numpy as np
 from unittest import TestCase
 from unittest.mock import MagicMock
-from micro_manager.interpolation import interpolate
+from micro_manager.interpolation import Interpolation
 
 
 class TestInterpolation(TestCase):
-
     def test_local_interpolation(self):
         """
         Test if local interpolation works as expected
         """
-        micro_output = [{"vector data": [1,1,1], "scalar data": [1]}] * 4
-        micro_output.append({"vector data": [3,3,3], "scalar data": [0]})
-        micro_output.append({"vector data": [0,0,0], "scalar data": [3]})
-        coords_known = [[2,0,0],[-2,0,0], [0,2,0], [0,-2,0], [0,0,2], [0,0,-1]]
-        unknown_coord = [0,0,0]
-        expected_interpolation_result = {"vector data": np.array([1,1,1]), "scalar data": np.array([2])}
-        interpolation_result = interpolate(MagicMock(), coords_known, unknown_coord , micro_output)
-        for key in interpolation_result.keys():
-            self.assertTrue(np.allclose(interpolation_result[key], expected_interpolation_result[key]))
-        
-    def test_local_extrapolation(self):
-        micro_output = [{"vector data": [3,2,1], "scalar data": [0]},
-                        {"vector data": [3,2,1], "scalar data": [0]},
-                        {"vector data": [3,2,1], "scalar data": [0]},
-                        {"vector data": [4,3,2], "scalar data": [4]},
-                        {"vector data": [3,2,1], "scalar data": [2]}]
-        coords_known = [[0,-2,0],[0,-4,0],[0,0,2], [2,0,0],[1,0,0]]
-        unknown_coord = [0,0,0]
-        expected_interpolation_result = {"vector data": [3,2,1], "scalar data": [2]}
-        interpolation_result = interpolate(MagicMock(), coords_known, unknown_coord , micro_output)
-        self.assertDictEqual(interpolation_result, expected_interpolation_result)
+        coords = [[-2, 0, 0], [-1, 0, 0], [2, 0, 0]]
+        inter_point = [1, 0, 0]
+        vector_data = [[-2, -2, -2], [-1, -1, -1], [2, 2, 2]]
+        expected_vector_data = [55 / 49, 55 / 49, 55 / 49]
+        scalar_data = [[-2], [-1], [2]]
+        expected_scalar_data = 55 / 49
+        interpolation = Interpolation(MagicMock())
+        interpolated_vector_data = interpolation.inv_dist_weighted_interp(
+            coords, inter_point, vector_data
+        )
+        interpolated_scalar_data = interpolation.inv_dist_weighted_interp(
+            coords, inter_point, scalar_data
+        )
+        self.assertTrue(np.allclose(interpolated_vector_data, expected_vector_data))
+        self.assertAlmostEqual(interpolated_scalar_data, expected_scalar_data)
+
+    def test_nearest_neighbor(self):
+        """
+        Test if finding nearest neighbor works as expected if interpolation point
+        itself is not part of neighbor coordinates
+        """
+        neighbors = [[0, 2, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0]]
+        inter_coord = [0, 0, 0]
+        expected_nearest_neighbor_index = [0, 1]
+        k = 2
+        interpolation = Interpolation(MagicMock())
+        nearest_neighbor_index = interpolation.get_nearest_neighbor_indices_local(
+            neighbors, inter_coord, k
+        )
+        self.assertListEqual(
+            nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
+        )
+
+    def test_nearest_neighbor_excluding_interpolation_point(self):
+        """
+        Test if finding nearest neighbor works as expected when the
+        interpolation point is part of the coordinate list but its
+        distance shall not be considered
+        """
+        neighbors = [[0, 0, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0]]
+        inter_coord = [0, 0, 0]
+        expected_nearest_neighbor_index = [1, 2]
+        k = 2
+        interpolation = Interpolation(MagicMock())
+        nearest_neighbor_index = interpolation.get_nearest_neighbor_indices_local(
+            neighbors, inter_coord, k
+        )
+        self.assertListEqual(
+            nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
+        )
+
+
+def test_nearest_neighbor_including_interpolation_point(self):
+    """
+    Test if finding nearest neighbor works as expected when the
+    interpolation point is part of the coordinate list and its
+    distance shall be considered
+    """
+    neighbors = [[0, 0, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0]]
+    inter_coord = [0, 0, 0]
+    expected_nearest_neighbor_index = [0, 1]
+    k = 2
+    interpolation = Interpolation(MagicMock())
+    nearest_neighbor_index = interpolation.get_nearest_neighbor_indices_local(
+        neighbors, inter_coord, k, inter_point_is_neighbor=True
+    )
+    self.assertListEqual(
+        nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
+    )

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -7,7 +7,7 @@ from micro_manager.interpolation import Interpolation
 class TestInterpolation(TestCase):
     def test_local_interpolation(self):
         """
-        Test if local interpolation works as expected
+        Test if local interpolation works as expected.
         """
         coords = [[-2, 0, 0], [-1, 0, 0], [2, 0, 0]]
         inter_point = [1, 0, 0]
@@ -28,7 +28,7 @@ class TestInterpolation(TestCase):
     def test_nearest_neighbor(self):
         """
         Test if finding nearest neighbor works as expected if interpolation point
-        itself is not part of neighbor coordinates
+        itself is not part of neighbor coordinates.
         """
         neighbors = [[0, 2, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0]]
         inter_coord = [0, 0, 0]
@@ -42,11 +42,10 @@ class TestInterpolation(TestCase):
             nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
         )
 
-    def test_nearest_neighbor_excluding_interpolation_point(self):
+    def test_nearest_neighbor_with_point_its_own_neighbor(self):
         """
         Test if finding nearest neighbor works as expected when the
-        interpolation point is part of the coordinate list but its
-        distance shall not be considered
+        interpolation point is part of the coordinate list.
         """
         neighbors = [[0, 0, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0]]
         inter_coord = [0, 0, 0]
@@ -59,22 +58,3 @@ class TestInterpolation(TestCase):
         self.assertListEqual(
             nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
         )
-
-
-def test_nearest_neighbor_including_interpolation_point(self):
-    """
-    Test if finding nearest neighbor works as expected when the
-    interpolation point is part of the coordinate list and its
-    distance shall be considered
-    """
-    neighbors = [[0, 0, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0]]
-    inter_coord = [0, 0, 0]
-    expected_nearest_neighbor_index = [0, 1]
-    k = 2
-    interpolation = Interpolation(MagicMock())
-    nearest_neighbor_index = interpolation.get_nearest_neighbor_indices_local(
-        neighbors, inter_coord, k, inter_point_is_neighbor=True
-    )
-    self.assertListEqual(
-        nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
-    )

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -7,13 +7,9 @@ import micro_manager
 
 
 class MicroSimulation:
-    def __init__(self, sim_id, crashing=False):
+    def __init__(self, sim_id):
         self.very_important_value = 0
-        self.sim_id = sim_id
-        self.crashing = crashing
-        self.current_time = 0
 
-        
     def initialize(self):
         pass
 
@@ -24,6 +20,7 @@ class MicroSimulation:
             "micro-scalar-data": macro_data["macro-scalar-data"] + 1,
             "micro-vector-data": macro_data["macro-vector-data"] + 1
             }
+
 
 class TestFunctioncalls(TestCase):
     def setUp(self):
@@ -96,7 +93,7 @@ class TestFunctioncalls(TestCase):
                 fake_data["macro-vector-data"].tolist(),
             )
 
-    def test_solve_micro_sims(self):
+    def test_solve_mico_sims(self):
         """
         Test if the internal function _solve_micro_simulations works as expected.
         """

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -18,8 +18,8 @@ class MicroSimulation:
         assert macro_data["macro-vector-data"].tolist() == [0, 1, 2]
         return {
             "micro-scalar-data": macro_data["macro-scalar-data"] + 1,
-            "micro-vector-data": macro_data["macro-vector-data"] + 1
-            }
+            "micro-vector-data": macro_data["macro-vector-data"] + 1,
+        }
 
 
 class TestFunctioncalls(TestCase):

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -102,7 +102,7 @@ class TestFunctioncalls(TestCase):
                 fake_data["macro-vector-data"].tolist(),
             )
 
-    def test_solve_micro_sims(self):
+    def test_solve_mico_sims(self):
         """
         Test if the internal function _solve_micro_simulations works as expected.
         """

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -7,20 +7,33 @@ import micro_manager
 
 
 class MicroSimulation:
-    def __init__(self, sim_id):
+    def __init__(self, sim_id, crashing=False):
         self.very_important_value = 0
+        self.sim_id = sim_id
+        self.crashing = crashing
+        self.current_time = 0
 
+        
     def initialize(self):
         pass
 
     def solve(self, macro_data, dt):
-        assert macro_data["macro-scalar-data"] == 1
-        assert macro_data["macro-vector-data"].tolist() == [0, 1, 2]
-        return {
-            "micro-scalar-data": macro_data["macro-scalar-data"] + 1,
-            "micro-vector-data": macro_data["macro-vector-data"] + 1,
-        }
-
+        if not self.crashing:
+            assert macro_data["macro-scalar-data"] == 1
+            assert macro_data["macro-vector-data"].tolist() == [0, 1, 2]
+            return {
+                "micro-scalar-data": macro_data["macro-scalar-data"] + 1,
+                "micro-vector-data": macro_data["macro-vector-data"] + 1
+                }
+        else:
+            if self.sim_id == 0:
+                self.current_time += dt
+                if self.current_time > dt:
+                    raise Exception("Micro Simulation has crashed")
+            return {
+                "micro-scalar-data": macro_data["macro-scalar-data"] + 1,
+                "micro-vector-data": macro_data["macro-vector-data"] + 1
+            }
 
 class TestFunctioncalls(TestCase):
     def setUp(self):
@@ -106,10 +119,36 @@ class TestFunctioncalls(TestCase):
 
         for data, fake_data in zip(micro_sims_output, self.fake_write_data):
             self.assertEqual(data["micro-scalar-data"], 2)
+
             self.assertListEqual(
                 data["micro-vector-data"].tolist(),
                 (fake_data["micro-vector-data"] + 1).tolist(),
             )
+
+    def test_crash_handling(self):
+        """
+        Test if the micro manager catches a simulation crash and handles it adequately.
+        """
+        manager = micro_manager.MicroManager('micro-manager-config.json')
+        manager._local_number_of_sims = 4
+        manager._micro_sims = [MicroSimulation(i, crashing = True) for i in range(4)]
+        manager._micro_sims_active_steps = np.zeros(4, dtype=np.int32)
+        # Momentarily, a simulation crash during the first step is not handled
+        micro_sims_output = manager._solve_micro_simulations(self.fake_read_data)
+        for i, data in enumerate(micro_sims_output):
+            self.fake_read_data[i]["macro-scalar-data"] = data["micro-scalar-data"]
+            self.fake_read_data[i]["macro-vector-data"] = data["micro-vector-data"]
+        micro_sims_output = manager._solve_micro_simulations(self.fake_read_data)
+        # The crashed simulation should have the same data as the previous step
+        data_crashed = micro_sims_output[0]
+        self.assertEqual(data_crashed["micro-scalar-data"], 2)
+        self.assertListEqual(data_crashed["micro-vector-data"].tolist(),
+                                (self.fake_write_data[0]["micro-vector-data"] + 1).tolist())
+        # Non-crashed simulations should have updated data
+        data_normal = micro_sims_output[1]
+        self.assertEqual(data_normal["micro-scalar-data"], 3)
+        self.assertListEqual(data_normal["micro-vector-data"].tolist(),
+                                (self.fake_write_data[1]["micro-vector-data"] + 2).tolist())
 
     def test_config(self):
         """

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -115,7 +115,6 @@ class TestFunctioncalls(TestCase):
 
         for data, fake_data in zip(micro_sims_output, self.fake_write_data):
             self.assertEqual(data["micro-scalar-data"], 2)
-<<<<<<< HEAD
 
             self.assertListEqual(
                 data["micro-vector-data"].tolist(),
@@ -146,10 +145,6 @@ class TestFunctioncalls(TestCase):
         self.assertEqual(data_normal["micro-scalar-data"], 3)
         self.assertListEqual(data_normal["micro-vector-data"].tolist(),
                                 (self.fake_write_data[1]["micro-vector-data"] + 2).tolist())
-=======
-            self.assertListEqual(data["micro-vector-data"].tolist(),
-                                 (fake_data["micro-vector-data"] + 1).tolist())
->>>>>>> 12a60fc (Add tests for simulation crashes)
 
     def test_config(self):
         """

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -7,13 +7,9 @@ import micro_manager
 
 
 class MicroSimulation:
-    def __init__(self, sim_id, crashing=False):
+    def __init__(self, sim_id):
         self.very_important_value = 0
-        self.sim_id = sim_id
-        self.crashing = crashing
-        self.current_time = 0
 
-        
     def initialize(self):
         pass
 
@@ -106,7 +102,7 @@ class TestFunctioncalls(TestCase):
                 fake_data["macro-vector-data"].tolist(),
             )
 
-    def test_solve_micro_sims(self):
+    def test_solve_mico_sims(self):
         """
         Test if the internal function _solve_micro_simulations works as expected.
         """
@@ -119,6 +115,7 @@ class TestFunctioncalls(TestCase):
 
         for data, fake_data in zip(micro_sims_output, self.fake_write_data):
             self.assertEqual(data["micro-scalar-data"], 2)
+<<<<<<< HEAD
 
             self.assertListEqual(
                 data["micro-vector-data"].tolist(),
@@ -149,6 +146,10 @@ class TestFunctioncalls(TestCase):
         self.assertEqual(data_normal["micro-scalar-data"], 3)
         self.assertListEqual(data_normal["micro-vector-data"].tolist(),
                                 (self.fake_write_data[1]["micro-vector-data"] + 2).tolist())
+=======
+            self.assertListEqual(data["micro-vector-data"].tolist(),
+                                 (fake_data["micro-vector-data"] + 1).tolist())
+>>>>>>> 12a60fc (Add tests for simulation crashes)
 
     def test_config(self):
         """

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -93,7 +93,7 @@ class TestFunctioncalls(TestCase):
                 fake_data["macro-vector-data"].tolist(),
             )
 
-    def test_solve_mico_sims(self):
+    def test_solve_micro_sims(self):
         """
         Test if the internal function _solve_micro_simulations works as expected.
         """

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -102,7 +102,7 @@ class TestFunctioncalls(TestCase):
                 fake_data["macro-vector-data"].tolist(),
             )
 
-    def test_solve_mico_sims(self):
+    def test_solve_micro_sims(self):
         """
         Test if the internal function _solve_micro_simulations works as expected.
         """

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -1,0 +1,103 @@
+import numpy as np
+from unittest import TestCase
+import micro_manager
+
+
+class MicroSimulation:
+    def __init__(self, sim_id):
+        self.very_important_value = 0
+        self.sim_id = sim_id
+        self.current_time = 0
+
+    def initialize(self):
+        pass
+
+    def solve(self, macro_data, dt):
+        if self.sim_id == 0:
+            self.current_time += dt
+            if self.current_time > dt:
+                raise Exception("Crash")
+
+        return {"micro-scalar-data": macro_data["macro-scalar-data"] + 1,
+                "micro-vector-data": macro_data["macro-vector-data"] + 1}
+
+
+class TestSimulationCrashHandling(TestCase):
+    def setUp(self):
+        self.fake_read_data_names = {
+            "macro-scalar-data": False, "macro-vector-data": True}
+        self.fake_read_data = [{"macro-scalar-data": 1,
+                                "macro-vector-data": np.array([0, 1, 2])}] * 10
+        self.fake_write_data = [{"micro-scalar-data": 1,
+                                 "micro-vector-data": np.array([0, 1, 2]),
+                                 "micro_sim_time": 0,
+                                 "active_state": 0,
+                                 "active_steps": 0}] * 10
+
+    def test_crash_handling(self):
+        """
+        Test if the micro manager catches a simulation crash and handles it adequately.
+        """
+        manager = micro_manager.MicroManager('micro-manager-config_crash.json')
+
+        manager._local_number_of_sims = 10
+        manager._crashed_sims = [False] * 10
+        manager._micro_sims = [MicroSimulation(i) for i in range(10)]
+        manager._micro_sims_active_steps = np.zeros(10, dtype=np.int32)
+        # Crash during first time step has to be handled differently
+
+        micro_sims_output = manager._solve_micro_simulations(
+            self.fake_read_data)
+        for i, data in enumerate(micro_sims_output):
+            self.fake_read_data[i]["macro-scalar-data"] = data["micro-scalar-data"]
+            self.fake_read_data[i]["macro-vector-data"] = data["micro-vector-data"]
+        micro_sims_output = manager._solve_micro_simulations(
+            self.fake_read_data)
+        # The crashed simulation should have the same data as the previous step
+        data_crashed = micro_sims_output[0]
+        self.assertEqual(data_crashed["micro-scalar-data"], 2)
+        self.assertListEqual(data_crashed["micro-vector-data"].tolist(),
+                             (self.fake_write_data[0]["micro-vector-data"] + 1).tolist())
+        # Non-crashed simulations should have updated data
+        data_normal = micro_sims_output[1]
+        self.assertEqual(data_normal["micro-scalar-data"], 3)
+        self.assertListEqual(data_normal["micro-vector-data"].tolist(),
+                             (self.fake_write_data[1]["micro-vector-data"] + 2).tolist())
+
+    def test_crash_handling_with_adaptivity(self):
+        """
+        Test if the micro manager catches a simulation crash and handles it adequately with adaptivity.
+        """
+        manager = micro_manager.MicroManager('micro-manager-config_crash.json')
+
+        manager._local_number_of_sims = 10
+        manager._crashed_sims = [False] * 10
+        manager._micro_sims = [MicroSimulation(i) for i in range(10)]
+        manager._micro_sims_active_steps = np.zeros(10, dtype=np.int32)
+        is_sim_active = np.array(
+            [True, True, False, True, False, False, False, True, True, False,])
+        sim_is_associated_to = np.array([-2, -2, 1, -2, 3, 3, 0, -2, -2, 8])
+        # Crash in the first time step is handled differently
+
+        micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
+            self.fake_read_data, is_sim_active, sim_is_associated_to)
+        for i, data in enumerate(micro_sims_output):
+            self.fake_read_data[i]["macro-scalar-data"] = data["micro-scalar-data"]
+            self.fake_read_data[i]["macro-vector-data"] = data["micro-vector-data"]
+        micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
+            self.fake_read_data, is_sim_active, sim_is_associated_to)
+        # The crashed simulation should have the same data as the previous step
+        data_crashed = micro_sims_output[0]
+        self.assertEqual(data_crashed["micro-scalar-data"], 2)
+        self.assertListEqual(data_crashed["micro-vector-data"].tolist(),
+                             (self.fake_write_data[0]["micro-vector-data"] + 1).tolist())
+        # Non-crashed simulations should have updated data
+        data_normal = micro_sims_output[1]
+        self.assertEqual(data_normal["micro-scalar-data"], 3)
+        self.assertListEqual(data_normal["micro-vector-data"].tolist(),
+                             (self.fake_write_data[1]["micro-vector-data"] + 2).tolist())
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -1,5 +1,7 @@
-import numpy as np
 from unittest import TestCase
+
+import numpy as np
+
 import micro_manager
 import micro_manager.interpolation
 
@@ -25,6 +27,7 @@ class TestSimulationCrashHandling(TestCase):
     def test_crash_handling(self):
         """
         Test if the micro manager catches a simulation crash and handles it adequately.
+        A crash if caught by interpolation within _solve_micro_simulations.
         """
 
         macro_data = []
@@ -38,11 +41,14 @@ class TestSimulationCrashHandling(TestCase):
         manager = micro_manager.MicroManager("micro-manager-config_crash.json")
 
         manager._local_number_of_sims = 4
-        manager._crashed_sims = [False] * 4
+        manager._has_sim_crashed = [False] * 4
         manager._mesh_vertex_coords = np.array(
             [[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]]
         )
         manager._neighbor_list = np.array([[1, 2, 3], [0, 2, 3], [0, 1, 3], [0, 1, 2]])
+        manager._is_adaptivity_on = (
+            False  # make sure adaptivity is off overriding config
+        )
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
 
         micro_sims_output = manager._solve_micro_simulations(macro_data)
@@ -67,6 +73,7 @@ class TestSimulationCrashHandling(TestCase):
     def test_crash_handling_with_adaptivity(self):
         """
         Test if the micro manager catches a simulation crash and handles it adequately with adaptivity.
+        A crash if caught by interpolation within _solve_micro_simulations_with_adaptivity.
         """
 
         macro_data = []
@@ -81,7 +88,7 @@ class TestSimulationCrashHandling(TestCase):
 
         manager._local_number_of_sims = 5
         manager._micro_sims_active_steps = np.zeros(5, dtype=np.int32)
-        manager._crashed_sims = [False] * 5
+        manager._has_sim_crashed = [False] * 5
         manager._mesh_vertex_coords = np.array(
             [[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]]
         )

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -45,7 +45,6 @@ class TestSimulationCrashHandling(TestCase):
         manager._mesh_vertex_coords = np.array(
             [[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]]
         )
-        manager._neighbor_list = np.array([[1, 2, 3], [0, 2, 3], [0, 1, 3], [0, 1, 2]])
         manager._is_adaptivity_on = (
             False  # make sure adaptivity is off overriding config
         )
@@ -53,7 +52,7 @@ class TestSimulationCrashHandling(TestCase):
 
         micro_sims_output = manager._solve_micro_simulations(macro_data)
 
-        # Crashed data has interpolated value
+        # Crashed simulation has interpolated value
         data_crashed = micro_sims_output[2]
         self.assertEqual(data_crashed["micro-scalar-data"], expected_crash_scalar_data)
         self.assertListEqual(
@@ -93,9 +92,6 @@ class TestSimulationCrashHandling(TestCase):
         manager._mesh_vertex_coords = np.array(
             [[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]]
         )
-        manager._neighbor_list = np.array(
-            [[1, 2, 3, 4], [0, 2, 3, 4], [0, 1, 3, 4], [0, 1, 2, 4], [0, 1, 2, 3]]
-        )
         manager._micro_sims = [MicroSimulation(i) for i in range(5)]
 
         is_sim_active = np.array([True, True, True, True, False])
@@ -104,7 +100,7 @@ class TestSimulationCrashHandling(TestCase):
             macro_data, is_sim_active, sim_is_associated_to
         )
 
-        # Crashed data has interpolated value
+        # Crashed simulation has interpolated value
         data_crashed = micro_sims_output[2]
         self.assertEqual(data_crashed["micro-scalar-data"], expected_crash_scalar_data)
         self.assertListEqual(

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -26,7 +26,7 @@ class MicroSimulation:
 class TestSimulationCrashHandling(TestCase):
     def test_crash_handling(self):
         """
-        Test if the micro manager catches a simulation crash and handles it adequately.
+        Test if the Micro Manager catches a simulation crash and handles it adequately.
         A crash if caught by interpolation within _solve_micro_simulations.
         """
 

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -1,103 +1,121 @@
 import numpy as np
 from unittest import TestCase
 import micro_manager
+import micro_manager.interpolation
 
 
 class MicroSimulation:
     def __init__(self, sim_id):
-        self.very_important_value = 0
         self.sim_id = sim_id
-        self.current_time = 0
 
     def initialize(self):
         pass
 
     def solve(self, macro_data, dt):
-        if self.sim_id == 0:
-            self.current_time += dt
-            if self.current_time > dt:
-                raise Exception("Crash")
+        if self.sim_id == 2:
+            raise Exception("Simulation experienced a crash")
 
-        return {"micro-scalar-data": macro_data["macro-scalar-data"] + 1,
-                "micro-vector-data": macro_data["macro-vector-data"] + 1}
+        return {
+            "micro-vector-data": macro_data["macro-vector-data"],
+            "micro-scalar-data": macro_data["macro-scalar-data"],
+        }
 
 
 class TestSimulationCrashHandling(TestCase):
-    def setUp(self):
-        self.fake_read_data_names = {
-            "macro-scalar-data": False, "macro-vector-data": True}
-        self.fake_read_data = [{"macro-scalar-data": 1,
-                                "macro-vector-data": np.array([0, 1, 2])}] * 10
-        self.fake_write_data = [{"micro-scalar-data": 1,
-                                 "micro-vector-data": np.array([0, 1, 2]),
-                                 "micro_sim_time": 0,
-                                 "active_state": 0,
-                                 "active_steps": 0}] * 10
-
     def test_crash_handling(self):
         """
         Test if the micro manager catches a simulation crash and handles it adequately.
         """
-        manager = micro_manager.MicroManager('micro-manager-config_crash.json')
 
-        manager._local_number_of_sims = 10
-        manager._crashed_sims = [False] * 10
-        manager._micro_sims = [MicroSimulation(i) for i in range(10)]
-        manager._micro_sims_active_steps = np.zeros(10, dtype=np.int32)
-        # Crash during first time step has to be handled differently
+        macro_data = []
+        for i in [-2, -1, 1, 2]:
+            macro_data.append(
+                {"macro-vector-data": np.array([i, i, i]), "macro-scalar-data": [i]}
+            )
+        expected_crash_vector_data = np.array([55 / 49, 55 / 49, 55 / 49])
+        expected_crash_scalar_data = 55 / 49
 
-        micro_sims_output = manager._solve_micro_simulations(
-            self.fake_read_data)
-        for i, data in enumerate(micro_sims_output):
-            self.fake_read_data[i]["macro-scalar-data"] = data["micro-scalar-data"]
-            self.fake_read_data[i]["macro-vector-data"] = data["micro-vector-data"]
-        micro_sims_output = manager._solve_micro_simulations(
-            self.fake_read_data)
-        # The crashed simulation should have the same data as the previous step
-        data_crashed = micro_sims_output[0]
-        self.assertEqual(data_crashed["micro-scalar-data"], 2)
-        self.assertListEqual(data_crashed["micro-vector-data"].tolist(),
-                             (self.fake_write_data[0]["micro-vector-data"] + 1).tolist())
-        # Non-crashed simulations should have updated data
+        manager = micro_manager.MicroManager("micro-manager-config_crash.json")
+
+        manager._local_number_of_sims = 4
+        manager._crashed_sims = [False] * 4
+        manager._mesh_vertex_coords = np.array(
+            [[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]]
+        )
+        manager._neighbor_list = np.array([[1, 2, 3], [0, 2, 3], [0, 1, 3], [0, 1, 2]])
+        manager._micro_sims = [MicroSimulation(i) for i in range(4)]
+
+        micro_sims_output = manager._solve_micro_simulations(macro_data)
+
+        # Crashed data has interpolated value
+        data_crashed = micro_sims_output[2]
+        self.assertEqual(data_crashed["micro-scalar-data"], expected_crash_scalar_data)
+        self.assertListEqual(
+            data_crashed["micro-vector-data"].tolist(),
+            expected_crash_vector_data.tolist(),
+        )
+        # Non-crashed simulations should remain constant
         data_normal = micro_sims_output[1]
-        self.assertEqual(data_normal["micro-scalar-data"], 3)
-        self.assertListEqual(data_normal["micro-vector-data"].tolist(),
-                             (self.fake_write_data[1]["micro-vector-data"] + 2).tolist())
+        self.assertEqual(
+            data_normal["micro-scalar-data"], macro_data[1]["macro-scalar-data"]
+        )
+        self.assertListEqual(
+            data_normal["micro-vector-data"].tolist(),
+            macro_data[1]["macro-vector-data"].tolist(),
+        )
 
     def test_crash_handling_with_adaptivity(self):
         """
         Test if the micro manager catches a simulation crash and handles it adequately with adaptivity.
         """
-        manager = micro_manager.MicroManager('micro-manager-config_crash.json')
 
-        manager._local_number_of_sims = 10
-        manager._crashed_sims = [False] * 10
-        manager._micro_sims = [MicroSimulation(i) for i in range(10)]
-        manager._micro_sims_active_steps = np.zeros(10, dtype=np.int32)
-        is_sim_active = np.array(
-            [True, True, False, True, False, False, False, True, True, False])
-        sim_is_associated_to = np.array([-2, -2, 1, -2, 3, 3, 0, -2, -2, 8])
-        # Crash in the first time step is handled differently
+        macro_data = []
+        for i in [-2, -1, 1, 2, 10]:
+            macro_data.append(
+                {"macro-vector-data": np.array([i, i, i]), "macro-scalar-data": [i]}
+            )
+        expected_crash_vector_data = np.array([55 / 49, 55 / 49, 55 / 49])
+        expected_crash_scalar_data = 55 / 49
 
+        manager = micro_manager.MicroManager("micro-manager-config_crash.json")
+
+        manager._local_number_of_sims = 5
+        manager._micro_sims_active_steps = np.zeros(5, dtype=np.int32)
+        manager._crashed_sims = [False] * 5
+        manager._mesh_vertex_coords = np.array(
+            [[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]]
+        )
+        manager._neighbor_list = np.array(
+            [[1, 2, 3, 4], [0, 2, 3, 4], [0, 1, 3, 4], [0, 1, 2, 4], [0, 1, 2, 3]]
+        )
+        manager._micro_sims = [MicroSimulation(i) for i in range(5)]
+
+        is_sim_active = np.array([True, True, True, True, False])
+        sim_is_associated_to = np.array([-2, -2, -2, -2, 2])
         micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
-            self.fake_read_data, is_sim_active, sim_is_associated_to)
-        for i, data in enumerate(micro_sims_output):
-            self.fake_read_data[i]["macro-scalar-data"] = data["micro-scalar-data"]
-            self.fake_read_data[i]["macro-vector-data"] = data["micro-vector-data"]
-        micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
-            self.fake_read_data, is_sim_active, sim_is_associated_to)
-        # The crashed simulation should have the same data as the previous step
-        data_crashed = micro_sims_output[0]
-        self.assertEqual(data_crashed["micro-scalar-data"], 2)
-        self.assertListEqual(data_crashed["micro-vector-data"].tolist(),
-                             (self.fake_write_data[0]["micro-vector-data"] + 1).tolist())
-        # Non-crashed simulations should have updated data
-        data_normal = micro_sims_output[1]
-        self.assertEqual(data_normal["micro-scalar-data"], 3)
-        self.assertListEqual(data_normal["micro-vector-data"].tolist(),
-                             (self.fake_write_data[1]["micro-vector-data"] + 2).tolist())
+            macro_data, is_sim_active, sim_is_associated_to
+        )
+
+        # Crashed data has interpolated value
+        data_crashed = micro_sims_output[2]
+        self.assertEqual(data_crashed["micro-scalar-data"], expected_crash_scalar_data)
+        self.assertListEqual(
+            data_crashed["micro-vector-data"].tolist(),
+            expected_crash_vector_data.tolist(),
+        )
+
+        # Inactive simulation that is associated with crashed simulation has same value
+        data_associated = micro_sims_output[4]
+        self.assertEqual(
+            data_associated["micro-scalar-data"], expected_crash_scalar_data
+        )
+        self.assertListEqual(
+            data_associated["micro-vector-data"].tolist(),
+            expected_crash_vector_data.tolist(),
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import unittest
+
     unittest.main()

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -75,7 +75,7 @@ class TestSimulationCrashHandling(TestCase):
         manager._micro_sims = [MicroSimulation(i) for i in range(10)]
         manager._micro_sims_active_steps = np.zeros(10, dtype=np.int32)
         is_sim_active = np.array(
-            [True, True, False, True, False, False, False, True, True, False,])
+            [True, True, False, True, False, False, False, True, True, False])
         sim_is_associated_to = np.array([-2, -2, 1, -2, 3, 3, 0, -2, -2, 8])
         # Crash in the first time step is handled differently
 

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -39,7 +39,7 @@ class TestSimulationCrashHandling(TestCase):
         expected_crash_scalar_data = 55 / 49
 
         manager = micro_manager.MicroManager("micro-manager-config_crash.json")
-
+        manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
         manager._local_number_of_sims = 4
         manager._has_sim_crashed = [False] * 4
         manager._mesh_vertex_coords = np.array(
@@ -86,6 +86,7 @@ class TestSimulationCrashHandling(TestCase):
 
         manager = micro_manager.MicroManager("micro-manager-config_crash.json")
 
+        manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
         manager._local_number_of_sims = 5
         manager._micro_sims_active_steps = np.zeros(5, dtype=np.int32)
         manager._has_sim_crashed = [False] * 5


### PR DESCRIPTION
This is an attempt to solve issue #74.
This cannot be a permanent solution to the handling of crashing simulation. If a simulation crashes during the first time step, it is replaced with data from another random simulation. In the long run, I don't see any other solution than an interpolation (in cases where only one simulation is given and it cannot be replaced by one of different complexity).
Moreover, it has not been tested with real simulations, in parallel, or using spack.