### PR TITLE
Change logging strategy and add new logging for adaptivity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Improve logging by wrapping Python logger in a class https://github.com/precice/micro-manager/pull/133
 - Add information about adaptivity tuning parameters https://github.com/precice/micro-manager/pull/131
 - Put computation of counting active steps inside the adaptivity variant `if` condition https://github.com/precice/micro-manager/pull/130
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ The Micro Manager is configured with a JSON file. An example configuration file 
 {
     "micro_file_name": "micro_solver",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"temperature": "scalar", "heat-flux": "vector"},
         "write_data_names": {"porosity": "scalar", "conductivity": "vector"}
@@ -38,7 +38,7 @@ There are three main sections in the configuration file, the `coupling_params`, 
 
 Parameter | Description
 --- | ---
-`config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
+`precice_config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
 `macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
 `read_data_names` |  A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
 `write_data_names` |  A Python dictionary with the names of the data to be written to preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
@@ -74,14 +74,14 @@ If the parameter `data_from_micro_sims` is set, the data to be output needs to b
 </participant>
 ```
 
-If `output_micro_sim_solve_time` is set, add similar entries for the data `micro_sim_time` in the following way:
+If `output_micro_sim_solve_time` is set, add similar entries for the data `solve_cpu_time` in the following way:
 
 ```xml
-<data:scalar name="micro_sim_time"/>
+<data:scalar name="solve_cpu_time"/>
 
 <participant name="Micro-Manager">
   ...
-  <write-data name="micro_sim_time" mesh="macro-mesh"/>
+  <write-data name="solve_cpu_time" mesh="macro-mesh"/>
   <export:vtu directory="Micro-Manager-output" every-n-time-windows="5"/>
 </participant>
 ```
@@ -120,6 +120,7 @@ Parameter | Description
 `refining_constant` | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$.
 `every_implicit_iteration` | If True, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.
 `similarity_measure`| Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*.
+`output_cpu_time` | Write CPU time of the adaptivity computation to preCICE, to be exported. This parameter is *optional*.
 
 The primary tuning parameters for adaptivity are the history parameter $$ \Lambda $$, the coarsening constant $$ C_c $$, and the refining constant $$ C_r $$. Their effects can be interpreted as:
 
