### PR TITLE
Remove the scalar and vector keywords from data names in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Remove the `scalar` and `vector` keyword values from data names in configuration https://github.com/precice/micro-manager/pull/142
 - Set default logger to stdout and add output directory setting option for file loggers https://github.com/precice/micro-manager/pull/139
 - Remove the `adaptivity_data` data structure and handle all adaptivity data internally https://github.com/precice/micro-manager/pull/137
 - Improve logging by wrapping Python logger in a class https://github.com/precice/micro-manager/pull/133

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,8 +15,8 @@ The Micro Manager is configured with a JSON file. An example configuration file 
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"temperature": "scalar", "heat-flux": "vector"},
-        "write_data_names": {"porosity": "scalar", "conductivity": "vector"}
+        "read_data_names": ["temperature", "heat-flux"],
+        "write_data_names": ["porosity", "conductivity"]
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
@@ -40,8 +40,8 @@ Parameter | Description
 --- | ---
 `precice_config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
 `macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
-`read_data_names` |  A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
-`write_data_names` |  A Python dictionary with the names of the data to be written to preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
+`read_data_names` |  A Python list with the names of the data to be read from preCICE.
+`write_data_names` |  A Python list with the names of the data to be written to preCICE.
 
 ## Simulation Parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,8 +40,8 @@ Parameter | Description
 --- | ---
 `precice_config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
 `macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
-`read_data_names` |  A Python list with the names of the data to be read from preCICE.
-`write_data_names` |  A Python list with the names of the data to be written to preCICE.
+`read_data_names` |  A list with the names of the data to be read from preCICE.
+`write_data_names` |  A list with the names of the data to be written to preCICE.
 
 ## Simulation Parameters
 

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -103,15 +103,15 @@ class MicroManagerCoupling(MicroManager):
             self._adaptivity_data_names = self._config.get_data_for_adaptivity()
 
             # Names of macro data to be used for adaptivity computation
-            self._adaptivity_macro_data_names = dict()
+            self._adaptivity_macro_data_names: list = []
 
             # Names of micro data to be used for adaptivity computation
-            self._adaptivity_micro_data_names = dict()
-            for name, is_data_vector in self._adaptivity_data_names.items():
+            self._adaptivity_micro_data_names: list = []
+            for name in self._adaptivity_data_names:
                 if name in self._read_data_names:
-                    self._adaptivity_macro_data_names[name] = is_data_vector
+                    self._adaptivity_macro_data_names.append(name)
                 if name in self._write_data_names:
-                    self._adaptivity_micro_data_names[name] = is_data_vector
+                    self._adaptivity_micro_data_names.append(name)
 
             self._adaptivity_in_every_implicit_step = (
                 self._config.is_adaptivity_required_in_every_implicit_iteration()
@@ -356,20 +356,8 @@ class MicroManagerCoupling(MicroManager):
         )
 
         if self._is_adaptivity_on:
-            for name, is_data_vector in self._adaptivity_data_names.items():
-                if is_data_vector:
-                    self._data_for_adaptivity[name] = np.zeros(
-                        (
-                            self._local_number_of_sims,
-                            self._participant.get_data_dimensions(
-                                self._macro_mesh_name, name
-                            ),
-                        )
-                    )
-                else:
-                    self._data_for_adaptivity[name] = np.zeros(
-                        (self._local_number_of_sims)
-                    )
+            for name in self._adaptivity_data_names:
+                self._data_for_adaptivity[name] = np.zeros((self._local_number_of_sims))
 
         # Create lists of local and global IDs
         sim_id = np.sum(nms_all_ranks[: self._rank])
