### PR TITLE
Set initial time window size of the micro simulation in the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-- Set initial time window size of micro simulation in the configuration, and use it in the coupling https://github.com/precice/micro-manager/pull/112
+- Set time step of micro simulation in the configuration, and use it in the coupling https://github.com/precice/micro-manager/pull/112
 - Add a base class called `MicroManager` with minimal API and member function definitions, rename the existing `MicroManager` class to `MicroManagerCoupling` https://github.com/precice/micro-manager/pull/111
 - Handle calling `initialize()` function of micro simulations written in languages other than Python https://github.com/precice/micro-manager/pull/110
 - Check if initial data returned from the micro simulation is the data that the adaptivity computation requires https://github.com/precice/micro-manager/pull/109

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Set initial time window size of micro simulation in the configuration, and use it in the coupling https://github.com/precice/micro-manager/pull/112
 - Add a base class called `MicroManager` with minimal API and member function definitions, rename the existing `MicroManager` class to `MicroManagerCoupling` https://github.com/precice/micro-manager/pull/111
 - Handle calling `initialize()` function of micro simulations written in languages other than Python https://github.com/precice/micro-manager/pull/110
 - Check if initial data returned from the micro simulation is the data that the adaptivity computation requires https://github.com/precice/micro-manager/pull/109

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ Parameter | Description
 `macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
 `read_data_names` |  A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
 `write_data_names` |  A Python dictionary with the names of the data to be written to preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
-`micro_time_window_size` | Initial time window size (dt) of the micro simulation.
+`micro_dt` | Initial time window size (dt) of the micro simulation.
 
 ## Simulation Parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,8 @@ The Micro Manager is configured with a JSON file. An example configuration file 
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"temperature": "scalar", "heat-flux": "vector"},
-        "write_data_names": {"porosity": "scalar", "conductivity": "vector"}
+        "write_data_names": {"porosity": "scalar", "conductivity": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
@@ -41,6 +42,7 @@ Parameter | Description
 `macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
 `read_data_names` |  A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
 `write_data_names` |  A Python dictionary with the names of the data to be written to preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
+`micro_time_window_size` | Initial time window size (dt) of the micro simulation.
 
 ## Simulation Parameters
 

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -30,6 +30,7 @@ class Config:
         self._macro_mesh_name = None
         self._read_data_names = dict()
         self._write_data_names = dict()
+        self._micro_time_window = None
 
         self._macro_domain_bounds = None
         self._ranks_per_axis = None
@@ -122,6 +123,8 @@ class Config:
             self._logger.info(
                 "Domain decomposition is not specified, so the Micro Manager will expect to be run in serial."
             )
+
+        self._micro_time_window = data["simulation_params"]["micro_time_window_size"]
 
         try:
             if data["simulation_params"]["adaptivity"] == "True":
@@ -431,3 +434,14 @@ class Config:
             True if adaptivity needs to be calculated in every time iteration, False otherwise.
         """
         return self._adaptivity_every_implicit_iteration
+
+    def get_micro_time_window(self):
+        """
+        Get the size of the micro time window.
+
+        Returns
+        -------
+        micro_time_window : float
+            Size of the micro time window.
+        """
+        return self._micro_time_window

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -30,7 +30,7 @@ class Config:
         self._macro_mesh_name = None
         self._read_data_names = dict()
         self._write_data_names = dict()
-        self._micro_time_window_size = None
+        self._micro_dt = None
 
         self._macro_domain_bounds = None
         self._ranks_per_axis = None
@@ -115,7 +115,7 @@ class Config:
                 "No read data names provided. Micro manager will only write data to preCICE."
             )
 
-        self._micro_time_window_size = data["coupling_params"]["micro_time_window_size"]
+        self._micro_dt = data["coupling_params"]["micro_dt"]
 
         self._macro_domain_bounds = data["simulation_params"]["macro_domain_bounds"]
 
@@ -435,7 +435,7 @@ class Config:
         """
         return self._adaptivity_every_implicit_iteration
 
-    def get_micro_time_window_size(self):
+    def get_micro_dt(self):
         """
         Get the size of the micro time window.
 
@@ -444,4 +444,4 @@ class Config:
         micro_time_window : float
             Size of the micro time window.
         """
-        return self._micro_time_window_size
+        return self._micro_dt

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -30,7 +30,7 @@ class Config:
         self._macro_mesh_name = None
         self._read_data_names = dict()
         self._write_data_names = dict()
-        self._micro_time_window = None
+        self._micro_time_window_size = None
 
         self._macro_domain_bounds = None
         self._ranks_per_axis = None
@@ -115,6 +115,8 @@ class Config:
                 "No read data names provided. Micro manager will only write data to preCICE."
             )
 
+        self._micro_time_window_size = data["coupling_params"]["micro_time_window_size"]
+
         self._macro_domain_bounds = data["simulation_params"]["macro_domain_bounds"]
 
         try:
@@ -123,8 +125,6 @@ class Config:
             self._logger.info(
                 "Domain decomposition is not specified, so the Micro Manager will expect to be run in serial."
             )
-
-        self._micro_time_window = data["simulation_params"]["micro_time_window_size"]
 
         try:
             if data["simulation_params"]["adaptivity"] == "True":
@@ -435,7 +435,7 @@ class Config:
         """
         return self._adaptivity_every_implicit_iteration
 
-    def get_micro_time_window(self):
+    def get_micro_time_window_size(self):
         """
         Get the size of the micro time window.
 
