### PR TITLE
Move micro_dt from coupling parameters to simulation parameters in the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Move the config variable `micro_dt` from the coupling parameters section to the simulation parameters section https://github.com/precice/micro-manager/pull/114
 - Set time step of micro simulation in the configuration, and use it in the coupling https://github.com/precice/micro-manager/pull/112
 - Add a base class called `MicroManager` with minimal API and member function definitions, rename the existing `MicroManager` class to `MicroManagerCoupling` https://github.com/precice/micro-manager/pull/111
 - Handle calling `initialize()` function of micro simulations written in languages other than Python https://github.com/precice/micro-manager/pull/110

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
         "adaptivity": "True",
         "adaptivity_settings": {

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]
     },
     "diagnostics": {

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
         "adaptivity": "True",
         "adaptivity_settings": {

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]
     },
     "diagnostics": {

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -115,7 +115,7 @@ class Config:
                 "No read data names provided. Micro manager will only write data to preCICE."
             )
 
-        self._micro_dt = data["coupling_params"]["micro_dt"]
+        self._micro_dt = data["simulation_params"]["micro_dt"]
 
         self._macro_domain_bounds = data["simulation_params"]["macro_domain_bounds"]
 

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
         "decomposition": [2, 1, 1],
         "adaptivity": "True",

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
         "adaptivity": "True",
         "adaptivity_settings": {

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
         "adaptivity": "True",
         "adaptivity_settings": {

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
 	    "decomposition": [1, 1, 2]
     },

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -4,10 +4,10 @@
         "config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
 	    "decomposition": [1, 2, 3]
     },

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -4,10 +4,10 @@
         "config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 0.1
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 0.1,
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
         "adaptivity": "True",
         "adaptivity_settings": {

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -4,10 +4,10 @@
         "config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"},
-        "micro_dt": 1.0
+        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
     },
     "simulation_params": {
+        "micro_dt": 1.0,
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
         "adaptivity": "True",
         "adaptivity_settings": {


### PR DESCRIPTION
The variable to set the micro simulation dt should be a simulation parameter rather than a coupling parameter. This PR changes the configuration and also all configuration files in the examples and tests. This change also needs to be done for the two-scale-heat-conduction tutorial.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
