### PR TITLE
Minor improvements: fix typo in test, remove redundant code and replace __import__

### DIFF
--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -19,6 +19,7 @@ from mpi4py import MPI
 import numpy as np
 import logging
 import time
+import importlib
 from copy import deepcopy
 from typing import Dict
 from warnings import warn
@@ -70,8 +71,6 @@ class MicroManager:
             self._config.get_config_file_name(),
             self._rank,
             self._size)
-
-        micro_file_name = self._config.get_micro_file_name()
 
         self._macro_mesh_name = self._config.get_macro_mesh_name()
 
@@ -309,9 +308,9 @@ class MicroManager:
         self._micro_sims = [None] * self._local_number_of_sims  # DECLARATION
 
         micro_problem = getattr(
-            __import__(
+            importlib.import_module(
                 self._config.get_micro_file_name(),
-                fromlist=["MicroSimulation"]),
+                "MicroSimulation"),
             "MicroSimulation")
 
         # Create micro simulation objects

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -75,7 +75,7 @@ class TestFunctioncalls(TestCase):
             self.assertListEqual(data["macro-vector-data"].tolist(),
                                  fake_data["macro-vector-data"].tolist())
 
-    def test_solve_mico_sims(self):
+    def test_solve_micro_sims(self):
         """
         Test if the internal function _solve_micro_simulations works as expected.
         """


### PR DESCRIPTION
The [documentation of `__import__()`](https://docs.python.org/3/library/functions.html#import__) states that "Direct use of `__import__()` is [...] discouraged in favor of importlib.import_module()"