@@ -572,10 +560,11 @@ class MicroManagerCoupling(MicroManager):
             List of dicts in which keys are names of data being read and the values are the data from preCICE.
         """
         read_data: Dict[str, list] = dict()
-        for name in self._read_data_names.keys():
+
+        for name in self._read_data_names:
             read_data[name] = []
 
-        for name in self._read_data_names.keys():
+        for name in self._read_data_names:
             read_data.update(
                 {
                     name: self._participant.read_data(
@@ -608,7 +597,7 @@ class MicroManagerCoupling(MicroManager):
                 for name, values in d.items():
                     data_dict[name].append(values)
 
-            for dname in self._write_data_names.keys():
+            for dname in self._write_data_names:
                 self._participant.write_data(
                     self._macro_mesh_name,
                     dname,
@@ -616,7 +605,7 @@ class MicroManagerCoupling(MicroManager):
                     data_dict[dname],
                 )
         else:
-            for dname in self._write_data_names.keys():
+            for dname in self._write_data_names:
                 self._participant.write_data(
                     self._macro_mesh_name, dname, [], np.array([])
                 )

--- a/micro_manager/snapshot/dataset.py
+++ b/micro_manager/snapshot/dataset.py
@@ -172,17 +172,17 @@ class ReadWriteHDF:
         parameter_data = dict()
         output = []
         # Read data by iterating over the relevant datasets
-        for key in data_names.keys():
-            parameter_data[key] = np.asarray(parameter_file[key][start:end])
-            my_key = (
-                key  # Save one key to be able to iterate over the length of the data
+        for name in data_names:
+            parameter_data[name] = np.asarray(parameter_file[name][start:end])
+            my_name = (
+                name  # Save one name to be able to iterate over the length of the data
             )
         # Iterate over len of data. In each iteration write data from all macro data sets
         # to a dictionary and append it to the output list of dicts.
-        for i in range(len(parameter_data[my_key])):
+        for i in range(len(parameter_data[my_name])):
             current_data = dict()
-            for key in data_names.keys():
-                current_data[key] = parameter_data[key][i]
+            for name in data_names:
+                current_data[name] = parameter_data[name][i]
             output.append(current_data)
         return output
 

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -4,8 +4,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 0.1,

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/unit/snapshot-config.json
+++ b/tests/unit/snapshot-config.json
@@ -2,8 +2,8 @@
     "micro_file_name": "test_snapshot_computation",
     "coupling_params": {
         "parameter_file_name": "test_parameter.hdf5",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -24,20 +24,17 @@ class MicroSimulation:
 
 class TestFunctioncalls(TestCase):
     def setUp(self):
-        self.fake_read_data_names = {
-            "macro-scalar-data": False,
-            "macro-vector-data": True,
-        }
+        self.fake_read_data_names = ["macro-scalar-data", "macro-vector-data"]
         self.fake_read_data = [
             {"macro-scalar-data": 1, "macro-vector-data": np.array([0, 1, 2])}
         ] * 4
-        self.fake_write_data_names = {
-            "micro-scalar-data": False,
-            "micro-vector-data": True,
-            "solve_cpu_time": False,
-            "active_state": False,
-            "active_steps": False,
-        }
+        self.fake_write_data_names = [
+            "micro-scalar-data",
+            "micro-vector-data",
+            "solve_cpu_time",
+            "active_state",
+            "active_steps",
+        ]
         self.fake_write_data = [
             {
                 "micro-scalar-data": 1,
@@ -56,8 +53,8 @@ class TestFunctioncalls(TestCase):
         manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
 
         self.assertListEqual(manager._macro_bounds, self.macro_bounds)
-        self.assertDictEqual(manager._read_data_names, self.fake_read_data_names)
-        self.assertDictEqual(self.fake_write_data_names, manager._write_data_names)
+        self.assertListEqual(manager._read_data_names, self.fake_read_data_names)
+        self.assertListEqual(self.fake_write_data_names, manager._write_data_names)
         self.assertEqual(manager._micro_n_out, 10)
 
     def test_initialization(self):
@@ -75,8 +72,8 @@ class TestFunctioncalls(TestCase):
         self.assertEqual(
             manager._micro_sims[0].very_important_value, 0
         )  # test inheritance
-        self.assertDictEqual(manager._read_data_names, self.fake_read_data_names)
-        self.assertDictEqual(self.fake_write_data_names, manager._write_data_names)
+        self.assertListEqual(manager._read_data_names, self.fake_read_data_names)
+        self.assertListEqual(self.fake_write_data_names, manager._write_data_names)
 
     def test_read_write_data_from_precice(self):
         """
