### PR TITLE
Explicitly check if the time window has completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Explicitly check if time window has converged using the API function `is_time_window_complete()` https://github.com/precice/micro-manager/pull/118
 - Add `MicroManagerSnapshot` enabling snapshot computation and storage of microdata in HDF5 format https://github.com/precice/micro-manager/pull/101
 - Make `sklearn` an optional dependency
 - Move the config variable `micro_dt` from the coupling parameters section to the simulation parameters section https://github.com/precice/micro-manager/pull/114

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -284,7 +284,9 @@ class MicroManagerCoupling(MicroManager):
                         is_sim_active = np.copy(is_sim_active_cp)
                         sim_is_associated_to = np.copy(sim_is_associated_to_cp)
 
-            else:  # Time window has converged, now micro output can be generated
+            if (
+                self._participant.is_time_window_complete()
+            ):  # Time window has converged, now micro output can be generated
                 self._logger.info(
                     "Micro simulations {} - {} have converged at t = {}".format(
                         self._micro_sims[0].get_global_id(),


### PR DESCRIPTION
Currently, the Micro Manager understands that a time window has converged when the API call `requires_reading_checkpoint()` is false. However, `requires_reading_checkpoint()` may return false when the time window has not converged. This could happen, for example, when the Micro Manager is subcycling. To avoid falsely indicating convergence in the Micro Manager, an explicit check using the API command `is_time_window_complete()` is necessary.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