@@ -169,6 +170,8 @@ The Micro Manager uses the output functionality of preCICE, hence these data set
     <write-data name="active_steps" mesh="macro-mesh"/>
 </participant>
 ```
+
+If the parameter `output_cpu_time` in `adaptivity_settings` is set to `True`, a scalar data field `adaptivity_cpu_time` needs to be added in the same way as described above.
 
 ## Interpolate a crashed micro simulation
 

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -16,7 +16,8 @@
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "True"
+            "every_implicit_iteration": "True",
+            "output_cpu_time": "True"
         }
     },
     "diagnostics": {

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "cpp-dummy/micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config-adaptivity.xml",
+        "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "cpp-dummy/micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -16,7 +16,8 @@
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "True"
+            "every_implicit_iteration": "True",
+            "output_cpu_time": "True"
         }
     },
     "diagnostics": {

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "python-dummy/micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config-adaptivity.xml",
+        "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "python-dummy/micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/examples/precice-config-adaptivity.xml
+++ b/examples/precice-config-adaptivity.xml
@@ -10,18 +10,20 @@
     <data:vector name="macro-vector-data"/>
     <data:scalar name="micro-scalar-data"/>
     <data:vector name="micro-vector-data"/>
-    <data:scalar name="micro_sim_time"/>
+    <data:scalar name="solve_cpu_time"/>
     <data:scalar name="active_state"/>
     <data:scalar name="active_steps"/>
+    <data:scalar name="adaptivity_cpu_time"/>
 
     <mesh name="macro-mesh" dimensions="3">
        <use-data name="macro-scalar-data"/>
        <use-data name="macro-vector-data"/>
        <use-data name="micro-scalar-data"/>
        <use-data name="micro-vector-data"/>
-       <use-data name="micro_sim_time"/>
+       <use-data name="solve_cpu_time"/>
        <use-data name="active_state"/>
        <use-data name="active_steps"/>
+       <use-data name="adaptivity_cpu_time"/>
     </mesh>
 
     <participant name="Macro-dummy">
@@ -38,9 +40,10 @@
       <read-data name="macro-vector-data" mesh="macro-mesh"/>
       <write-data name="micro-scalar-data" mesh="macro-mesh"/>
       <write-data name="micro-vector-data" mesh="macro-mesh"/>
-      <write-data name="micro_sim_time" mesh="macro-mesh"/>
+      <write-data name="solve_cpu_time" mesh="macro-mesh"/>
       <write-data name="active_state" mesh="macro-mesh"/>
       <write-data name="active_steps" mesh="macro-mesh"/>
+      <write-data name="adaptivity_cpu_time" mesh="macro-mesh"/>
     </participant>
 
     <m2n:sockets acceptor="Micro-Manager" connector="Macro-dummy"/>

--- a/examples/precice-config.xml
+++ b/examples/precice-config.xml
@@ -8,14 +8,14 @@
   <data:vector name="macro-vector-data" />
   <data:scalar name="micro-scalar-data" />
   <data:vector name="micro-vector-data" />
-  <data:scalar name="micro_sim_time" />
+  <data:scalar name="solve_cpu_time" />
 
   <mesh name="macro-mesh" dimensions="3">
     <use-data name="macro-scalar-data" />
     <use-data name="macro-vector-data" />
     <use-data name="micro-scalar-data" />
     <use-data name="micro-vector-data" />
-    <use-data name="micro_sim_time" />
+    <use-data name="solve_cpu_time" />
   </mesh>
 
   <participant name="Macro-dummy">
@@ -32,7 +32,7 @@
     <read-data name="macro-vector-data" mesh="macro-mesh" />
     <write-data name="micro-scalar-data" mesh="macro-mesh" />
     <write-data name="micro-vector-data" mesh="macro-mesh" />
-    <write-data name="micro_sim_time" mesh="macro-mesh" />
+    <write-data name="solve_cpu_time" mesh="macro-mesh" />
   </participant>
 
   <m2n:sockets acceptor="Micro-Manager" connector="Macro-dummy" />

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -10,7 +10,7 @@ import numpy as np
 
 
 class AdaptivityCalculator:
-    def __init__(self, configurator, logger) -> None:
+    def __init__(self, configurator) -> None:
         """
         Class constructor.
 
@@ -25,8 +25,6 @@ class AdaptivityCalculator:
         self._hist_param = configurator.get_adaptivity_hist_param()
         self._adaptivity_data_names = configurator.get_data_for_adaptivity()
         self._adaptivity_type = configurator.get_adaptivity_type()
-
-        self._logger = logger
 
         self._coarse_tol = 0.0
         self._ref_tol = 0.0

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -126,18 +126,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             similarity_dists, is_sim_active, sim_is_associated_to
         )
 
-        # self._logger.info(
-        #     "{} active simulations, {} inactive simulations".format(
-        #         np.count_nonzero(
-        #             is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1]
-        #         ),
-        #         np.count_nonzero(
-        #             is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1]
-        #             == False
-        #         ),
-        #     )
-        # )
-
         return similarity_dists, is_sim_active, sim_is_associated_to
 
     def communicate_micro_output(

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -190,6 +190,22 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         return micro_sims_output
 
+    def log_metrics(self, logger, adaptivity_data: list, n: int) -> None:
+        """ """
+        is_sim_active = adaptivity_data[1]
+        global_active_sims = np.count_nonzero(is_sim_active)
+        global_inactive_sims = np.count_nonzero(is_sim_active == False)
+
+        logger.log_info_one_rank(
+            "{},{},{},{},{}".format(
+                n,
+                np.mean(global_active_sims),
+                np.mean(global_inactive_sims),
+                np.max(global_active_sims),
+                np.max(global_inactive_sims),
+            )
+        )
+
     def _communicate_micro_output(
         self,
         adaptivity_data: list,

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -19,7 +19,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
     def __init__(
         self,
         configurator,
-        logger,
         global_number_of_sims: float,
         global_ids: list,
         rank: int,
@@ -43,7 +42,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         comm : MPI.COMM_WORLD
             Global communicator of MPI.
         """
-        super().__init__(configurator, logger)
+        super().__init__(configurator)
         self._global_ids = global_ids
         self._comm = comm
         self._rank = rank
@@ -127,17 +126,17 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             similarity_dists, is_sim_active, sim_is_associated_to
         )
 
-        self._logger.info(
-            "{} active simulations, {} inactive simulations".format(
-                np.count_nonzero(
-                    is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1]
-                ),
-                np.count_nonzero(
-                    is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1]
-                    == False
-                ),
-            )
-        )
+        # self._logger.info(
+        #     "{} active simulations, {} inactive simulations".format(
+        #         np.count_nonzero(
+        #             is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1]
+        #         ),
+        #         np.count_nonzero(
+        #             is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1]
+        #             == False
+        #         ),
+        #     )
+        # )
 
         return similarity_dists, is_sim_active, sim_is_associated_to
 

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -80,12 +80,12 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             similarity_dists, is_sim_active, sim_is_associated_to
         )
 
-        self._logger.info(
-            "{} active simulations, {} inactive simulations".format(
-                np.count_nonzero(is_sim_active),
-                np.count_nonzero(is_sim_active == False),
-            )
-        )
+        # self._logger.info(
+        #     "{} active simulations, {} inactive simulations".format(
+        #         np.count_nonzero(is_sim_active),
+        #         np.count_nonzero(is_sim_active == False),
+        #     )
+        # )
 
         return similarity_dists, is_sim_active, sim_is_associated_to
 

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -9,7 +9,7 @@ from .adaptivity import AdaptivityCalculator
 
 
 class LocalAdaptivityCalculator(AdaptivityCalculator):
-    def __init__(self, configurator, logger) -> None:
+    def __init__(self, configurator) -> None:
         """
         Class constructor.
 
@@ -20,7 +20,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         logger : object of logging
             Logger defined from the standard package logging
         """
-        super().__init__(configurator, logger)
+        super().__init__(configurator)
 
     def compute_adaptivity(
         self,

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -80,13 +80,6 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             similarity_dists, is_sim_active, sim_is_associated_to
         )
 
-        # self._logger.info(
-        #     "{} active simulations, {} inactive simulations".format(
-        #         np.count_nonzero(is_sim_active),
-        #         np.count_nonzero(is_sim_active == False),
-        #     )
-        # )
-
         return similarity_dists, is_sim_active, sim_is_associated_to
 
     def _update_inactive_sims(

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -13,19 +13,20 @@ class Config:
     the config class in https://github.com/precice/fenics-adapter/tree/develop/fenicsadapter
     """
 
-    def __init__(self, config_filename):
+    def __init__(self, config_file_name):
         """
         Constructor of the Config class.
 
         Parameters
         ----------
-        config_filename : string
+        config_file_name : string
             Name of the JSON configuration file
         """
+        self._config_file_name = config_file_name
         self._logger = None
         self._micro_file_name = None
 
-        self._config_file_name = None
+        self._precice_config_file_name = None
         self._macro_mesh_name = None
         self._read_data_names = dict()
         self._write_data_names = dict()
@@ -56,8 +57,6 @@ class Config:
 
         self._output_micro_sim_time = False
 
-        self.read_json(config_filename)
-
     def set_logger(self, logger):
         """
         Set the logger for the Config class.
@@ -69,17 +68,17 @@ class Config:
         """
         self._logger = logger
 
-    def read_json(self, config_filename):
+    def _read_json(self, config_file_name):
         """
         Reads JSON configuration file.
 
         Parameters
         ----------
-        config_filename : string
+        config_file_name : string
             Name of the JSON configuration file
         """
-        self._folder = os.path.dirname(os.path.join(os.getcwd(), config_filename))
-        path = os.path.join(self._folder, os.path.basename(config_filename))
+        self._folder = os.path.dirname(os.path.join(os.getcwd(), config_file_name))
+        path = os.path.join(self._folder, os.path.basename(config_file_name))
         with open(path, "r") as read_file:
             self._data = json.load(read_file)
 
@@ -145,8 +144,10 @@ class Config:
         Reads Micro Manager relevant information from JSON configuration file
         and saves the data to the respective instance attributes.
         """
-        self._config_file_name = os.path.join(
-            self._folder, self._data["coupling_params"]["config_file_name"]
+        self._read_json(self._config_file_name)  # Read base information
+
+        self._precice_config_file_name = os.path.join(
+            self._folder, self._data["coupling_params"]["precice_config_file_name"]
         )
         self._macro_mesh_name = self._data["coupling_params"]["macro_mesh_name"]
 
@@ -276,6 +277,11 @@ class Config:
             )
 
     def read_json_snapshot(self):
+        """
+        Reads Snapshot relevant information from JSON configuration file
+        """
+        self._read_json(self._config_file_name)  # Read base information
+
         self._parameter_file_name = os.path.join(
             self._folder, self._data["coupling_params"]["parameter_file_name"]
         )
@@ -320,16 +326,16 @@ class Config:
                 "For each snapshot a new micro simulation object will be created"
             )
 
-    def get_config_file_name(self):
+    def get_precice_config_file_name(self):
         """
-        Get the name of the JSON configuration file.
+        Get the name of the preCICE XML configuration file.
 
         Returns
         -------
         config_file_name : string
-            Name of the JSON configuration file provided to the Config class.
+            Name of the preCICE XML configuration file.
         """
-        return self._config_file_name
+        return self._precice_config_file_name
 
     def get_macro_mesh_name(self):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -133,9 +133,9 @@ class Config:
         self._micro_dt = self._data["simulation_params"]["micro_dt"]
 
         try:
-            if self._data["diagnostics"]["output_micro_sim_solve_time"]:
+            if self._data["diagnostics"]["output_micro_sim_solve_time"] == "True":
                 self._output_micro_sim_time = True
-                self._write_data_names["micro_sim_time"] = False
+                self._write_data_names["solve_cpu_time"] = False
         except BaseException:
             self._logger.log_info_one_rank(
                 "Micro manager will not output time required to solve each micro simulation in each time step."
@@ -257,9 +257,12 @@ class Config:
             self._write_data_names["active_steps"] = False
 
             try:
-                if self.data["simulation_params"]["adaptivity_settings"][
-                    "output_cpu_time"
-                ]:
+                if (
+                    self._data["simulation_params"]["adaptivity_settings"][
+                        "output_cpu_time"
+                    ]
+                    == "True"
+                ):
                     self._adaptivity_output_cpu_time = True
                     self._write_data_names["adaptivity_cpu_time"] = False
             except BaseException:

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -22,6 +22,7 @@ class Config:
         config_filename : string
             Name of the JSON configuration file
         """
+        self._logger = None
         self._micro_file_name = None
 
         self._config_file_name = None

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -5,6 +5,7 @@ Class Config provides functionality to read a JSON file and pass the values to t
 import json
 import os
 from warnings import warn
+from .tools.logging_wrapper import Logger
 
 
 class Config:
@@ -13,7 +14,7 @@ class Config:
     the config class in https://github.com/precice/fenics-adapter/tree/develop/fenicsadapter
     """
 
-    def __init__(self, logger, config_filename):
+    def __init__(self, config_filename):
         """
         Constructor of the Config class.
 
@@ -22,7 +23,7 @@ class Config:
         config_filename : string
             Name of the JSON configuration file
         """
-        self._logger = logger
+        self._logger = Logger("Config", "micro_manager_config.log", 0, 1)
 
         self._micro_file_name = None
 
@@ -96,7 +97,7 @@ class Config:
                         "Write data dictionary as a value other than 'scalar' or 'vector'"
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No write data names provided. Micro manager will only read data from preCICE."
             )
 
@@ -115,7 +116,7 @@ class Config:
                         "Read data dictionary as a value other than 'scalar' or 'vector'"
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No read data names provided. Micro manager will only write data to preCICE."
             )
 
@@ -126,7 +127,7 @@ class Config:
                 self._output_micro_sim_time = True
                 self._write_data_names["micro_sim_time"] = False
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "Micro manager will not output time required to solve each micro simulation in each time step."
             )
 
@@ -165,7 +166,7 @@ class Config:
                         "Adaptivity settings are provided but adaptivity is turned off."
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "Micro Manager will not adaptively run micro simulations, but instead will run all micro simulations."
             )
 
@@ -253,14 +254,14 @@ class Config:
                         "Diagnostics data dictionary as a value other than 'scalar' or 'vector'"
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No diagnostics data is defined. Micro Manager will not output any diagnostics data."
             )
 
         try:
             self._micro_output_n = self._data["diagnostics"]["micro_output_n"]
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "Output interval of micro simulations not specified, if output is available then it will be called "
                 "in every time window."
             )
@@ -278,7 +279,7 @@ class Config:
                 .replace(".py", "")
             )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No post-processing file name provided. Snapshot computation will not perform any post-processing."
             )
             self._postprocessing_file_name = None
@@ -298,7 +299,7 @@ class Config:
                         "Diagnostics data dictionary has a value other than 'scalar' or 'vector'"
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No diagnostics data is defined. Snapshot computation will not output any diagnostics data."
             )
 
@@ -306,7 +307,7 @@ class Config:
             if self._data["snapshot_params"]["initialize_once"] == "True":
                 self._initialize_once = True
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "For each snapshot a new micro simulation object will be created"
             )
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -5,7 +5,6 @@ Class Config provides functionality to read a JSON file and pass the values to t
 import json
 import os
 from warnings import warn
-from .tools.logging_wrapper import Logger
 
 
 class Config:
@@ -23,8 +22,6 @@ class Config:
         config_filename : string
             Name of the JSON configuration file
         """
-        self._logger = Logger("Config", "micro_manager_config.log", 0)
-
         self._micro_file_name = None
 
         self._config_file_name = None
@@ -59,6 +56,17 @@ class Config:
         self._output_micro_sim_time = False
 
         self.read_json(config_filename)
+
+    def set_logger(self, logger):
+        """
+        Set the logger for the Config class.
+
+        Parameters
+        ----------
+        logger : object of logging
+            Logger defined from the standard package logging
+        """
+        self._logger = logger
 
     def read_json(self, config_filename):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -50,7 +50,7 @@ class Config:
         self._adaptivity_refining_constant = 0.5
         self._adaptivity_every_implicit_iteration = False
         self._adaptivity_similarity_measure = "L1"
-        self._adaptivity_output_n = 1
+        self._adaptivity_output_n = -2
         self._adaptivity_output_cpu_time = False
         self._adaptivity_output_mem_usage = False
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -23,7 +23,7 @@ class Config:
         config_filename : string
             Name of the JSON configuration file
         """
-        self._logger = Logger("Config", "micro_manager_config.log", 0, 1)
+        self._logger = Logger("Config", "micro_manager_config.log", 0)
 
         self._micro_file_name = None
 
@@ -148,7 +148,7 @@ class Config:
         try:
             self._ranks_per_axis = self._data["simulation_params"]["decomposition"]
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "Domain decomposition is not specified, so the Micro Manager will expect to be run in serial."
             )
 
@@ -213,7 +213,7 @@ class Config:
                     "adaptivity_settings"
                 ]["similarity_measure"]
             else:
-                self._logger.info(
+                self._logger.log_info_one_rank(
                     "No similarity measure provided, using L1 norm as default"
                 )
                 self._adaptivity_similarity_measure = "L1"
@@ -228,7 +228,7 @@ class Config:
                 self._adaptivity_every_implicit_iteration = False
 
             if not self._adaptivity_every_implicit_iteration:
-                self._logger.info(
+                self._logger.log_info_one_rank(
                     "Micro Manager will compute adaptivity once at the start of every time window"
                 )
 

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -6,14 +6,12 @@ import numpy as np
 
 
 class DomainDecomposer:
-    def __init__(self, logger, dims, rank, size) -> None:
+    def __init__(self, dims, rank, size) -> None:
         """
         Class constructor.
 
         Parameters
         ----------
-        logger : object of logging
-            Logger defined from the standard package logging.
         dims : int
             Dimensions of the problem.
         rank : int
@@ -21,7 +19,6 @@ class DomainDecomposer:
         size : int
             Total number of MPI processes.
         """
-        self._logger = logger
         self._rank = rank
         self._size = size
         self._dims = dims
@@ -97,7 +94,5 @@ class DomainDecomposer:
             # Adjust the maximum bound to be exactly the domain size
             if rank_in_axis[d] + 1 == ranks_per_axis[d]:
                 mesh_bounds[d * 2 + 1] = macro_bounds[d * 2 + 1]
-
-        self._logger.log_info_any_rank("Bounding box limits are {}".format(mesh_bounds))
 
         return mesh_bounds

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -98,6 +98,6 @@ class DomainDecomposer:
             if rank_in_axis[d] + 1 == ranks_per_axis[d]:
                 mesh_bounds[d * 2 + 1] = macro_bounds[d * 2 + 1]
 
-        self._logger.info("Bounding box limits are {}".format(mesh_bounds))
+        self._logger.log_info_any_rank("Bounding box limits are {}".format(mesh_bounds))
 
         return mesh_bounds

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -31,7 +31,7 @@ class Interpolation:
             Local indices of the k nearest neighbors in all local points.
         """
         if len(coords) < k:
-            self._logger.info(
+            self._logger.log_info_any_rank(
                 "Number of desired neighbors k = {} is larger than the number of available neighbors {}. Resetting k = {}.".format(
                     k, len(coords), len(coords)
                 )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -49,11 +49,12 @@ class MicroManagerCoupling(MicroManager):
         config_file : string
             Name of the JSON configuration file (provided by the user).
         """
+        super().__init__(config_file)
+
         self._logger = Logger(
-            "MicroManagerCoupling", "micro_manager_coupling.log", 0, 1
+            "MicroManagerCoupling", "micro_manager_coupling.log", self._rank
         )
 
-        super().__init__(config_file)
         self._config.read_json_micro_manager()
         # Define the preCICE Participant
         self._participant = precice.Participant(

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -100,7 +100,7 @@ class MicroManagerCoupling(MicroManager):
             )
 
             self._adaptivity_logger.log_info_one_rank(
-                "Time,Avg Active Sims,Avg Inactive Sims,Max Active,Max Inactive"
+                "Time Window,Avg Active Sims,Avg Inactive Sims,Max Active,Max Inactive"
             )
 
             self._number_of_sims_for_adaptivity = 0
@@ -300,6 +300,7 @@ class MicroManagerCoupling(MicroManager):
 
             t += dt  # increase internal time when time step is done.
             n += 1  # increase counter
+
             self._participant.advance(
                 dt
             )  # notify preCICE that time step of size dt is complete
@@ -341,7 +342,7 @@ class MicroManagerCoupling(MicroManager):
                     if self._rank == 0:
                         self._adaptivity_logger.log_info_one_rank(
                             "{},{},{},{},{}".format(
-                                t,
+                                n,
                                 np.mean(global_active_sims),
                                 np.mean(global_inactive_sims),
                                 np.max(global_active_sims),

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -748,7 +748,7 @@ class MicroManagerCoupling(MicroManager):
                     end_time = time.time()
                     # Write solve time of the macro simulation if required and the simulation has not crashed
                     if self._is_micro_solve_time_required:
-                        micro_sims_output[count]["micro_sim_time"] = (
+                        micro_sims_output[count]["solve_cpu_time"] = (
                             end_time - start_time
                         )
 
@@ -859,7 +859,7 @@ class MicroManagerCoupling(MicroManager):
                     end_time = time.process_time()
                     # Write solve time of the macro simulation if required and the simulation has not crashed
                     if self._is_micro_solve_time_required:
-                        micro_sims_output[active_id]["micro_sim_time"] = (
+                        micro_sims_output[active_id]["solve_cpu_time"] = (
                             end_time - start_time
                         )
 
@@ -930,7 +930,7 @@ class MicroManagerCoupling(MicroManager):
             ] = self._micro_sims_active_steps[inactive_id]
 
             if self._is_micro_solve_time_required:
-                micro_sims_output[inactive_id]["micro_sim_time"] = 0
+                micro_sims_output[inactive_id]["solve_cpu_time"] = 0
 
         # Collect micro sim output for adaptivity calculation
         for i in range(self._local_number_of_sims):
@@ -1017,13 +1017,13 @@ class MicroManagerCoupling(MicroManager):
             if self._is_adaptivity_on:
                 interpol_space.append(micro_sims_active_input_lists[neighbor].copy())
                 interpol_values.append(micro_sims_active_values[neighbor].copy())
-                interpol_values[-1].pop("micro_sim_time", None)
+                interpol_values[-1].pop("solve_cpu_time", None)
                 interpol_values[-1].pop("active_state", None)
                 interpol_values[-1].pop("active_steps", None)
             else:
                 interpol_space.append(micro_sims_active_input_lists[neighbor].copy())
                 interpol_values.append(micro_sims_active_values[neighbor].copy())
-                interpol_values[-1].pop("micro_sim_time", None)
+                interpol_values[-1].pop("solve_cpu_time", None)
 
         # Interpolate for each parameter
         output_interpol = dict()
@@ -1037,7 +1037,7 @@ class MicroManagerCoupling(MicroManager):
             )
         # Reintroduce removed information
         if self._is_micro_solve_time_required:
-            output_interpol["micro_sim_time"] = 0
+            output_interpol["solve_cpu_time"] = 0
         if self._is_adaptivity_on:
             output_interpol["active_state"] = 1
             output_interpol["active_steps"] = self._micro_sims_active_steps[unset_sim]

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -665,7 +665,7 @@ class MicroManagerCoupling(MicroManager):
                             self._mesh_vertex_coords[count], micro_sims_input[count]
                         )
                     )
-                    self._logger.error(error_message)
+                    self._logger.log_error_any_rank(error_message)
                     self._has_sim_crashed[count] = True
 
         # If interpolate is off, terminate after crash
@@ -782,7 +782,7 @@ class MicroManagerCoupling(MicroManager):
                             self._mesh_vertex_coords[active_id]
                         )
                     )
-                    self._logger.error(error_message)
+                    self._logger.log_error_any_rank(error_message)
                     self._has_sim_crashed[active_id] = True
 
         # If interpolate is off, terminate after crash

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -88,7 +88,7 @@ class MicroManagerCoupling(MicroManager):
 
         if self._is_adaptivity_on:
             self._adaptivity_logger = Logger(
-                "Adaptivity", "adaptivity_metrics.csv", self._rank, csv_logger=True
+                "Adaptivity", "adaptivity-metrics.csv", self._rank, csv_logger=True
             )
 
             self._adaptivity_logger.log_info_one_rank(
@@ -312,7 +312,7 @@ class MicroManagerCoupling(MicroManager):
 
                 if self._is_adaptivity_on:
                     if self._adaptivity_type == "local":
-                        # Gather is necessary as local adaptivity only stores local data
+                        # MPI Gather is necessary as local adaptivity only stores local data
                         local_active_sims = np.count_nonzero(is_sim_active)
                         global_active_sims = self._comm.gather(local_active_sims)
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -338,15 +338,16 @@ class MicroManagerCoupling(MicroManager):
                         global_active_sims = np.count_nonzero(is_sim_active)
                         global_inactive_sims = np.count_nonzero(is_sim_active == False)
 
-                    self._adaptivity_logger.log_info_one_rank(
-                        "{},{},{},{},{}".format(
-                            t,
-                            np.mean(global_active_sims),
-                            np.mean(global_inactive_sims),
-                            np.max(global_active_sims),
-                            np.max(global_inactive_sims),
+                    if self._rank == 0:
+                        self._adaptivity_logger.log_info_one_rank(
+                            "{},{},{},{},{}".format(
+                                t,
+                                np.mean(global_active_sims),
+                                np.mean(global_inactive_sims),
+                                np.max(global_active_sims),
+                                np.max(global_inactive_sims),
+                            )
                         )
-                    )
                 self._logger.log_info_one_rank("Time window {} converged.".format(n))
 
         self._participant.finalize()

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -8,7 +8,6 @@ For more details see the MicroManagerCoupling class or the documentation at http
 """
 
 from mpi4py import MPI
-import logging
 from abc import ABC, abstractmethod
 
 from .config import Config
@@ -52,20 +51,6 @@ class MicroManager(MicroManagerInterface):
         self._rank = self._comm.Get_rank()
         self._size = self._comm.Get_size()
 
-        self._logger = logging.getLogger(__name__)
-        self._logger.setLevel(level=logging.INFO)
-
-        # Create file handler which logs messages
-        fh = logging.FileHandler("micro-manager.log")
-        fh.setLevel(logging.INFO)
-
-        # Create formatter and add it to handlers
-        formatter = logging.Formatter(
-            "[" + str(self._rank) + "] %(name)s -  %(levelname)s - %(message)s"
-        )
-        fh.setFormatter(formatter)
-        self._logger.addHandler(fh)  # add the handlers to the logger
-
         self._is_parallel = self._size > 1
         self._micro_sims_have_output = False
 
@@ -73,8 +58,7 @@ class MicroManager(MicroManagerInterface):
         self._global_number_of_sims = 0
         self._is_rank_empty = False
 
-        self._logger.info("Provided configuration file: {}".format(config_file))
-        self._config = Config(self._logger, config_file)
+        self._config = Config(config_file)
 
         # Data names of data to output to the snapshot database
         self._write_data_names = self._config.get_write_data_names()

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -60,16 +60,6 @@ class MicroManager(MicroManagerInterface):
 
         self._config = Config(config_file)
 
-        # Data names of data to output to the snapshot database
-        self._write_data_names = self._config.get_write_data_names()
-
-        # Data names of data to read as input parameter to the simulations
-        self._read_data_names = self._config.get_read_data_names()
-
-        self._micro_dt = self._config.get_micro_dt()
-
-        self._is_micro_solve_time_required = self._config.write_micro_solve_time()
-
     def initialize(self):
         """
         Initialize micro simulations. Not implemented

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -21,6 +21,7 @@ from .dataset import ReadWriteHDF
 from micro_manager.micro_simulation import create_simulation_class
 from micro_manager.tools.logging_wrapper import Logger
 
+
 sys.path.append(os.getcwd())
 
 
@@ -37,10 +38,21 @@ class MicroManagerSnapshot(MicroManager):
         super().__init__(config_file)
 
         self._logger = Logger(
-            "MicroManagerSnapshot", "micro_manager_snapshot.log", self._rank
+            "MicroManagerSnapshot", "micro-manager-snapshot.log", self._rank
         )
 
+        self._config.set_logger(self._logger)
         self._config.read_json_snapshot()
+
+        # Data names of data to output to the snapshot database
+        self._write_data_names = self._config.get_write_data_names()
+
+        # Data names of data to read as input parameter to the simulations
+        self._read_data_names = self._config.get_read_data_names()
+
+        self._micro_dt = self._config.get_micro_dt()
+
+        self._is_micro_solve_time_required = self._config.write_micro_solve_time()
 
         # Path to the parameter file containing input parameters for micro simulations
         self._parameter_file = self._config.get_parameter_file_name()

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -287,12 +287,12 @@ class MicroManagerSnapshot(MicroManager):
             simulations. The return type is None if the simulation has crashed.
         """
         try:
-            start_time = time.time()
+            start_time = time.process_time()
             micro_sims_output = self._micro_sims.solve(micro_sims_input, self._micro_dt)
-            end_time = time.time()
+            end_time = time.process_time()
 
             if self._is_micro_solve_time_required:
-                micro_sims_output["micro_sim_time"] = end_time - start_time
+                micro_sims_output["solve_cpu_time"] = end_time - start_time
 
             return micro_sims_output
         # Handle simulation crash

--- a/micro_manager/tools/logging_wrapper.py
+++ b/micro_manager/tools/logging_wrapper.py
@@ -30,7 +30,9 @@ class Logger:
         handler.setLevel(level)
 
         formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            "["
+            + str(self._rank)
+            + "] %(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
         handler.setFormatter(formatter)
 
@@ -81,4 +83,4 @@ class Logger:
         message : string
             Message to log.
         """
-        self._logger.error("[" + str(self._rank) + "] " + message)
+        self._logger.error(message)

--- a/micro_manager/tools/logging_wrapper.py
+++ b/micro_manager/tools/logging_wrapper.py
@@ -34,48 +34,51 @@ class Logger:
         )
         handler.setFormatter(formatter)
 
-        logger = logging.getLogger(name)
-        logger.setLevel(level)
-        logger.addHandler(handler)
+        self._logger = logging.getLogger(name)
+        self._logger.setLevel(level)
+        self._logger.addHandler(handler)
 
-        return logger
+    def get_logger(self):
+        """
+        Get the logger.
 
-    def log_info_one_rank(self, logger, message):
+        Returns
+        -------
+        logger : object of logging
+            Logger defined from the standard package logging
+        """
+        return self._logger
+
+    def log_info_one_rank(self, message):
         """
         Log a message. Only the rank 0 logs the message.
 
         Parameters
         ----------
-        logger : Logger
-            Logger object.
         message : string
             Message to log.
         """
         if self._rank == 0:
-            logger.info(message)
+            self._logger.info(message)
 
-    def log_info_any_rank(self, logger, message):
+    def log_info_any_rank(self, message):
         """
         Log a message. All ranks log the message.
 
         Parameters
         ----------
-        logger : Logger
-            Logger object.
         message : string
             Message to log.
         """
-        logger.info(message)
+        self._logger.info(message)
 
-    def log_error_any_rank(self, logger, message):
+    def log_error_any_rank(self, message):
         """
         Log an error message. Only the rank 0 logs the message.
 
         Parameters
         ----------
-        logger : Logger
-            Logger object.
         message : string
             Message to log.
         """
-        logger.error(message)
+        self._logger.error("[" + str(self._rank) + "] " + message)

--- a/micro_manager/tools/logging_wrapper.py
+++ b/micro_manager/tools/logging_wrapper.py
@@ -10,7 +10,7 @@ class Logger:
     Provides a logging wrapper for the Micro Manager classes.
     """
 
-    def __init__(self, name, log_file, rank=0, level=logging.INFO):
+    def __init__(self, name, log_file, rank=0, level=logging.INFO, csv_logger=False):
         """
         Set up a logger.
 
@@ -20,8 +20,12 @@ class Logger:
             Name of the logger.
         log_file : string
             Name of the log file.
+        rank : int, optional
+            Rank of the logger (default is 0).
         level : int, optional
             Logging level (default is logging.INFO).
+        csv_logger : bool, optional
+            If True, the logger will log in CSV format (default is False).
         """
 
         self._rank = rank
@@ -29,11 +33,15 @@ class Logger:
         handler = logging.FileHandler(log_file)
         handler.setLevel(level)
 
-        formatter = logging.Formatter(
-            "["
-            + str(self._rank)
-            + "] %(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
+        if csv_logger:
+            formatter = logging.Formatter("%(message)s")
+        else:
+            formatter = logging.Formatter(
+                "["
+                + str(self._rank)
+                + "] %(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            )
+
         handler.setFormatter(formatter)
 
         self._logger = logging.getLogger(name)

--- a/micro_manager/tools/logging_wrapper.py
+++ b/micro_manager/tools/logging_wrapper.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Provides a logging wrapper for the Micro Manager classes.
+"""
+import logging
+
+
+class Logger:
+    """
+    Provides a logging wrapper for the Micro Manager classes.
+    """
+
+    def __init__(self, name, log_file, rank=0, level=logging.INFO):
+        """
+        Set up a logger.
+
+        Parameters
+        ----------
+        name : string
+            Name of the logger.
+        log_file : string
+            Name of the log file.
+        level : int, optional
+            Logging level (default is logging.INFO).
+        """
+
+        self._rank = rank
+
+        handler = logging.FileHandler(log_file)
+        handler.setLevel(level)
+
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+
+        logger = logging.getLogger(name)
+        logger.setLevel(level)
+        logger.addHandler(handler)
+
+        return logger
+
+    def log_info_one_rank(self, logger, message):
+        """
+        Log a message. Only the rank 0 logs the message.
+
+        Parameters
+        ----------
+        logger : Logger
+            Logger object.
+        message : string
+            Message to log.
+        """
+        if self._rank == 0:
+            logger.info(message)
+
+    def log_info_any_rank(self, logger, message):
+        """
+        Log a message. All ranks log the message.
+
+        Parameters
+        ----------
+        logger : Logger
+            Logger object.
+        message : string
+            Message to log.
+        """
+        logger.info(message)
+
+    def log_error_any_rank(self, logger, message):
+        """
+        Log an error message. Only the rank 0 logs the message.
+
+        Parameters
+        ----------
+        logger : Logger
+            Logger object.
+        message : string
+            Message to log.
+        """
+        logger.error(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Repository = "https://github.com/precice/micro-manager"
 micro-manager-precice = "micro_manager:main"
 
 [tool.setuptools]
-packages=["micro_manager", "micro_manager.adaptivity", "micro_manager.snapshot"]
+packages=["micro_manager", "micro_manager.adaptivity", "micro_manager.snapshot", "micro_manager.tools"]
 
 [tool.setuptools-git-versioning]
 enabled = true

--- a/tests/integration/test_unit_cube/clean-test.sh
+++ b/tests/integration/test_unit_cube/clean-test.sh
@@ -9,3 +9,4 @@ rm -fv *.err
 rm -fv output/*.vtu
 rm -fv output/*.pvtu
 rm -r -fv __pycache__
+rm -fv *.csv

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -17,7 +17,11 @@
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "True"
+            "every_implicit_iteration": "True",
+	        "output_cpu_time": "True"
         }
+    },
+    "diagnostics": {
+        "output_micro_sim_solve_time": "True"
     }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/precice-config.xml
+++ b/tests/integration/test_unit_cube/precice-config.xml
@@ -8,18 +8,20 @@
   <data:vector name="macro-vector-data" />
   <data:scalar name="micro-scalar-data" />
   <data:vector name="micro-vector-data" />
-  <data:scalar name="micro_sim_time" />
   <data:scalar name="active_state" />
   <data:scalar name="active_steps" />
+  <data:scalar name="adaptivity_cpu_time" />
+  <data:scalar name="solve_cpu_time" />
 
   <mesh name="macro-cube-mesh" dimensions="3">
     <use-data name="macro-scalar-data" />
     <use-data name="macro-vector-data" />
     <use-data name="micro-scalar-data" />
     <use-data name="micro-vector-data" />
-    <use-data name="micro_sim_time" />
     <use-data name="active_state" />
     <use-data name="active_steps" />
+    <use-data name="adaptivity_cpu_time" />
+    <use-data name="solve_cpu_time" />
   </mesh>
 
   <participant name="macro-cube">
@@ -36,9 +38,10 @@
     <read-data name="macro-vector-data" mesh="macro-cube-mesh" />
     <write-data name="micro-scalar-data" mesh="macro-cube-mesh" />
     <write-data name="micro-vector-data" mesh="macro-cube-mesh" />
-    <write-data name="micro_sim_time" mesh="macro-cube-mesh" />
     <write-data name="active_state" mesh="macro-cube-mesh" />
     <write-data name="active_steps" mesh="macro-cube-mesh" />
+    <write-data name="adaptivity_cpu_time" mesh="macro-cube-mesh" />
+    <write-data name="solve_cpu_time" mesh="macro-cube-mesh" />
     <export:vtu directory="output" />
   </participant>
 

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "test_micro_manager",
     "coupling_params": {
-        "config_file_name": "dummy-config.xml",
+        "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "test_micro_simulation_crash_handling",
     "coupling_params": {
-        "config_file_name": "dummy-config.xml",
+        "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -31,7 +31,7 @@ class TestGlobalAdaptivity(TestCase):
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
         adaptivity_controller = GlobalAdaptivityCalculator(
-            configurator, MagicMock(), 5, global_ids, rank=self._rank, comm=self._comm
+            configurator, 5, global_ids, rank=self._rank, comm=self._comm
         )
 
         # Force the activation of sim #0 and #4
@@ -105,7 +105,7 @@ class TestGlobalAdaptivity(TestCase):
         configurator.get_adaptivity_coarsening_const = MagicMock(return_value=0.2)
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L2rel")
         adaptivity_controller = GlobalAdaptivityCalculator(
-            configurator, MagicMock(), 5, global_ids, rank=self._rank, comm=self._comm
+            configurator, 5, global_ids, rank=self._rank, comm=self._comm
         )
 
         adaptivity_controller._adaptivity_data_names = {
@@ -173,7 +173,7 @@ class TestGlobalAdaptivity(TestCase):
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
         adaptivity_controller = GlobalAdaptivityCalculator(
-            configurator, MagicMock(), 5, global_ids, rank=self._rank, comm=self._comm
+            configurator, 5, global_ids, rank=self._rank, comm=self._comm
         )
 
         adaptivity_controller.communicate_micro_output(

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -235,7 +235,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = LocalAdaptivityCalculator(configurator)
+        adaptivity_controller = LocalAdaptivityCalculator(configurator, MagicMock())
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -68,7 +68,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator, logger=MagicMock())
+        adaptivity_controller = AdaptivityCalculator(configurator)
         adaptivity_controller._hist_param = 0.5
         adaptivity_controller._adaptivity_data_names = [
             "micro-scalar-data",
@@ -102,7 +102,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator, logger=MagicMock())
+        adaptivity_controller = AdaptivityCalculator(configurator)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [
@@ -127,8 +127,7 @@ class TestLocalAdaptivity(TestCase):
         """
         Test functionality for calculating similarity criteria between pairs of simulations using different norms in class AdaptivityCalculator.
         """
-        logger = MagicMock()
-        calc = AdaptivityCalculator(Config(logger, "micro-manager-config.json"), logger)
+        calc = AdaptivityCalculator(Config("micro-manager-config.json"))
 
         fake_data = np.array([[1], [2], [3]])
         self.assertTrue(
@@ -209,7 +208,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator, logger=MagicMock())
+        adaptivity_controller = AdaptivityCalculator(configurator)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [
@@ -236,9 +235,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = LocalAdaptivityCalculator(
-            configurator, logger=MagicMock()
-        )
+        adaptivity_controller = LocalAdaptivityCalculator(configurator)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -8,7 +8,6 @@ from micro_manager.domain_decomposition import DomainDecomposer
 
 class TestDomainDecomposition(TestCase):
     def setUp(self) -> None:
-        self._logger = MagicMock()
         self._macro_bounds_3d = [
             -1,
             1,
@@ -25,7 +24,7 @@ class TestDomainDecomposition(TestCase):
         rank = 5
         size = 10
         ranks_per_axis = [1, 2, 5]
-        domain_decomposer = DomainDecomposer(self._logger, 3, rank, size)
+        domain_decomposer = DomainDecomposer(3, rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -40,7 +39,7 @@ class TestDomainDecomposition(TestCase):
         rank = 10
         size = 32
         ranks_per_axis = [4, 1, 8]
-        domain_decomposer = DomainDecomposer(self._logger, 3, rank, size)
+        domain_decomposer = DomainDecomposer(3, rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -55,7 +54,7 @@ class TestDomainDecomposition(TestCase):
         rank = 7
         size = 16
         ranks_per_axis = [8, 2, 1]
-        domain_decomposer = DomainDecomposer(self._logger, 3, rank, size)
+        domain_decomposer = DomainDecomposer(3, rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -34,7 +34,7 @@ class TestFunctioncalls(TestCase):
         self.fake_write_data_names = {
             "micro-scalar-data": False,
             "micro-vector-data": True,
-            "micro_sim_time": False,
+            "solve_cpu_time": False,
             "active_state": False,
             "active_steps": False,
         }
@@ -42,7 +42,7 @@ class TestFunctioncalls(TestCase):
             {
                 "micro-scalar-data": 1,
                 "micro-vector-data": np.array([0, 1, 2]),
-                "micro_sim_time": 0,
+                "solve_cpu_time": 0,
                 "active_state": 0,
                 "active_steps": 0,
             }

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -120,8 +120,11 @@ class TestFunctioncalls(TestCase):
         Test if the functions in the Config class work.
         """
         config = micro_manager.Config("micro-manager-config.json")
+        config.set_logger(MagicMock())
         config.read_json_micro_manager()
-        self.assertEqual(config._config_file_name.split("/")[-1], "dummy-config.xml")
+        self.assertEqual(
+            config._precice_config_file_name.split("/")[-1], "dummy-config.xml"
+        )
         self.assertEqual(config._micro_file_name, "test_micro_manager")
         self.assertEqual(config._macro_mesh_name, "dummy-macro-mesh")
         self.assertEqual(config._micro_output_n, 10)

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -119,7 +119,7 @@ class TestFunctioncalls(TestCase):
         """
         Test if the functions in the Config class work.
         """
-        config = micro_manager.Config(MagicMock(), "micro-manager-config.json")
+        config = micro_manager.Config("micro-manager-config.json")
         config.read_json_micro_manager()
         self.assertEqual(config._config_file_name.split("/")[-1], "dummy-config.xml")
         self.assertEqual(config._micro_file_name, "test_micro_manager")

--- a/tests/unit/test_snapshot_computation.py
+++ b/tests/unit/test_snapshot_computation.py
@@ -137,6 +137,7 @@ class TestFunctionCalls(TestCase):
         Test if the functions in the SnapshotConfig class work.
         """
         config = Config("snapshot-config.json")
+        config.set_logger(MagicMock())
         config.read_json_snapshot()
 
         self.assertEqual(

--- a/tests/unit/test_snapshot_computation.py
+++ b/tests/unit/test_snapshot_computation.py
@@ -136,7 +136,7 @@ class TestFunctionCalls(TestCase):
         """
         Test if the functions in the SnapshotConfig class work.
         """
-        config = Config(MagicMock(), "snapshot-config.json")
+        config = Config("snapshot-config.json")
         config.read_json_snapshot()
 
         self.assertEqual(


### PR DESCRIPTION
This PR adds the following:

- A new logging framework with a dedicated `Logger` class. In this class, a logger is generated and logging options are provided for logging via one one rank, any rank of choice, or all ranks. Different types of logging are possible. Currently the options are `info` and `error`.
- **Breaking change**: changes the configuration parameter `config_file_name` to `precice_config_file_name` to differentiate it from the Micro Manager JSON configuration file.
- Add optional parameter `output_cpu_time` to `adaptivity_settings` which will output CPU time of the adaptivity computation on every rank. The data is written to preCICE with the intention of being exported. All the micro simulations (coupling vertices) on one rank will have the same scalar value of the adaptivity computation CPU time.
- **Breaking change**: Change the name of the diagnostics output `micro_sim_time` to `solve_cpu_time`.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
