### PR TITLE
Add feature to find similarity tolerances automatically

### DIFF
--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -227,7 +227,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         _sim_is_associated_to : numpy array
             1D array with values of associated simulations of inactive simulations. Active simulations have None
         """
-        self._ref_tol = self._refine_const * np.amax(similarity_dists)
+        # self._ref_tol = self._refine_const * np.amax(similarity_dists)
+        self._ref_tol = self._get_activate_distance(similarity_dists, is_sim_active)
 
         _is_sim_active = np.copy(
             is_sim_active

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -118,7 +118,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         _sim_is_associated_to : numpy array
             1D array with values of associated simulations of inactive simulations. Active simulations have None
         """
-        self._ref_tol = self._refine_const * np.amax(similarity_dists)
+        # self._ref_tol = self._refine_const * np.amax(similarity_dists)
+        self._ref_tol = self._get_activate_distance(similarity_dists, is_sim_active)
 
         _is_sim_active = np.copy(
             is_sim_active


### PR DESCRIPTION
Currently the similarity distances are computed as `max(similarity_distances)*coarsening_constant` or `max(similarity_distances)*coarsening_constant*refining_constant`. 
With #64, it requires less active micro-scale simulations per iteration, but sometimes much more iterations to converge when important micro-scale simulations are missed by the stricter similarity condition.

In this PR, the two similarity distances are located by looking for the max-gap in the 1D distance array which is ascending sorted. 
The distances could be weighted by a factor which is the exponential function of the right end distance of each gap. The exponent could be constant or some varying value computed from convergence status.

With the tests, this method could locate the threshold values relatively well:
with different adaptivity constants, the runtime varied between 150s to more than 2400s. With this method it took respectively (power = 0,5) 206s and (power = 0,7) 163s. 

In these tests only the runtime is compared, not the accuracy. Local adaptivity and serial run for micro-simulations are used.

ToDo:
- [ ] compute the tolerances only one time in each iteration;
- [ ] test with parallelized micro-scale
- [ ] accuracy and convergence study
