### PR TITLE
Simplify the algorithm for domain decomposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fix bug in the domain decomposition which was returning incorrect bounding box limits for the decomposition of `[2, 2, 1]` and similar https://github.com/precice/micro-manager/pull/146
 - Fix bug in handling of vector data returned by the MicroSimulation `solve()` method, for scenarios with adaptivity https://github.com/precice/micro-manager/pull/143
 - Remove the `scalar` and `vector` keyword values from data names in configuration https://github.com/precice/micro-manager/pull/142
 - Set default logger to stdout and add output directory setting option for file loggers https://github.com/precice/micro-manager/pull/139

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -48,39 +48,22 @@ class DomainDecomposer:
             np.prod(ranks_per_axis) == self._size
         ), "Total number of processors provided in the Micro Manager configuration and in the MPI execution command do not match."
 
+        for z in range(ranks_per_axis[2]):
+            for y in range(ranks_per_axis[1]):
+                for x in range(ranks_per_axis[0]):
+                    n = (
+                        x
+                        + y * ranks_per_axis[0]
+                        + z * ranks_per_axis[0] * ranks_per_axis[1]
+                    )
+                    if n == self._rank:
+                        rank_in_axis = [x, y, z]
+
         dx = []
         for d in range(self._dims):
             dx.append(
                 abs(macro_bounds[d * 2 + 1] - macro_bounds[d * 2]) / ranks_per_axis[d]
             )
-
-        rank_in_axis: list[int] = [0] * self._dims
-        if ranks_per_axis[0] == 1:  # if serial in x axis
-            rank_in_axis[0] = 0
-        else:
-            rank_in_axis[0] = self._rank % ranks_per_axis[0]  # x axis
-
-        if self._dims == 2:
-            if ranks_per_axis[1] == 1:  # if serial in y axis
-                rank_in_axis[1] = 0
-            else:
-                rank_in_axis[1] = int(self._rank / ranks_per_axis[0])  # y axis
-        elif self._dims == 3:
-            if ranks_per_axis[2] == 1:  # if serial in z axis
-                rank_in_axis[2] = 0
-            else:
-                rank_in_axis[2] = int(
-                    self._rank / (ranks_per_axis[0] * ranks_per_axis[1])
-                )  # z axis
-
-            if ranks_per_axis[1] == 1:  # if serial in y axis
-                rank_in_axis[1] = 0
-            else:
-                rank_in_axis[1] = (
-                    self._rank - ranks_per_axis[0] * ranks_per_axis[1] * rank_in_axis[2]
-                ) % ranks_per_axis[
-                    2
-                ]  # y axis
 
         mesh_bounds = []
         for d in range(self._dims):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -281,9 +281,12 @@ class MicroManagerCoupling(MicroManager):
         assert len(self._macro_bounds) / 2 == self._participant.get_mesh_dimensions(
             self._macro_mesh_name
         ), "Provided macro mesh bounds are of incorrect dimension"
+        assert len(self._ranks_per_axis) == self._participant.get_mesh_dimensions(
+            self._macro_mesh_name
+        ), "Provided ranks combination is of incorrect dimension"
+
         if self._is_parallel:
             domain_decomposer = DomainDecomposer(
-                self._participant.get_mesh_dimensions(self._macro_mesh_name),
                 self._rank,
                 self._size,
             )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -281,11 +281,12 @@ class MicroManagerCoupling(MicroManager):
         assert len(self._macro_bounds) / 2 == self._participant.get_mesh_dimensions(
             self._macro_mesh_name
         ), "Provided macro mesh bounds are of incorrect dimension"
-        assert len(self._ranks_per_axis) == self._participant.get_mesh_dimensions(
-            self._macro_mesh_name
-        ), "Provided ranks combination is of incorrect dimension"
 
         if self._is_parallel:
+            assert len(self._ranks_per_axis) == self._participant.get_mesh_dimensions(
+                self._macro_mesh_name
+            ), "Provided ranks combination is of incorrect dimension"
+
             domain_decomposer = DomainDecomposer(
                 self._rank,
                 self._size,

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -1,5 +1,5 @@
+import unittest
 from unittest import TestCase
-from unittest.mock import MagicMock
 
 import numpy as np
 
@@ -16,6 +16,23 @@ class TestDomainDecomposition(TestCase):
             -2,
             8,
         ]  # Cuboid which is not symmetric around origin
+
+    def test_rank1_out_of_4_3d(self):
+        """
+        Check bounds for rank 1 in a setting of axis-wise ranks: [2, 2, 1]
+        """
+        rank = 1
+        size = 4
+        ranks_per_axis = [2, 2, 1]
+        domain_decomposer = DomainDecomposer(3, rank, size)
+        domain_decomposer._dims = 3
+        mesh_bounds = domain_decomposer.decompose_macro_domain(
+            self._macro_bounds_3d, ranks_per_axis
+        )
+
+        print("mesh_bounds", mesh_bounds)
+
+        self.assertTrue(np.allclose(mesh_bounds, [0.0, 1, -2, 0.0, -2, 8]))
 
     def test_rank5_outof_10_3d(self):
         """

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -14,6 +14,28 @@ class TestDomainDecomposition(TestCase):
             8,
         ]  # Cuboid which is not symmetric around origin
 
+        self._macro_bounds_2d = [
+            0,
+            1,
+            0,
+            2,
+        ]
+
+    def test_rank2_out_of_4_2d(self):
+        """
+        Check bounds for rank 2 in a setting of axis-wise ranks: [2, 2]
+        """
+        rank = 2
+        size = 4
+        ranks_per_axis = [2, 2]
+        domain_decomposer = DomainDecomposer(rank, size)
+        domain_decomposer._dims = 2
+        mesh_bounds = domain_decomposer.decompose_macro_domain(
+            self._macro_bounds_2d, ranks_per_axis
+        )
+
+        self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, 1, 2]))
+
     def test_rank1_out_of_4_3d(self):
         """
         Check bounds for rank 1 in a setting of axis-wise ranks: [2, 2, 1]
@@ -21,7 +43,7 @@ class TestDomainDecomposition(TestCase):
         rank = 1
         size = 4
         ranks_per_axis = [2, 2, 1]
-        domain_decomposer = DomainDecomposer(3, rank, size)
+        domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -36,7 +58,7 @@ class TestDomainDecomposition(TestCase):
         rank = 5
         size = 10
         ranks_per_axis = [1, 2, 5]
-        domain_decomposer = DomainDecomposer(3, rank, size)
+        domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -51,7 +73,7 @@ class TestDomainDecomposition(TestCase):
         rank = 10
         size = 32
         ranks_per_axis = [4, 1, 8]
-        domain_decomposer = DomainDecomposer(3, rank, size)
+        domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -66,7 +88,7 @@ class TestDomainDecomposition(TestCase):
         rank = 7
         size = 16
         ranks_per_axis = [8, 2, 1]
-        domain_decomposer = DomainDecomposer(3, rank, size)
+        domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -1,8 +1,5 @@
-import unittest
 from unittest import TestCase
-
 import numpy as np
-
 from micro_manager.domain_decomposition import DomainDecomposer
 
 
@@ -29,8 +26,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
         )
-
-        print("mesh_bounds", mesh_bounds)
 
         self.assertTrue(np.allclose(mesh_bounds, [0.0, 1, -2, 0.0, -2, 8]))
 


### PR DESCRIPTION
The domain decomposition was yielding incorrect results for cases which have the same number of domains in the `x` and `y` directions, for example `[2, 2, 1]`. This PR simplifies the algorithm and adds tests to ensure that the potentially problematic scenario is covered for.

<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.