### PR TITLE
Add base class for Micro Manager and restructure main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Add base class, rename `MicroManager` to `MicroManagerCoupling` and change setup of the main class https://github.com/precice/micro-manager/pull/111
 - Handle calling `initialize()` function of micro simulations written in languages other than Python https://github.com/precice/micro-manager/pull/110
 - Check if initial data returned from the micro simulation is the data that the adaptivity computation requires https://github.com/precice/micro-manager/pull/109
 - Use executable `micro-manager-precice` by default, and stop using the script `run_micro_manager.py` https://github.com/precice/micro-manager/pull/105

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-- Add base class, rename `MicroManager` to `MicroManagerCoupling` and change setup of the main class https://github.com/precice/micro-manager/pull/111
+- Add a base class called `MicroManager` with minimal API and member function definitions, rename the existing `MicroManager` class to `MicroManagerCoupling` https://github.com/precice/micro-manager/pull/111
 - Handle calling `initialize()` function of micro simulations written in languages other than Python https://github.com/precice/micro-manager/pull/110
 - Check if initial data returned from the micro simulation is the data that the adaptivity computation requires https://github.com/precice/micro-manager/pull/109
 - Use executable `micro-manager-precice` by default, and stop using the script `run_micro_manager.py` https://github.com/precice/micro-manager/pull/105

--- a/micro_manager/__init__.py
+++ b/micro_manager/__init__.py
@@ -2,7 +2,7 @@ import argparse
 import os
 
 from .config import Config
-from .micro_manager import MicroManager
+from .micro_manager import MicroManagerCoupling
 
 
 def main():
@@ -16,7 +16,7 @@ def main():
     if not os.path.isabs(config_file_path):
         config_file_path = os.getcwd() + "/" + config_file_path
 
-    manager = MicroManager(config_file_path)
+    manager = MicroManagerCoupling(config_file_path)
 
     manager.initialize()
 

--- a/micro_manager/__init__.py
+++ b/micro_manager/__init__.py
@@ -1,2 +1,23 @@
+import argparse
+import os
+
 from .config import Config
 from .micro_manager import MicroManager
+
+
+def main():
+    parser = argparse.ArgumentParser(description=".")
+    parser.add_argument(
+        "config_file", type=str, help="Path to the JSON config file of the manager."
+    )
+
+    args = parser.parse_args()
+    config_file_path = args.config_file
+    if not os.path.isabs(config_file_path):
+        config_file_path = os.getcwd() + "/" + config_file_path
+
+    manager = MicroManager(config_file_path)
+
+    manager.initialize()
+
+    manager.solve()

