### PR TITLE
Remove export of adaptivity CPU time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Remove adaptivity computation CPU time export functionality https://github.com/precice/micro-manager/pull/152
 - Replace `Allgatherv` with `allgather` to avoid running into the error of size buffer https://github.com/precice/micro-manager/pull/151
 - Update Actions workflows due to updates in `precice/precice:nightly` https://github.com/precice/micro-manager/pull/150
 - Move adaptivity CPU time output from preCICE export to metrics logging https://github.com/precice/micro-manager/pull/149

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -176,7 +176,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         return micro_sims_output
 
-    def log_metrics(self, n: int, adaptivity_cpu_time: float) -> None:
+    def log_metrics(self, n: int) -> None:
         """
         Log metrics for global adaptivity.
 
@@ -184,20 +184,17 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         n : int
             Time step count at which the metrics are logged
-        adaptivity_cpu_time : float
-            CPU time taken for adaptivity calculation
         """
         global_active_sims = np.count_nonzero(self._is_sim_active)
         global_inactive_sims = np.count_nonzero(self._is_sim_active == False)
 
         self._metrics_logger.log_info_one_rank(
-            "{},{},{},{},{},{}".format(
+            "{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),
                 np.mean(global_inactive_sims),
                 np.max(global_active_sims),
                 np.max(global_inactive_sims),
-                adaptivity_cpu_time,
             )
         )
 

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -138,7 +138,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         return micro_sims_output
 
-    def log_metrics(self, n: int, adaptivity_cpu_time: float) -> None:
+    def log_metrics(self, n: int) -> None:
         """
         Log metrics for local adaptivity.
 
@@ -146,8 +146,6 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         n : int
             Current time step
-        adaptivity_cpu_time : float
-            CPU time taken for adaptivity calculation
         """
         # MPI Gather is necessary as local adaptivity only stores local data
         local_active_sims = np.count_nonzero(self._is_sim_active)
@@ -157,13 +155,12 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         global_inactive_sims = self._comm.gather(local_inactive_sims)
 
         self._metrics_logger.log_info_one_rank(
-            "{},{},{},{},{},{}".format(
+            "{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),
                 np.mean(global_inactive_sims),
                 np.max(global_active_sims),
                 np.max(global_inactive_sims),
-                adaptivity_cpu_time,
             )
         )
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -192,7 +192,7 @@ class MicroManagerCoupling(MicroManager):
 
             micro_sims_input = self._read_data_from_precice(dt)
 
-            micro_sims_output, adaptivity_time = micro_sim_solve(micro_sims_input, dt)
+            micro_sims_output = micro_sim_solve(micro_sims_input, dt)
 
             # Check if more than a certain percentage of the micro simulations have crashed and terminate if threshold is exceeded
             if self._interpolate_crashed_sims:
@@ -597,7 +597,7 @@ class MicroManagerCoupling(MicroManager):
                     self._macro_mesh_name, dname, [], np.array([])
                 )
 
-    def _solve_micro_simulations(self, micro_sims_input: list, dt: float) -> tuple:
+    def _solve_micro_simulations(self, micro_sims_input: list, dt: float) -> list:
         """
         Solve all micro simulations and assemble the micro simulations outputs in a list of dicts format.
 
@@ -611,8 +611,8 @@ class MicroManagerCoupling(MicroManager):
 
         Returns
         -------
-        tuple
-            A tuple of micro_sims_output (list of Dicts) and dummy adaptivity computation CPU time.
+        micro_sims_output : list
+            List of dicts in which keys are names of data and the values are the data which are required outputs of
         """
         micro_sims_output: list[dict] = [None] * self._local_number_of_sims
 
@@ -670,11 +670,11 @@ class MicroManagerCoupling(MicroManager):
                     micro_sims_input, micro_sims_output, unset_sim
                 )
 
-        return micro_sims_output, 0.0
+        return micro_sims_output
 
     def _solve_micro_simulations_with_adaptivity(
         self, micro_sims_input: list, dt: float
-    ) -> tuple:
+    ) -> list:
         """
         Adaptively solve micro simulations and assemble the micro simulations outputs in a list of dicts format.
 
@@ -688,8 +688,8 @@ class MicroManagerCoupling(MicroManager):
 
         Returns
         -------
-        tuple
-            A tuple of micro_sims_output (list of Dicts) and adaptivity computation CPU time.
+        micro_sims_output : list
+            List of dicts in which keys are names of data and the values are the data which are required outputs of
         """
         active_sim_ids = self._adaptivity_controller.get_active_sim_ids()
 

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -102,9 +102,7 @@ class TestFunctioncalls(TestCase):
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
         manager._micro_sims_active_steps = np.zeros(4, dtype=np.int32)
 
-        micro_sims_output, _ = manager._solve_micro_simulations(
-            self.fake_read_data, 1.0
-        )
+        micro_sims_output = manager._solve_micro_simulations(self.fake_read_data, 1.0)
 
         for data, fake_data in zip(micro_sims_output, self.fake_write_data):
             self.assertEqual(data["micro-scalar-data"], 2)

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -52,7 +52,7 @@ class TestSimulationCrashHandling(TestCase):
         )
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
 
-        micro_sims_output, _ = manager._solve_micro_simulations(macro_data, 1.0)
+        micro_sims_output = manager._solve_micro_simulations(macro_data, 1.0)
 
         # Crashed simulation has interpolated value
         data_crashed = micro_sims_output[2]
@@ -106,7 +106,7 @@ class TestSimulationCrashHandling(TestCase):
             [-2, -2, -2, -2, 2]
         )
 
-        micro_sims_output, _ = manager._solve_micro_simulations_with_adaptivity(
+        micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
             macro_data, 1.0
         )
 


### PR DESCRIPTION
The export of adaptivity computation CPU time is no longer relevant because a newer implementation has been done in https://github.com/precice/micro-manager/pull/141 which uses the preCICE profiling API.

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.