@@ -130,10 +127,10 @@ class TestFunctioncalls(TestCase):
         self.assertEqual(config._micro_file_name, "test_micro_manager")
         self.assertEqual(config._macro_mesh_name, "dummy-macro-mesh")
         self.assertEqual(config._micro_output_n, 10)
-        self.assertDictEqual(config._read_data_names, self.fake_read_data_names)
-        self.assertDictEqual(self.fake_write_data_names, config._write_data_names)
+        self.assertListEqual(config._read_data_names, self.fake_read_data_names)
+        self.assertListEqual(self.fake_write_data_names, config._write_data_names)
         self.assertEqual(config._adaptivity, True)
-        self.assertDictEqual(config._data_for_adaptivity, self.fake_read_data_names)
+        self.assertListEqual(config._data_for_adaptivity, self.fake_read_data_names)
         self.assertEqual(config._adaptivity_type, "local")
         self.assertEqual(config._adaptivity_history_param, 0.5)
         self.assertEqual(config._adaptivity_coarsening_constant, 0.3)

--- a/tests/unit/test_snapshot_computation.py
+++ b/tests/unit/test_snapshot_computation.py
@@ -22,19 +22,13 @@ class MicroSimulation:
 
 class TestFunctionCalls(TestCase):
     def setUp(self):
-        self.fake_read_data_names = {
-            "macro-scalar-data": False,
-            "macro-vector-data": True,
-        }
+        self.fake_read_data_names = ["macro-scalar-data", "macro-vector-data"]
         self.fake_read_data = {
             "macro-scalar-data": 1,
             "macro-vector-data": np.array([0, 1, 2]),
         }
 
-        self.fake_write_data_names = {
-            "micro-scalar-data": False,
-            "micro-vector-data": True,
-        }
+        self.fake_write_data_names = ["micro-scalar-data", "micro-vector-data"]
         self.fake_write_data = [
             {
                 "micro-scalar-data": 1,
@@ -48,10 +42,10 @@ class TestFunctionCalls(TestCase):
         """
         snapshot_object = MicroManagerSnapshot("snapshot-config.json")
 
-        self.assertDictEqual(
+        self.assertListEqual(
             snapshot_object._read_data_names, self.fake_read_data_names
         )
-        self.assertDictEqual(
+        self.assertListEqual(
             snapshot_object._write_data_names, self.fake_write_data_names
         )
         self.assertEqual(
@@ -72,10 +66,10 @@ class TestFunctionCalls(TestCase):
 
         snapshot_object.initialize()
         self.assertEqual(snapshot_object._global_number_of_sims, 1)
-        self.assertDictEqual(
+        self.assertListEqual(
             snapshot_object._read_data_names, self.fake_read_data_names
         )
-        self.assertDictEqual(
+        self.assertListEqual(
             snapshot_object._write_data_names, self.fake_write_data_names
         )
         self.assertTrue(os.path.isfile(complete_path))
@@ -144,8 +138,8 @@ class TestFunctionCalls(TestCase):
             config._parameter_file_name.split("/")[-1], "test_parameter.hdf5"
         )
         self.assertEqual(config._micro_file_name, "test_snapshot_computation")
-        self.assertDictEqual(config._read_data_names, self.fake_read_data_names)
-        self.assertDictEqual(config._write_data_names, self.fake_write_data_names)
+        self.assertListEqual(config._read_data_names, self.fake_read_data_names)
+        self.assertListEqual(config._write_data_names, self.fake_write_data_names)
         self.assertEqual(config._postprocessing_file_name, "snapshot_post_processing")
         self.assertTrue(config._initialize_once)
 


### PR DESCRIPTION
The `scalar` and `vector` keyword values for data name dictionaries are no longer necessary as the preCICE v3.x API does not distinguish between the data dimensions it works with. No functionality in the Micro Manager relies on this user information.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
