### PR TITLE
Add info about adaptivity tuning parameters

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,12 @@ Parameter | Description
 `every_implicit_iteration` | If True, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.
 `similarity_measure`| Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*.
 
+The primary tuning parameters for adaptivity are the history parameter $$ \Lambda $$, the coarsening constant $$ C_c $$, and the $$ C_r $$. Their effects can be interpreted as:
+
+- Higher values of the history parameter $$ \Lambda $$ imply lower significance of the adaptivity state in the previous timestep on the state in the current timestep.
+- Higher values of the coarsening constant $$ C_c $$ imply that more active simulations from the previous timestep will remain active in the current timestep.
+- Higher values of the refining constant $$ C_r $$ imply that less inactive points from the previous timestep will become active in the current timestep.
+
 Example of adaptivity configuration is
 
 ```json


### PR DESCRIPTION
In the configuration documentation, information about the adaptivity tuning parameters was missing. This PR adds information, which is taken from [this paper](https://doi.org/10.1016/j.amc.2020.125933).

Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
