### PR TITLE
Fix snapshot status attribute and log completion only once

### DIFF
--- a/micro_manager/snapshot/dataset.py
+++ b/micro_manager/snapshot/dataset.py
@@ -219,7 +219,7 @@ class ReadWriteHDF:
 
     def set_status(self, file_path: str, status: str):
         """
-        Set the status of the file to "finished" to indicate that it is no longer accessed.
+        Set the status of file to the given status.
 
         Parameters
         ----------

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -129,7 +129,6 @@ class MicroManagerSnapshot(MicroManager):
             self._data_storage.write_crashed_snapshots(
                 self._output_file_path, self._crashed_snapshots
             )
-        self._data_storage.set_status(self._output_file_path, "none")
 
         # Merge output files
         if self._is_parallel:
@@ -144,7 +143,10 @@ class MicroManagerSnapshot(MicroManager):
                     list_of_output_files,
                     self._parameter_space_size,
                 )
-        self._logger.info("Snapshot computation completed.")
+        else:
+            self._data_storage.set_status(self._output_file_path, "finished")
+        if self._rank == 0:
+            self._logger.info("Snapshot computation completed.")
 
     def initialize(self) -> None:
         """


### PR DESCRIPTION
The status attribute written to the database is inconsistent in the snapshot feature, this PR fixes that. Additionally, the completion of the snapshot computation is now only logged once instead of being logged by every MPI rank.

Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
