### PR TITLE
Fix bug in handling of vector data

### DIFF
--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: micro-manager
         run: pip3 install .
 
-       - name: Run integration test with global adaptivity in parallel
+      - name: Run integration test with global adaptivity in parallel
         timeout-minutes: 3
         working-directory: micro-manager/tests/integration/test_unit_cube
         run: |

--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -1,0 +1,80 @@
+name: Test adaptivity functionality in parallel
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  adaptivity_integration_test_parallel:
+    name: Adaptivity integration test in parallel
+    runs-on: ubuntu-latest
+    container: precice/precice:nightly
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: micro-manager
+
+      - name: Install sudo for MPI
+        working-directory: micro-manager
+        run: |
+          apt-get -qq update
+          apt-get -qq install sudo
+
+      - name: Use mpi4py
+        uses: mpi4py/setup-mpi@v1
+
+      - name: Install dependencies
+        working-directory: micro-manager
+        run: |
+          apt-get -qq update
+          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
+          pip3 install --upgrade pip
+
+      - name: Install Micro Manager
+        working-directory: micro-manager
+        run: pip3 install .
+
+       - name: Run integration test with global adaptivity in parallel
+        timeout-minutes: 3
+        working-directory: micro-manager/tests/integration/test_unit_cube
+        run: |
+          mpiexec -n 2 --allow-run-as-root micro-manager-precice micro-manager-config-global-adaptivity.json &
+          python3 unit_cube.py
+
+  adaptivity_unit_tests_parallel:
+    name: Adaptivity unit tests in parallel
+    runs-on: ubuntu-latest
+    container: precice/precice:nightly
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          path: micro-manager
+
+      - name: Install sudo for MPI
+        working-directory: micro-manager
+        run: |
+          apt-get -qq update
+          apt-get -qq install sudo
+
+      - name: Use mpi4py
+        uses: mpi4py/setup-mpi@v1
+
+      - name: Install Dependencies
+        working-directory: micro-manager
+        run: |
+          apt-get -qq update
+          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
+          pip3 install --upgrade pip
+
+      - name: Install Micro Manager
+        working-directory: micro-manager
+        run: pip3 install --user .
+
+      - name: Run parallel unit tests
+        working-directory: micro-manager/tests/unit
+        run: mpiexec -n 2 --allow-run-as-root python3 -m unittest test_adaptivity_parallel.py

--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -42,7 +42,7 @@ jobs:
         timeout-minutes: 3
         working-directory: micro-manager/tests/integration/test_unit_cube
         run: |
-          mpiexec -n 2 --allow-run-as-root micro-manager-precice micro-manager-config-global-adaptivity.json &
+          mpiexec -n 2 --allow-run-as-root micro-manager-precice micro-manager-config-global-adaptivity-parallel.json &
           python3 unit_cube.py
 
   adaptivity_unit_tests_parallel:

--- a/.github/workflows/run-adaptivity-tests-serial.yml
+++ b/.github/workflows/run-adaptivity-tests-serial.yml
@@ -1,4 +1,4 @@
-name: Test adaptivity functionality
+name: Test adaptivity functionality in serial
 on:
   push:
     branches:
@@ -9,7 +9,7 @@ on:
       - "*"
 jobs:
   adaptivity_integration_tests:
-    name: Run adaptivity integration tests
+    name: Adaptivity integration tests in serial
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -67,37 +67,3 @@ jobs:
       - name: Run unit tests
         working-directory: micro-manager/tests/unit
         run: python3 -m unittest test_adaptivity_serial.py
-
-  adaptivity_unit_tests_parallel:
-    name: Run adaptivity unit tests in parallel
-    runs-on: ubuntu-latest
-    container: precice/precice:nightly
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          path: micro-manager
-
-      - name: Install sudo for MPI
-        working-directory: micro-manager
-        run: |
-          apt-get -qq update
-          apt-get -qq install sudo
-
-      - name: Use mpi4py
-        uses: mpi4py/setup-mpi@v1
-
-      - name: Install Dependencies
-        working-directory: micro-manager
-        run: |
-          apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
-
-      - name: Install Micro Manager
-        working-directory: micro-manager
-        run: pip3 install --user .
-
-      - name: Run unit tests
-        working-directory: micro-manager/tests/unit
-        run: mpiexec -n 2 --allow-run-as-root python3 -m unittest test_adaptivity_parallel.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fix bug in handling of vector data returned by the MicroSimulation `solve()` method, for scenarios with adaptivity https://github.com/precice/micro-manager/pull/143
 - Remove the `scalar` and `vector` keyword values from data names in configuration https://github.com/precice/micro-manager/pull/142
 - Set default logger to stdout and add output directory setting option for file loggers https://github.com/precice/micro-manager/pull/139
 - Remove the `adaptivity_data` data structure and handle all adaptivity data internally https://github.com/precice/micro-manager/pull/137

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -78,7 +78,7 @@ class AdaptivityCalculator:
 
         data_diff = np.zeros_like(_similarity_dists)
         for name in data.keys():