--- a/micro_manager/__init__.py
+++ b/micro_manager/__init__.py
@@ -5,7 +5,7 @@ from .config import Config
 from .micro_manager import MicroManagerCoupling
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description=".")
     parser.add_argument(
         "config_file", type=str, help="Path to the JSON config file of the manager."

--- a/micro_manager/__main__.py
+++ b/micro_manager/__main__.py
@@ -1,0 +1,3 @@
+from micro_manager import main
+
+main()

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -5,13 +5,12 @@ This files the class MicroManager which has the following callable public method
 
 - solve
 
-This file is directly executable as it consists of a main() function. Upon execution, an object of the class MicroManager is created using a given JSON file,
+This file is executable via __main__.py. Upon execution, an object of the class MicroManager is created using a given JSON file,
 and the initialize and solve methods are called.
 
 Detailed documentation: https://precice.org/tooling-micro-manager-overview.html
 """
 
-import argparse
 import importlib
 import logging
 import os
@@ -943,25 +942,3 @@ class MicroManager:
             output_interpol["active_state"] = 1
             output_interpol["active_steps"] = self._micro_sims_active_steps[unset_sim]
         return output_interpol
-
-
-def main():
-    parser = argparse.ArgumentParser(description=".")
-    parser.add_argument(
-        "config_file", type=str, help="Path to the JSON config file of the manager."
-    )
-
-    args = parser.parse_args()
-    config_file_path = args.config_file
-    if not os.path.isabs(config_file_path):
-        config_file_path = os.getcwd() + "/" + config_file_path
-
-    manager = MicroManager(config_file_path)
-
-    manager.initialize()
-
-    manager.solve()
-
-
-if __name__ == "__main__":
-    main()

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -23,7 +23,6 @@ from warnings import warn
 
 import numpy as np
 import precice
-from mpi4py import MPI
 
 from .micro_manager_base import MicroManager
 from .adaptivity.global_adaptivity import GlobalAdaptivityCalculator

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -6,7 +6,7 @@ This files the class MicroManager which has the following callable public method
 - solve
 - initialize
 
-This file is executable via __main__.py. Upon execution, an object of the class MicroManager is created using a given JSON file,
+Upon execution, an object of the class MicroManager is created using a given JSON file,
 and the initialize and solve methods are called.
 
 Detailed documentation: https://precice.org/tooling-micro-manager-overview.html

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+The Micro Manager abstract base class and base class provide an interface for Micro Manager
+classes and an implementation for the common functionalities of its subclasses (MicroManagerCoupling), respectively.
+The base class should not be executed on its own. It is meant to be inherited by MicroManagerCoupling.
+
+For more details see the MicroManagerCoupling class or the documentation at https://precice.org/tooling-micro-manager-overview.html.
+"""
+from mpi4py import MPI
+import logging
+from abc import ABC, abstractmethod
+
+from .config import Config
+
+
+class MicroManagerAbstract(ABC):
+    """
+    Abstract base class of Micro Manager classes. Defines interface for Micro Manager classes.
+    """
+
+    @abstractmethod
+    def initialize(self):
+        """
+        Initialize micro simulations.
+        """
+        pass
+
+    @abstractmethod
+    def solve(self):
+        """
+        Solve micro simulations.
+        """
+        pass
+
+
+class MicroManager(MicroManagerAbstract):
+    """
+    Micro Manager base class provides common functionalities for its subclasses.
+    """
+
+    def __init__(self, config_file):
+        """
+        Constructor. Initializes member variables and logger shared between all subclasses.
+
+        Parameters
+        ----------
+        config_file : string
+            Name of the JSON configuration file (provided by the user).
+        """
+        self._comm = MPI.COMM_WORLD
+        self._rank = self._comm.Get_rank()
+        self._size = self._comm.Get_size()
+
+        self._logger = logging.getLogger(__name__)
+        self._logger.setLevel(level=logging.INFO)
+
+        # Create file handler which logs messages
+        fh = logging.FileHandler("micro-manager.log")
+        fh.setLevel(logging.INFO)
+
+        # Create formatter and add it to handlers
+        formatter = logging.Formatter(
+            "[" + str(self._rank) + "] %(name)s -  %(levelname)s - %(message)s"
+        )
+        fh.setFormatter(formatter)
+        self._logger.addHandler(fh)  # add the handlers to the logger
+
+        self._is_parallel = self._size > 1
+        self._micro_sims_have_output = False
+
+        self._local_number_of_sims = 0
+        self._global_number_of_sims = 0
+        self._is_rank_empty = False
+
+        self._logger.info("Provided configuration file: {}".format(config_file))
+        self._config = Config(self._logger, config_file)
+
+    def initialize(self):
+        """
+        Initialize micro simulations. Not implemented
+        """
+        raise NotImplementedError(
+            "Initialization of micro simulations is not implemented in base class"
+        )
+
+    def solve(self):
+        """
+        Solve micro simulations. Not implemented
+        """
+        raise NotImplementedError(
+            "Solving micro simulations is not implemented in base class"
+        )

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """
-The Micro Manager abstract base class and base class provide an interface for Micro Manager
-classes and an implementation for the common functionalities of its subclasses (MicroManagerCoupling), respectively.
+The Micro Manager abstract base class and base class provide an interface its subclasses.
+The Micro Manager base class handles initialization shared by its subclasses (MicroManagerCoupling), respectively.
 The base class should not be executed on its own. It is meant to be inherited by MicroManagerCoupling.
 
 For more details see the MicroManagerCoupling class or the documentation at https://precice.org/tooling-micro-manager-overview.html.
 """
+
 from mpi4py import MPI
 import logging
 from abc import ABC, abstractmethod

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-The Micro Manager abstract base class and base class provide an interface its subclasses.
-The Micro Manager base class handles initialization shared by its subclasses (MicroManagerCoupling), respectively.
+The Micro Manager abstract base class provides an interface for its subclasses.
+The Micro Manager base class handles initialization shared by its subclasses (MicroManagerCoupling).
 The base class should not be executed on its own. It is meant to be inherited by MicroManagerCoupling.
 
 For more details see the MicroManagerCoupling class or the documentation at https://precice.org/tooling-micro-manager-overview.html.
@@ -14,7 +14,7 @@ from abc import ABC, abstractmethod
 from .config import Config
 
 
-class MicroManagerAbstract(ABC):
+class MicroManagerInterface(ABC):
     """
     Abstract base class of Micro Manager classes. Defines interface for Micro Manager classes.
     """
@@ -34,7 +34,7 @@ class MicroManagerAbstract(ABC):
         pass
 
 
-class MicroManager(MicroManagerAbstract):
+class MicroManager(MicroManagerInterface):
     """
     Micro Manager base class provides common functionalities for its subclasses.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Repository = "https://github.com/precice/micro-manager"
 "Bug Tracker" = "https://github.com/precice/micro-manager/issues"
 
 [project.scripts]
-micro-manager-precice = "micro_manager.micro_manager:main"
+micro-manager-precice = "micro_manager:main"
 
 [tool.setuptools]
 packages=["micro_manager", "micro_manager.adaptivity"]

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -53,7 +53,7 @@ class TestFunctioncalls(TestCase):
         """
         Test if the constructor of the MicroManager class passes correct values to member variables.
         """
-        manager = micro_manager.MicroManager("micro-manager-config.json")
+        manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
 
         self.assertListEqual(manager._macro_bounds, self.macro_bounds)
         self.assertDictEqual(manager._read_data_names, self.fake_read_data_names)
@@ -64,7 +64,7 @@ class TestFunctioncalls(TestCase):
         """
         Test if the initialize function of the MicroManager class initializes member variables to correct values
         """
-        manager = micro_manager.MicroManager("micro-manager-config.json")
+        manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
         manager.initialize()
 
         self.assertEqual(manager._dt, 0.1)  # from Interface.initialize
@@ -82,7 +82,7 @@ class TestFunctioncalls(TestCase):
         """
         Test if the internal functions _read_data_from_precice and _write_data_to_precice work as expected.
         """
-        manager = micro_manager.MicroManager("micro-manager-config.json")
+        manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
 
         manager._write_data_to_precice(self.fake_write_data)
         read_data = manager._read_data_from_precice()
@@ -98,7 +98,7 @@ class TestFunctioncalls(TestCase):
         """
         Test if the internal function _solve_micro_simulations works as expected.
         """
-        manager = micro_manager.MicroManager("micro-manager-config.json")
+        manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
         manager.initialize()
 
         manager._local_number_of_sims = 4

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 import numpy as np
 
 import micro_manager
-import micro_manager.interpolation
 
 
 class MicroSimulation:
@@ -38,7 +37,7 @@ class TestSimulationCrashHandling(TestCase):
         expected_crash_vector_data = np.array([55 / 49, 55 / 49, 55 / 49])
         expected_crash_scalar_data = 55 / 49
 
-        manager = micro_manager.MicroManager("micro-manager-config_crash.json")
+        manager = micro_manager.MicroManagerCoupling("micro-manager-config_crash.json")
         manager.initialize()
 
         manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
@@ -85,7 +84,7 @@ class TestSimulationCrashHandling(TestCase):
         expected_crash_vector_data = np.array([55 / 49, 55 / 49, 55 / 49])
         expected_crash_scalar_data = 55 / 49
 
-        manager = micro_manager.MicroManager("micro-manager-config_crash.json")
+        manager = micro_manager.MicroManagerCoupling("micro-manager-config_crash.json")
         manager.initialize()
 
         manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3


### PR DESCRIPTION
In preparation for the Snapshot computation #101 this PR adds base classes to reduce code repetitions. This introduces a new interface class `MicroManagerInterface`, a base class `MicroManager` and renames the original `MicroManager` class in `MicroManagerCoupling`. The PR also changes the structure and position of the `main`-method to allow snapshot execution via a flag as suggested in #101. 

This is also done with the idea to extend this base class in a potential future restructuting process of the `MicroManagerCoupling` class. 

Feedback on how to implement the base classes in clean way is highly apprecitated  as I wasn't able to find examples or best practices regarding this scenario, in which a base class handles part of a constrcutor. 

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
