### PR TITLE
TBD: Follow time stepping proposed in documentation

### DIFF
--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -173,6 +173,9 @@ class MicroManager:
                 )
 
         while self._participant.is_coupling_ongoing():
+
+            self._dt = self._participant.get_max_time_step_size()  # ask preCICE at beginning of time step for allowed time step size
+
             # Write a checkpoint
             if self._participant.requires_writing_checkpoint():
                 for i in range(self._local_number_of_sims):
@@ -256,11 +259,9 @@ class MicroManager:
 
             self._write_data_to_precice(micro_sims_output)
 
-            self._participant.advance(self._dt)
-            self._dt = self._participant.get_max_time_step_size()
-
-            t += self._dt
-            n += 1
+            t += self._dt  # increase internal time when time step is done.
+            n += 1  # increase counter
+            self._participant.advance(self._dt)  # notify preCICE that time step of size self._dt is complete
 
             # Revert micro simulations to their last checkpoints if required
             if self._participant.requires_reading_checkpoint():

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -174,7 +174,9 @@ class MicroManager:
 
         while self._participant.is_coupling_ongoing():
 
-            self._dt = self._participant.get_max_time_step_size()  # ask preCICE at beginning of time step for allowed time step size
+            self._dt = (
+                self._participant.get_max_time_step_size()
+            )  # ask preCICE at beginning of time step for allowed time step size
 
             # Write a checkpoint
             if self._participant.requires_writing_checkpoint():
@@ -261,7 +263,9 @@ class MicroManager:
 
             t += self._dt  # increase internal time when time step is done.
             n += 1  # increase counter
-            self._participant.advance(self._dt)  # notify preCICE that time step of size self._dt is complete
+            self._participant.advance(
+                self._dt
+            )  # notify preCICE that time step of size self._dt is complete
 
             # Revert micro simulations to their last checkpoints if required
             if self._participant.requires_reading_checkpoint():


### PR DESCRIPTION
In the step-by-step guide on precice.org it is suggested to get the maximum allowed time step size from preCICE before calling advance.

To me it looks dangerous how things are done at the moment, because actually the following is happening:

```
self._participant.advance(self._dt)
self._dt = self._participant.get_max_time_step_size()

t += self._dt
n += 1
```
We tell preCICE "I just finished window `n` with time step size `self._dt`, but then update the internal time `t` by the step size of the **upcoming** window. I always prefer to first do all the updates and then call advance:

```
self._dt = self._participant.get_max_time_step_size()    # assuming this has been called at the beginning of the current time step
...
# time step is finished, update internal counters
t += self._dt 
n += 1

self._participant.advance(self._dt)  # tell preCICE: I'm done and ready to go to the next time step / iteration
```
This should generally also work with subcycling and/or the participant-first method (no guarantee, because this needs testing and is always easy to break, if hard-to-spot errors are in the code)