-            data_vals = data[name]
+            data_vals = np.array(data[name])
             if data_vals.ndim == 1:
                 # If the adaptivity data is a scalar for each simulation,
                 # expand the dimension to make it a 2D array to unify the calculation.

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -800,6 +800,8 @@ class MicroManagerCoupling(MicroManager):
 
         adaptivity_cpu_time += end_time - start_time
 
+        print("DEBUG micro_sim_output: ", micro_sims_output)
+
         # Resolve micro sim output data for inactive simulations
         for inactive_id in inactive_sim_ids:
             micro_sims_output[inactive_id]["active_state"] = 0

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -725,6 +725,9 @@ class MicroManagerCoupling(MicroManager):
         active_sim_ids = self._adaptivity_controller.get_active_sim_ids()
         inactive_sim_ids = self._adaptivity_controller.get_inactive_sim_ids()
 
+        print("DEBUG active_sim_ids: ", active_sim_ids)
+        print("DEBUG inactive_sim_ids: ", inactive_sim_ids)
+
         micro_sims_output = [0] * self._local_number_of_sims
 
         # Solve all active micro simulations
@@ -760,6 +763,8 @@ class MicroManagerCoupling(MicroManager):
                     )
                     self._logger.log_error_any_rank(error_message)
                     self._has_sim_crashed[active_id] = True
+
+        print("DEBUG _has_sim_crashed: ", self._has_sim_crashed)
 
         # If interpolate is off, terminate after crash
         if not self._interpolate_crashed_sims:

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -725,9 +725,6 @@ class MicroManagerCoupling(MicroManager):
         active_sim_ids = self._adaptivity_controller.get_active_sim_ids()
         inactive_sim_ids = self._adaptivity_controller.get_inactive_sim_ids()
 
-        print("DEBUG active_sim_ids: ", active_sim_ids)
-        print("DEBUG inactive_sim_ids: ", inactive_sim_ids)
-
         micro_sims_output = [0] * self._local_number_of_sims
 
         # Solve all active micro simulations
@@ -764,8 +761,6 @@ class MicroManagerCoupling(MicroManager):
                     self._logger.log_error_any_rank(error_message)
                     self._has_sim_crashed[active_id] = True
 
-        print("DEBUG _has_sim_crashed: ", self._has_sim_crashed)
-
         # If interpolate is off, terminate after crash
         if not self._interpolate_crashed_sims:
             crashed_sims_on_all_ranks = np.zeros(self._size, dtype=np.int64)
@@ -781,7 +776,7 @@ class MicroManagerCoupling(MicroManager):
         # Interpolate result for crashed simulation
         unset_sims = []
         for active_id in active_sim_ids:
-            if micro_sims_output[active_id] is None:
+            if micro_sims_output[active_id] == 0:
                 unset_sims.append(active_id)
 
         # Iterate over all crashed simulations to interpolate output
@@ -804,8 +799,6 @@ class MicroManagerCoupling(MicroManager):
         end_time = time.process_time()
 
         adaptivity_cpu_time += end_time - start_time
-
-        print("DEBUG micro_sim_output: ", micro_sims_output)
 
         # Resolve micro sim output data for inactive simulations
         for inactive_id in inactive_sim_ids:

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -98,7 +98,7 @@ class MicroManagerCoupling(MicroManager):
         self._is_adaptivity_on = self._config.turn_on_adaptivity()
 
         if self._is_adaptivity_on:
-            self._data_for_adaptivity: Dict[str, np.ndarray] = dict()
+            self._data_for_adaptivity: Dict[str, list] = dict()
 
             self._adaptivity_data_names = self._config.get_data_for_adaptivity()
 
@@ -357,7 +357,7 @@ class MicroManagerCoupling(MicroManager):
 
         if self._is_adaptivity_on:
             for name in self._adaptivity_data_names:
-                self._data_for_adaptivity[name] = np.zeros((self._local_number_of_sims))
+                self._data_for_adaptivity[name] = [0] * self._local_number_of_sims
 
         # Create lists of local and global IDs
         sim_id = np.sum(nms_all_ranks[: self._rank])
@@ -725,7 +725,7 @@ class MicroManagerCoupling(MicroManager):
         active_sim_ids = self._adaptivity_controller.get_active_sim_ids()
         inactive_sim_ids = self._adaptivity_controller.get_inactive_sim_ids()
 
-        micro_sims_output = [None] * self._local_number_of_sims
+        micro_sims_output = [0] * self._local_number_of_sims
 
         # Solve all active micro simulations
         for active_id in active_sim_ids:


### PR DESCRIPTION
The Micro Manager could not handle the case where a micro simulation returns vector data in the form of a list. This was because the data collection for adaptivity was done on a predefined `numpy.array` data structure. Now the data collection is done in a Python list and the list is converted to a NumPy array only just before the data is used for the similarity calculation.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