@@ -444,4 +444,4 @@ class Config:
         micro_time_window : float
             Size of the micro time window.
         """
-        return self._micro_time_window
+        return self._micro_time_window_size

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -426,7 +426,7 @@ class MicroManagerCoupling(MicroManager):
         self._micro_sims_init = False  # DECLARATION
 
         # Read initial data from preCICE, if it is available
-        initial_data = self._read_data_from_precice(dt=self._micro_dt)
+        initial_data = self._read_data_from_precice(dt=0)
 
         if not initial_data:
             is_initial_data_available = False

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -196,7 +196,7 @@ class MicroManagerCoupling(MicroManager):
                     for active_id in active_sim_ids:
                         self._micro_sims_active_steps[active_id] += 1
 
-            micro_sims_input = self._read_data_from_precice()
+            micro_sims_input = self._read_data_from_precice(dt)
 
             if self._is_adaptivity_on:
                 if self._adaptivity_in_every_implicit_step:
@@ -426,7 +426,7 @@ class MicroManagerCoupling(MicroManager):
         self._micro_sims_init = False  # DECLARATION
 
         # Read initial data from preCICE, if it is available
-        initial_data = self._read_data_from_precice()
+        initial_data = self._read_data_from_precice(dt=self._micro_dt)
 
         if not initial_data:
             is_initial_data_available = False

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -76,7 +76,7 @@ class MicroManager(MicroManagerInterface):
         self._logger.info("Provided configuration file: {}".format(config_file))
         self._config = Config(self._logger, config_file)
 
-        self._micro_dt = self._config.get_micro_time_window()
+        self._micro_dt = self._config.get_micro_time_window_size()
 
     def initialize(self):
         """

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -76,7 +76,7 @@ class MicroManager(MicroManagerInterface):
         self._logger.info("Provided configuration file: {}".format(config_file))
         self._config = Config(self._logger, config_file)
 
-        self._micro_dt = self._config.get_micro_time_window_size()
+        self._micro_dt = self._config.get_micro_dt()
 
     def initialize(self):
         """

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -76,6 +76,8 @@ class MicroManager(MicroManagerInterface):
         self._logger.info("Provided configuration file: {}".format(config_file))
         self._config = Config(self._logger, config_file)
 
+        self._micro_dt = self._config.get_micro_time_window()
+
     def initialize(self):
         """
         Initialize micro simulations. Not implemented

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -4,7 +4,8 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -4,7 +4,8 @@
         "config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_time_window_size": 0.1
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 0.1
+        "micro_dt": 0.1
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -4,7 +4,8 @@
         "config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
+        "micro_time_window_size": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -5,7 +5,7 @@
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_time_window_size": 1.0
+        "micro_dt": 1.0
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -67,7 +67,7 @@ class TestFunctioncalls(TestCase):
         manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
         manager.initialize()
 
-        self.assertEqual(manager._dt, 0.1)  # from Interface.initialize
+        self.assertEqual(manager._micro_dt, 0.1)  # from Interface.initialize
         self.assertEqual(manager._global_number_of_sims, 4)
         self.assertListEqual(manager._macro_bounds, self.macro_bounds)
         self.assertListEqual(manager._mesh_vertex_ids.tolist(), [0, 1, 2, 3])
@@ -85,7 +85,7 @@ class TestFunctioncalls(TestCase):
         manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
 
         manager._write_data_to_precice(self.fake_write_data)
-        read_data = manager._read_data_from_precice()
+        read_data = manager._read_data_from_precice(1.0)
 
         for data, fake_data in zip(read_data, self.fake_read_data):
             self.assertEqual(data["macro-scalar-data"], 1)
@@ -105,7 +105,7 @@ class TestFunctioncalls(TestCase):
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
         manager._micro_sims_active_steps = np.zeros(4, dtype=np.int32)
 
-        micro_sims_output = manager._solve_micro_simulations(self.fake_read_data)
+        micro_sims_output = manager._solve_micro_simulations(self.fake_read_data, 1.0)
 
         for data, fake_data in zip(micro_sims_output, self.fake_write_data):
             self.assertEqual(data["micro-scalar-data"], 2)

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -51,7 +51,7 @@ class TestSimulationCrashHandling(TestCase):
         )
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
 
-        micro_sims_output = manager._solve_micro_simulations(macro_data)
+        micro_sims_output = manager._solve_micro_simulations(macro_data, 1.0)
 
         # Crashed simulation has interpolated value
         data_crashed = micro_sims_output[2]
@@ -99,7 +99,7 @@ class TestSimulationCrashHandling(TestCase):
         is_sim_active = np.array([True, True, True, True, False])
         sim_is_associated_to = np.array([-2, -2, -2, -2, 2])
         micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
-            macro_data, is_sim_active, sim_is_associated_to
+            macro_data, is_sim_active, sim_is_associated_to, 1.0
         )
 
         # Crashed simulation has interpolated value


### PR DESCRIPTION
This PR implements changes which allow for the user to set the initial time window size (dt) of the micro simulation during configuration. The time window size is then using in the coupling, which allows for subcycling. 

**Note**: The micro simulation cannot modify the time window size during the coupling. A followup feature can change the micro simulation library API in a way that the `solve(...)` function call can return the desired time step value of the micro simulation.

<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
