### PR TITLE
Release v0.6.0

### DIFF
--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: micro-manager/tests/integration/test_unit_cube
         run: |
           mpiexec -n 2 --allow-run-as-root micro-manager-precice micro-manager-config-global-adaptivity-parallel.json &
-          python3 unit_cube.py
+          python3 unit_cube.py 2
 
   adaptivity_unit_tests_parallel:
     name: Adaptivity unit tests in parallel

--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -8,8 +8,8 @@ on:
     branches:
       - "*"
 jobs:
-  adaptivity_integration_test_parallel:
-    name: Adaptivity integration test in parallel
+  adaptivity_integration_parallel_tests:
+    name: Adaptivity tests in parallel
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -31,50 +31,27 @@ jobs:
         working-directory: micro-manager
         run: |
           apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
+          apt-get -qq install python3-dev git python3-venv pkg-config
 
-      - name: Install Micro Manager
+      - name: Create a virtual environment and install Micro Manager in it
         working-directory: micro-manager
-        run: pip3 install .
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install .
 
       - name: Run integration test with global adaptivity in parallel
         timeout-minutes: 3
-        working-directory: micro-manager/tests/integration/test_unit_cube
+        working-directory: micro-manager
         run: |
+          . .venv/bin/activate
+          cd tests/integration/test_unit_cube/
           mpiexec -n 2 --allow-run-as-root micro-manager-precice micro-manager-config-global-adaptivity-parallel.json &
           python3 unit_cube.py 2
 
-  adaptivity_unit_tests_parallel:
-    name: Adaptivity unit tests in parallel
-    runs-on: ubuntu-latest
-    container: precice/precice:nightly
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          path: micro-manager
-
-      - name: Install sudo for MPI
-        working-directory: micro-manager
-        run: |
-          apt-get -qq update
-          apt-get -qq install sudo
-
-      - name: Use mpi4py
-        uses: mpi4py/setup-mpi@v1
-
-      - name: Install Dependencies
-        working-directory: micro-manager
-        run: |
-          apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
-
-      - name: Install Micro Manager
-        working-directory: micro-manager
-        run: pip3 install --user .
-
       - name: Run parallel unit tests
-        working-directory: micro-manager/tests/unit
-        run: mpiexec -n 2 --allow-run-as-root python3 -m unittest test_adaptivity_parallel.py
+        working-directory: micro-manager
+        run: |
+          . .venv/bin/activate
+          cd tests/unit
+          mpiexec -n 2 --allow-run-as-root python3 -m unittest test_adaptivity_parallel.py

--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -1,0 +1,80 @@
+name: Test adaptivity functionality in parallel
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  adaptivity_integration_test_parallel:
+    name: Adaptivity integration test in parallel
+    runs-on: ubuntu-latest
+    container: precice/precice:nightly
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: micro-manager
+
+      - name: Install sudo for MPI
+        working-directory: micro-manager
+        run: |
+          apt-get -qq update
+          apt-get -qq install sudo
+
+      - name: Use mpi4py
+        uses: mpi4py/setup-mpi@v1
+
+      - name: Install dependencies
+        working-directory: micro-manager
+        run: |
+          apt-get -qq update
+          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
+          pip3 install --upgrade pip
+
+      - name: Install Micro Manager
+        working-directory: micro-manager
+        run: pip3 install .
+
+      - name: Run integration test with global adaptivity in parallel
+        timeout-minutes: 3
+        working-directory: micro-manager/tests/integration/test_unit_cube
+        run: |
+          mpiexec -n 2 --allow-run-as-root micro-manager-precice micro-manager-config-global-adaptivity-parallel.json &
+          python3 unit_cube.py
+
+  adaptivity_unit_tests_parallel:
+    name: Adaptivity unit tests in parallel
+    runs-on: ubuntu-latest
+    container: precice/precice:nightly
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          path: micro-manager
+
+      - name: Install sudo for MPI
+        working-directory: micro-manager
+        run: |
+          apt-get -qq update
+          apt-get -qq install sudo
+
+      - name: Use mpi4py
+        uses: mpi4py/setup-mpi@v1
+
+      - name: Install Dependencies
+        working-directory: micro-manager
+        run: |
+          apt-get -qq update
+          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
+          pip3 install --upgrade pip
+
+      - name: Install Micro Manager
+        working-directory: micro-manager
+        run: pip3 install --user .
+
+      - name: Run parallel unit tests
+        working-directory: micro-manager/tests/unit
+        run: mpiexec -n 2 --allow-run-as-root python3 -m unittest test_adaptivity_parallel.py

--- a/.github/workflows/run-adaptivity-tests-serial.yml
+++ b/.github/workflows/run-adaptivity-tests-serial.yml
@@ -34,14 +34,14 @@ jobs:
         working-directory: micro-manager/tests/integration/test_unit_cube
         run: |
           micro-manager-precice micro-manager-config-local-adaptivity.json &
-          python3 unit_cube.py
+          python3 unit_cube.py 2
 
       - name: Run integration test with global adaptivity
         timeout-minutes: 3
         working-directory: micro-manager/tests/integration/test_unit_cube
         run: |
           micro-manager-precice micro-manager-config-global-adaptivity.json &
-          python3 unit_cube.py
+          python3 unit_cube.py 2
 
   adaptivity_unit_tests_serial:
     name: Run adaptivity unit tests in serial

--- a/.github/workflows/run-adaptivity-tests-serial.yml
+++ b/.github/workflows/run-adaptivity-tests-serial.yml
@@ -8,8 +8,8 @@ on:
     branches:
       - "*"
 jobs:
-  adaptivity_integration_tests:
-    name: Adaptivity integration tests in serial
+  adaptivity_serial_tests:
+    name: Adaptivity tests in serial
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -22,48 +22,36 @@ jobs:
         working-directory: micro-manager
         run: |
           apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
+          apt-get -qq install python3-dev python3-venv git pkg-config
 
-      - name: Install Micro Manager
+      - name: Create a virtual environment and install the Micro Manager in it
         working-directory: micro-manager
-        run: pip3 install .
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install .
 
       - name: Run integration test with local adaptivity
         timeout-minutes: 3
-        working-directory: micro-manager/tests/integration/test_unit_cube
+        working-directory: micro-manager
         run: |
+          . .venv/bin/activate
+          cd tests/integration/test_unit_cube
           micro-manager-precice micro-manager-config-local-adaptivity.json &
           python3 unit_cube.py 2
 
       - name: Run integration test with global adaptivity
         timeout-minutes: 3
-        working-directory: micro-manager/tests/integration/test_unit_cube
+        working-directory: micro-manager
         run: |
+          . .venv/bin/activate
+          cd tests/integration/test_unit_cube
           micro-manager-precice micro-manager-config-global-adaptivity.json &
           python3 unit_cube.py 2
 
-  adaptivity_unit_tests_serial:
-    name: Run adaptivity unit tests in serial
-    runs-on: ubuntu-latest
-    container: precice/precice:nightly
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          path: micro-manager
-
-      - name: Install Dependencies
+      - name: Run adaptivity unit tests in serial
         working-directory: micro-manager
         run: |
-          apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
-
-      - name: Install Micro Manager
-        working-directory: micro-manager
-        run: pip3 install --user .
-
-      - name: Run unit tests
-        working-directory: micro-manager/tests/unit
-        run: python3 -m unittest test_adaptivity_serial.py
+          . .venv/bin/activate
+          cd tests/unit
+          python3 -m unittest test_adaptivity_serial.py

--- a/.github/workflows/run-adaptivity-tests-serial.yml
+++ b/.github/workflows/run-adaptivity-tests-serial.yml
@@ -1,4 +1,4 @@
-name: Test adaptivity functionality
+name: Test adaptivity functionality in serial
 on:
   push:
     branches:
@@ -9,7 +9,7 @@ on:
       - "*"
 jobs:
   adaptivity_integration_tests:
-    name: Run adaptivity integration tests
+    name: Adaptivity integration tests in serial
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -67,37 +67,3 @@ jobs:
       - name: Run unit tests
         working-directory: micro-manager/tests/unit
         run: python3 -m unittest test_adaptivity_serial.py
-
-  adaptivity_unit_tests_parallel:
-    name: Run adaptivity unit tests in parallel
-    runs-on: ubuntu-latest
-    container: precice/precice:nightly
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          path: micro-manager
-
-      - name: Install sudo for MPI
-        working-directory: micro-manager
-        run: |
-          apt-get -qq update
-          apt-get -qq install sudo
-
-      - name: Use mpi4py
-        uses: mpi4py/setup-mpi@v1
-
-      - name: Install Dependencies
-        working-directory: micro-manager
-        run: |
-          apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
-
-      - name: Install Micro Manager
-        working-directory: micro-manager
-        run: pip3 install --user .
-
-      - name: Run unit tests
-        working-directory: micro-manager/tests/unit
-        run: mpiexec -n 2 --allow-run-as-root python3 -m unittest test_adaptivity_parallel.py

--- a/.github/workflows/run-domain-decomposition-tests.yml
+++ b/.github/workflows/run-domain-decomposition-tests.yml
@@ -8,50 +8,6 @@ on:
     branches:
       - "*"
 jobs:
-  domain_decomposition_integration_tests:
-    name: Run domain decomposition integration tests
-    runs-on: ubuntu-latest
-    container: precice/precice:nightly
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          path: micro-manager
-
-      - name: Install sudo for MPI
-        working-directory: micro-manager
-        run: |
-          apt-get -qq update
-          apt-get -qq install sudo
-
-      - name: Use mpi4py
-        uses: mpi4py/setup-mpi@v1
-
-      - name: Install Dependencies
-        working-directory: micro-manager
-        run: |
-          apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
-
-      - name: Install micro-manager
-        working-directory: micro-manager
-        run: pip3 install .
-
-      - name: Run integration test (2 processes)
-        timeout-minutes: 3
-        working-directory: micro-manager/tests/integration/test_unit_cube
-        run: |
-          mpiexec -n 2 --allow-run-as-root micro-manager-precice micro-manager-config-parallel-1.json &
-          python3 unit_cube.py
-
-      - name: Run integration test (6 processes)
-        timeout-minutes: 3
-        working-directory: micro-manager/tests/integration/test_unit_cube
-        run: |
-          mpiexec -n 6 --oversubscribe --allow-run-as-root micro-manager-precice micro-manager-config-parallel-2.json &
-          python3 unit_cube.py
-
   domain_decomposition_unit_tests:
     name: Run domain decomposition unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/run-domain-decomposition-tests.yml
+++ b/.github/workflows/run-domain-decomposition-tests.yml
@@ -22,13 +22,18 @@ jobs:
         working-directory: micro-manager
         run: |
           apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
+          apt-get -qq install python3-dev python3-venv git pkg-config
 
-      - name: Install Micro Manager
+      - name: Create a virtual environment and install the Micro Manager in it
         working-directory: micro-manager
-        run: pip3 install --user .
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install .
 
       - name: Run unit tests
-        working-directory: micro-manager/tests/unit
-        run: python3 -m unittest test_domain_decomposition.py
+        working-directory: micro-manager
+        run: |
+          . .venv/bin/activate
+          cd tests/unit
+          python3 -m unittest test_domain_decomposition.py

--- a/.github/workflows/run-macro-micro-dummy.yml
+++ b/.github/workflows/run-macro-micro-dummy.yml
@@ -23,43 +23,55 @@ jobs:
         working-directory: micro-manager
         run: |
           apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          apt-get -qq install sudo
-          pip3 install --upgrade pip
+          apt-get -qq install python3-dev python3-venv git pkg-config
 
-      - name: Install micro-manager
+      - name: Create a virtual environment and install Micro Manager in it
+        timeout-minutes: 6
         working-directory: micro-manager
         run: |
-          pip3 install .
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install .
 
-      - name: Run python macro-micro dummy
+      - name: Run python dummy
         timeout-minutes: 3
-        working-directory: micro-manager/examples
+        working-directory: micro-manager
         run: |
+          . .venv/bin/activate
+          cd examples/
           micro-manager-precice micro-manager-python-config.json &
-          python3 macro_dummy.py
+          python3 macro_dummy.py no_adaptivity
+          ./clean-example.sh
 
-      - name: Run adaptive python macro-micro dummy
+      - name: Run python dummy with adaptivity
         timeout-minutes: 3
-        working-directory: micro-manager/examples
+        working-directory: micro-manager
         run: |
+          . .venv/bin/activate
+          cd examples/
           micro-manager-precice micro-manager-python-adaptivity-config.json &
-          python3 macro_dummy.py
+          python3 macro_dummy.py adaptivity
+          ./clean-example.sh
 
-      - name: Run c++ macro-micro dummy
+      - name: Run C++ dummy
         timeout-minutes: 3
-        working-directory: micro-manager/examples
+        working-directory: micro-manager
         run: |
-          cd cpp-dummy/
+          . .venv/bin/activate
+          cd examples/cpp-dummy/
           pip install pybind11
           c++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) micro_cpp_dummy.cpp -o micro_dummy$(python3-config --extension-suffix)
           cd ../
           micro-manager-precice micro-manager-cpp-config.json &
-          python3 macro_dummy.py
+          python3 macro_dummy.py no_adaptivity
+          ./clean-example.sh
 
-      - name: Run adaptive c++ macro-micro dummy
+      - name: Run adaptive C++ dummy
         timeout-minutes: 3
-        working-directory: micro-manager/examples
+        working-directory: micro-manager
         run: |
+          . .venv/bin/activate
+          cd examples/
           micro-manager-precice micro-manager-cpp-adaptivity-config.json &
-          python3 macro_dummy.py
+          python3 macro_dummy.py adaptivity
+          ./clean-example.sh

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -19,39 +19,52 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get -qq update
-          apt-get -qq install python3-dev python3-pip git python-is-python3 pkg-config
-          pip3 install --upgrade pip
+          apt-get -qq install python3-dev python3-venv git pkg-config
 
-      - name: Install Micro Manager and run micro_manager unit test
-        working-directory: micro-manager/
+      - name: Create a virtual environment and install Micro Manager in it
+        timeout-minutes: 6
+        working-directory: micro-manager
         run: |
-          pip3 install --user .
-          pip3 uninstall -y pyprecice
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install .
+
+      - name: Run micro_manager unit test
+        working-directory: micro-manager
+        run: |
+          . .venv/bin/activate
+          pip uninstall -y pyprecice
           cd tests/unit
           python3 -m unittest test_micro_manager.py
 
       - name: Install Micro Manager and run interpolation unit test
-        working-directory: micro-manager/
+        working-directory: micro-manager
         run: |
-          pip3 install --user .[sklearn]
-          pip3 uninstall -y pyprecice
+          . .venv/bin/activate
+          pip install .[sklearn]
+          pip uninstall -y pyprecice
           cd tests/unit
           python3 -m unittest test_interpolation.py
 
       - name: Install Micro Manager and run micro simulation crash unit test
-        working-directory: micro-manager/tests/unit/
+        working-directory: micro-manager
         run: |
+          . .venv/bin/activate
+          cd tests/unit
           python3 -m unittest test_micro_simulation_crash_handling.py
 
       - name: Install Micro Manager and run HDF5 read and write unit tests
         working-directory: micro-manager/
         run: |
-          pip3 install --user .[snapshot]
-          pip3 uninstall -y pyprecice
+          . .venv/bin/activate
+          pip install .[snapshot]
+          pip uninstall -y pyprecice
           cd tests/unit
           python3 -m unittest test_hdf5_functionality.py
 
       - name: Install Micro Manager and run snapshot_computation unit tests
-        working-directory: micro-manager/tests/unit/
+        working-directory: micro-manager
         run: |
+          . .venv/bin/activate
+          cd tests/unit
           python3 -m unittest test_snapshot_computation.py

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -39,11 +39,8 @@ jobs:
           python3 -m unittest test_interpolation.py
 
       - name: Install Micro Manager and run micro simulation crash unit test
-        working-directory: micro-manager/
+        working-directory: micro-manager/tests/unit/
         run: |
-          pip3 install --user .
-          pip3 uninstall -y pyprecice
-          cd tests/unit
           python3 -m unittest test_micro_simulation_crash_handling.py
 
       - name: Install Micro Manager and run HDF5 read and write unit tests
@@ -55,9 +52,6 @@ jobs:
           python3 -m unittest test_hdf5_functionality.py
 
       - name: Install Micro Manager and run snapshot_computation unit tests
-        working-directory: micro-manager/
+        working-directory: micro-manager/tests/unit/
         run: |
-          pip3 install --user .[snapshot]
-          pip3 uninstall -y pyprecice
-          cd tests/unit
           python3 -m unittest test_snapshot_computation.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Micro Manager changelog
 
-## latest
+## v0.6.0
 
 - Add functionality for lazy creation and initialization of micro simulations https://github.com/precice/micro-manager/pull/117
 - Improve logging wrapper function names to be more clear https://github.com/precice/micro-manager/pull/153

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Improve logging by wrapping Python logger in a class https://github.com/precice/micro-manager/pull/133
 - Refactor large parts of solve and adaptivity to group datasets and simplify handling https://github.com/precice/micro-manager/pull/135
 - Add information about adaptivity tuning parameters https://github.com/precice/micro-manager/pull/131
 - Put computation of counting active steps inside the adaptivity variant `if` condition https://github.com/precice/micro-manager/pull/130

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Remove the `adaptivity_data` data structure and handle all adaptivity data internally https://github.com/precice/micro-manager/pull/137
 - Improve logging by wrapping Python logger in a class https://github.com/precice/micro-manager/pull/133
 - Refactor large parts of solve and adaptivity to group datasets and simplify handling https://github.com/precice/micro-manager/pull/135
 - Add information about adaptivity tuning parameters https://github.com/precice/micro-manager/pull/131

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Remove adaptivity computation CPU time export functionality https://github.com/precice/micro-manager/pull/152
 - Replace `Allgatherv` with `allgather` to avoid running into the error of size buffer https://github.com/precice/micro-manager/pull/151
 - Update Actions workflows due to updates in `precice/precice:nightly` https://github.com/precice/micro-manager/pull/150
 - Move adaptivity CPU time output from preCICE export to metrics logging https://github.com/precice/micro-manager/pull/149

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Refactor large parts of solve and adaptivity to group datasets and simplify handling https://github.com/precice/micro-manager/pull/135
 - Add information about adaptivity tuning parameters https://github.com/precice/micro-manager/pull/131
 - Put computation of counting active steps inside the adaptivity variant `if` condition https://github.com/precice/micro-manager/pull/130
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Set default logger to stdout and add output directory setting option for file loggers https://github.com/precice/micro-manager/pull/139
 - Remove the `adaptivity_data` data structure and handle all adaptivity data internally https://github.com/precice/micro-manager/pull/137
 - Improve logging by wrapping Python logger in a class https://github.com/precice/micro-manager/pull/133
 - Refactor large parts of solve and adaptivity to group datasets and simplify handling https://github.com/precice/micro-manager/pull/135

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Micro Manager changelog
 
+## latest
+
+- Put computation of counting active steps inside the adaptivity variant `if` condition https://github.com/precice/micro-manager/pull/130
+
 ## v0.5.0
 
 - Use absolute values to calculate normalizing factor for relative norms in adaptivity https://github.com/precice/micro-manager/pull/125

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Update Actions workflows due to updates in `precice/precice:nightly` https://github.com/precice/micro-manager/pull/150
 - Move adaptivity CPU time output from preCICE export to metrics logging https://github.com/precice/micro-manager/pull/149
 - Fix bug in the domain decomposition which was returning incorrect bounding box limits for the decomposition of `[2, 2, 1]` and similar https://github.com/precice/micro-manager/pull/146
 - Fix bug in calling of the adaptivity computation for explicit coupling scenarios https://github.com/precice/micro-manager/pull/145

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Replace `Allgatherv` with `allgather` to avoid running into the error of size buffer https://github.com/precice/micro-manager/pull/151
 - Update Actions workflows due to updates in `precice/precice:nightly` https://github.com/precice/micro-manager/pull/150
 - Move adaptivity CPU time output from preCICE export to metrics logging https://github.com/precice/micro-manager/pull/149
 - Fix bug in the domain decomposition which was returning incorrect bounding box limits for the decomposition of `[2, 2, 1]` and similar https://github.com/precice/micro-manager/pull/146

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Move adaptivity CPU time output from preCICE export to metrics logging https://github.com/precice/micro-manager/pull/149
 - Fix bug in the domain decomposition which was returning incorrect bounding box limits for the decomposition of `[2, 2, 1]` and similar https://github.com/precice/micro-manager/pull/146
 - Fix bug in calling of the adaptivity computation for explicit coupling scenarios https://github.com/precice/micro-manager/pull/145
 - Fix bug in handling of vector data returned by the MicroSimulation `solve()` method, for scenarios with adaptivity https://github.com/precice/micro-manager/pull/143

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fix bug in handling of vector data returned by the MicroSimulation `solve()` method, for scenarios with adaptivity https://github.com/precice/micro-manager/pull/143
 - Remove the `scalar` and `vector` keyword values from data names in configuration https://github.com/precice/micro-manager/pull/142
 - Set default logger to stdout and add output directory setting option for file loggers https://github.com/precice/micro-manager/pull/139
 - Remove the `adaptivity_data` data structure and handle all adaptivity data internally https://github.com/precice/micro-manager/pull/137

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fix bug in calling of the adaptivity computation for explicit coupling scenarios https://github.com/precice/micro-manager/pull/145
 - Fix bug in handling of vector data returned by the MicroSimulation `solve()` method, for scenarios with adaptivity https://github.com/precice/micro-manager/pull/143
 - Remove the `scalar` and `vector` keyword values from data names in configuration https://github.com/precice/micro-manager/pull/142
 - Set default logger to stdout and add output directory setting option for file loggers https://github.com/precice/micro-manager/pull/139

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Remove the `scalar` and `vector` keyword values from data names in configuration https://github.com/precice/micro-manager/pull/142
 - Set default logger to stdout and add output directory setting option for file loggers https://github.com/precice/micro-manager/pull/139
 - Remove the `adaptivity_data` data structure and handle all adaptivity data internally https://github.com/precice/micro-manager/pull/137
 - Improve logging by wrapping Python logger in a class https://github.com/precice/micro-manager/pull/133

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Improve logging wrapper function names to be more clear https://github.com/precice/micro-manager/pull/153
 - Remove adaptivity computation CPU time export functionality https://github.com/precice/micro-manager/pull/152
 - Replace `Allgatherv` with `allgather` to avoid running into the error of size buffer https://github.com/precice/micro-manager/pull/151
 - Update Actions workflows due to updates in `precice/precice:nightly` https://github.com/precice/micro-manager/pull/150

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fix bug in the domain decomposition which was returning incorrect bounding box limits for the decomposition of `[2, 2, 1]` and similar https://github.com/precice/micro-manager/pull/146
 - Fix bug in calling of the adaptivity computation for explicit coupling scenarios https://github.com/precice/micro-manager/pull/145
 - Fix bug in handling of vector data returned by the MicroSimulation `solve()` method, for scenarios with adaptivity https://github.com/precice/micro-manager/pull/143
 - Remove the `scalar` and `vector` keyword values from data names in configuration https://github.com/precice/micro-manager/pull/142

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Add information about adaptivity tuning parameters https://github.com/precice/micro-manager/pull/131
 - Put computation of counting active steps inside the adaptivity variant `if` condition https://github.com/precice/micro-manager/pull/130
 
 ## v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Add functionality for lazy creation and initialization of micro simulations https://github.com/precice/micro-manager/pull/117
 - Improve logging wrapper function names to be more clear https://github.com/precice/micro-manager/pull/153
 - Remove adaptivity computation CPU time export functionality https://github.com/precice/micro-manager/pull/152
 - Replace `Allgatherv` with `allgather` to avoid running into the error of size buffer https://github.com/precice/micro-manager/pull/151

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
     <img src="https://img.shields.io/github/license/precice/micro-manager.svg" alt="GNU LGPL license">
 </a>
 
-<a style="text-decoration: none" href="https://github.com/precice/fenics-adapter/actions/workflows/build-and-test.yml" target="_blank">
-    <img src="https://github.com/precice/micro-manager/actions/workflows/run-adaptivity-test.yml/badge.svg" alt="Test Adaptivity">
-</a>
-
 <a style="text-decoration: none" href="https://pypi.org/project/micro-manager-precice/" target="_blank">
     <img src="https://github.com/precice/micro-manager/actions/workflows/pythonpublish.yml/badge.svg" alt="Upload Python Package">
 </a>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ Parameter | Description
 `refining_constant` | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$.
 `every_implicit_iteration` | If True, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.
 `similarity_measure`| Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*.
+`lazy_initialization` | Set to `True` to lazily create and initialize micro simulations. If selected, micro simulation objects are created only when the micro simulation is activated for the first time. Default: `False`.
 
 The primary tuning parameters for adaptivity are the history parameter $$ \Lambda $$, the coarsening constant $$ C_c $$, and the refining constant $$ C_r $$. Their effects can be interpreted as:
 
@@ -139,7 +140,8 @@ Example of adaptivity configuration is
         "history_param": 0.5,
         "coarsening_constant": 0.3,
         "refining_constant": 0.4,
-        "every_implicit_iteration": "True"
+        "every_implicit_iteration": "True",
+        "lazy_initialization": "True"
     }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,7 +120,6 @@ Parameter | Description
 `refining_constant` | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$.
 `every_implicit_iteration` | If True, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.
 `similarity_measure`| Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*.
-`output_cpu_time` | Write CPU time of the adaptivity computation to preCICE, to be exported. This parameter is *optional*.
 
 The primary tuning parameters for adaptivity are the history parameter $$ \Lambda $$, the coarsening constant $$ C_c $$, and the refining constant $$ C_r $$. Their effects can be interpreted as:
 
@@ -170,8 +169,6 @@ The Micro Manager uses the output functionality of preCICE, hence these data set
     <write-data name="active_steps" mesh="macro-mesh"/>
 </participant>
 ```
-
-If the parameter `output_cpu_time` in `adaptivity_settings` is set to `True`, a scalar data field `adaptivity_cpu_time` needs to be added in the same way as described above.
 
 ## Interpolate a crashed micro simulation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,8 +15,8 @@ The Micro Manager is configured with a JSON file. An example configuration file 
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"temperature": "scalar", "heat-flux": "vector"},
-        "write_data_names": {"porosity": "scalar", "conductivity": "vector"}
+        "read_data_names": ["temperature", "heat-flux"],
+        "write_data_names": ["porosity", "conductivity"]
     },
     "simulation_params": {
         "macro_domain_bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
@@ -40,8 +40,8 @@ Parameter | Description
 --- | ---
 `precice_config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
 `macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
-`read_data_names` |  A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
-`write_data_names` |  A Python dictionary with the names of the data to be written to preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
+`read_data_names` |  A list with the names of the data to be read from preCICE.
+`write_data_names` |  A list with the names of the data to be written to preCICE.
 
 ## Simulation Parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ The Micro Manager is configured with a JSON file. An example configuration file 
 {
     "micro_file_name": "micro_solver",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"temperature": "scalar", "heat-flux": "vector"},
         "write_data_names": {"porosity": "scalar", "conductivity": "vector"}
@@ -38,7 +38,7 @@ There are three main sections in the configuration file, the `coupling_params`, 
 
 Parameter | Description
 --- | ---
-`config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
+`precice_config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
 `macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
 `read_data_names` |  A Python dictionary with the names of the data to be read from preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
 `write_data_names` |  A Python dictionary with the names of the data to be written to preCICE as keys and `"scalar"` or `"vector"`  as values depending on the nature of the data.
@@ -74,14 +74,14 @@ If the parameter `data_from_micro_sims` is set, the data to be output needs to b
 </participant>
 ```
 
-If `output_micro_sim_solve_time` is set, add similar entries for the data `micro_sim_time` in the following way:
+If `output_micro_sim_solve_time` is set, add similar entries for the data `solve_cpu_time` in the following way:
 
 ```xml
-<data:scalar name="micro_sim_time"/>
+<data:scalar name="solve_cpu_time"/>
 
 <participant name="Micro-Manager">
   ...
-  <write-data name="micro_sim_time" mesh="macro-mesh"/>
+  <write-data name="solve_cpu_time" mesh="macro-mesh"/>
   <export:vtu directory="Micro-Manager-output" every-n-time-windows="5"/>
 </participant>
 ```
@@ -120,6 +120,7 @@ Parameter | Description
 `refining_constant` | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$.
 `every_implicit_iteration` | If True, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.
 `similarity_measure`| Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*.
+`output_cpu_time` | Write CPU time of the adaptivity computation to preCICE, to be exported. This parameter is *optional*.
 
 The primary tuning parameters for adaptivity are the history parameter $$ \Lambda $$, the coarsening constant $$ C_c $$, and the refining constant $$ C_r $$. Their effects can be interpreted as:
 
@@ -169,6 +170,8 @@ The Micro Manager uses the output functionality of preCICE, hence these data set
     <write-data name="active_steps" mesh="macro-mesh"/>
 </participant>
 ```
+
+If the parameter `output_cpu_time` in `adaptivity_settings` is set to `True`, a scalar data field `adaptivity_cpu_time` needs to be added in the same way as described above.
 
 ## Interpolate a crashed micro simulation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,10 +116,16 @@ Parameter | Description
 `type` | Set to either `local` or `global`. The type of adaptivity matters when the Micro Manager is run in parallel. `local` means comparing micro simulations within a local partitioned domain for similarity. `global` means comparing micro simulations from all partitions, so over the entire domain.
 `data` | List of names of data which are to be used to calculate if micro-simulations are similar or not. For example `["temperature", "porosity"]`.
 `history_param` | History parameter $$ \Lambda $$, set as $$ \Lambda >= 0 $$.
-`coarsening_constant` | Coarsening constant $$ C_c $$, set as $$ C_c < 1 $$.
-`refining_constant` | Refining constant $$ C_r $$, set as $$ C_r >= 0 $$.
+`coarsening_constant` | Coarsening constant $$ C_c $$, set as $$ 0 =< C_c < 1 $$.
+`refining_constant` | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$.
 `every_implicit_iteration` | If True, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.
 `similarity_measure`| Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*.
+
+The primary tuning parameters for adaptivity are the history parameter $$ \Lambda $$, the coarsening constant $$ C_c $$, and the refining constant $$ C_r $$. Their effects can be interpreted as:
+
+- Higher values of the history parameter $$ \Lambda $$ imply lower significance of the similarity measures in the previous timestep on the similarity measure and thus adaptivity state in the current timestep.
+- Higher values of the coarsening constant $$ C_c $$ imply that more active simulations from the previous timestep will remain active in the current timestep.
+- Higher values of the refining constant $$ C_r $$ imply that less inactive points from the previous timestep will become active in the current timestep.
 
 Example of adaptivity configuration is
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Solverdummies
 
-The `solverdummies` are minimal working examples for using the preCICE Micro Manager with different languages. At the moment, there are examples for Python, and C++. They can be coupled with any other solver, for example the `macro_dummy.py` in this directory.
+The `solverdummies` are minimal working examples for using the preCICE Micro Manager with different languages. At the moment, there are examples for Python, and C++. They can be coupled with any other solver, for example the `macro_dummy.py` in this directory. The `macro_dummy.py` needs the input `adaptivity` or `no_adaptivity` depending on which type of dummy problem is being solved.
 
 ## Python
 
@@ -9,7 +9,7 @@ To run the Python solverdummies, run the commands given below in the `examples/`
 First terminal:
 
 ```bash
-python macro_dummy.py
+python macro_dummy.py no_adaptivity
 ```
 
 Second terminal:
@@ -25,7 +25,7 @@ To run the Python solverdummies with adaptivity, run the commands given below in
 First terminal:
 
 ```bash
-python macro_dummy.py
+python macro_dummy.py adaptivity
 ```
 
 Second terminal:
@@ -64,7 +64,7 @@ To run the Python solverdummies, run the commands given below in the `examples/`
 First terminal:
 
 ```bash
-python macro_dummy.py
+python macro_dummy.py no_adaptivity
 ```
 
 Second terminal:
@@ -78,7 +78,7 @@ To run the C++ solverdummies with adaptivity, run the following commands in the 
 First terminal:
 
 ```bash
-python macro_dummy.py
+python macro_dummy.py adaptivity
 ```
 
 Second terminal:

--- a/examples/macro_dummy.py
+++ b/examples/macro_dummy.py
@@ -3,19 +3,36 @@
 
 import numpy as np
 import precice
+import argparse
 
 
 def main():
     """
     Dummy macro simulation which is coupled to a set of micro simulations via preCICE and the Micro Manager
     """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "adaptivity",
+        help="the simulation is run with adaptivity",
+        type=str,
+        choices=["adaptivity", "no_adaptivity"],
+    )
+    args = parser.parse_args()
+
     nv = 25  # number of vertices
 
     n = n_checkpoint = 0
     t = t_checkpoint = 0
 
     # preCICE setup
-    interface = precice.Participant("Macro-dummy", "precice-config.xml", 0, 1)
+    if args.adaptivity == "no_adaptivity":
+        interface = precice.Participant("Macro-dummy", "precice-config.xml", 0, 1)
+    elif args.adaptivity == "adaptivity":
+        interface = precice.Participant(
+            "Macro-dummy", "precice-config-adaptivity.xml", 0, 1
+        )
+    else:
+        raise ValueError("Unknown adaptivity setting")
 
     # define coupling meshes
     read_mesh_name = write_mesh_name = "macro-mesh"

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "cpp-dummy/micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config-adaptivity.xml",
+        "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
@@ -16,7 +16,8 @@
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "True"
+            "every_implicit_iteration": "True",
+            "output_cpu_time": "True"
         }
     },
     "diagnostics": {

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "cpp-dummy/micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "python-dummy/micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config-adaptivity.xml",
+        "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
@@ -16,7 +16,8 @@
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "True"
+            "every_implicit_iteration": "True",
+            "output_cpu_time": "True"
         }
     },
     "diagnostics": {

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "python-dummy/micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/examples/precice-config-adaptivity.xml
+++ b/examples/precice-config-adaptivity.xml
@@ -10,18 +10,20 @@
     <data:vector name="macro-vector-data"/>
     <data:scalar name="micro-scalar-data"/>
     <data:vector name="micro-vector-data"/>
-    <data:scalar name="micro_sim_time"/>
+    <data:scalar name="solve_cpu_time"/>
     <data:scalar name="active_state"/>
     <data:scalar name="active_steps"/>
+    <data:scalar name="adaptivity_cpu_time"/>
 
     <mesh name="macro-mesh" dimensions="3">
        <use-data name="macro-scalar-data"/>
        <use-data name="macro-vector-data"/>
        <use-data name="micro-scalar-data"/>
        <use-data name="micro-vector-data"/>
-       <use-data name="micro_sim_time"/>
+       <use-data name="solve_cpu_time"/>
        <use-data name="active_state"/>
        <use-data name="active_steps"/>
+       <use-data name="adaptivity_cpu_time"/>
     </mesh>
 
     <participant name="Macro-dummy">
@@ -38,9 +40,10 @@
       <read-data name="macro-vector-data" mesh="macro-mesh"/>
       <write-data name="micro-scalar-data" mesh="macro-mesh"/>
       <write-data name="micro-vector-data" mesh="macro-mesh"/>
-      <write-data name="micro_sim_time" mesh="macro-mesh"/>
+      <write-data name="solve_cpu_time" mesh="macro-mesh"/>
       <write-data name="active_state" mesh="macro-mesh"/>
       <write-data name="active_steps" mesh="macro-mesh"/>
+      <write-data name="adaptivity_cpu_time" mesh="macro-mesh"/>
     </participant>
 
     <m2n:sockets acceptor="Micro-Manager" connector="Macro-dummy"/>

--- a/examples/precice-config-adaptivity.xml
+++ b/examples/precice-config-adaptivity.xml
@@ -13,7 +13,6 @@
     <data:scalar name="solve_cpu_time"/>
     <data:scalar name="active_state"/>
     <data:scalar name="active_steps"/>
-    <data:scalar name="adaptivity_cpu_time"/>
 
     <mesh name="macro-mesh" dimensions="3">
        <use-data name="macro-scalar-data"/>
@@ -23,7 +22,6 @@
        <use-data name="solve_cpu_time"/>
        <use-data name="active_state"/>
        <use-data name="active_steps"/>
-       <use-data name="adaptivity_cpu_time"/>
     </mesh>
 
     <participant name="Macro-dummy">
@@ -43,7 +41,6 @@
       <write-data name="solve_cpu_time" mesh="macro-mesh"/>
       <write-data name="active_state" mesh="macro-mesh"/>
       <write-data name="active_steps" mesh="macro-mesh"/>
-      <write-data name="adaptivity_cpu_time" mesh="macro-mesh"/>
     </participant>
 
     <m2n:sockets acceptor="Micro-Manager" connector="Macro-dummy"/>

--- a/examples/precice-config.xml
+++ b/examples/precice-config.xml
@@ -8,14 +8,14 @@
   <data:vector name="macro-vector-data" />
   <data:scalar name="micro-scalar-data" />
   <data:vector name="micro-vector-data" />
-  <data:scalar name="micro_sim_time" />
+  <data:scalar name="solve_cpu_time" />
 
   <mesh name="macro-mesh" dimensions="3">
     <use-data name="macro-scalar-data" />
     <use-data name="macro-vector-data" />
     <use-data name="micro-scalar-data" />
     <use-data name="micro-vector-data" />
-    <use-data name="micro_sim_time" />
+    <use-data name="solve_cpu_time" />
   </mesh>
 
   <participant name="Macro-dummy">
@@ -32,7 +32,7 @@
     <read-data name="macro-vector-data" mesh="macro-mesh" />
     <write-data name="micro-scalar-data" mesh="macro-mesh" />
     <write-data name="micro-vector-data" mesh="macro-mesh" />
-    <write-data name="micro_sim_time" mesh="macro-mesh" />
+    <write-data name="solve_cpu_time" mesh="macro-mesh" />
   </participant>
 
   <m2n:sockets acceptor="Micro-Manager" connector="Macro-dummy" />

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -5,6 +5,7 @@ import sys
 from math import exp
 from typing import Callable
 from warnings import warn
+import subprocess
 from micro_manager.tools.logging_wrapper import Logger
 
 import numpy as np
@@ -37,9 +38,17 @@ class AdaptivityCalculator:
             configurator.get_adaptivity_similarity_measure()
         )
 
-        self._metrics_logger = Logger(
-            "Adaptivity", "adaptivity-metrics.csv", rank, csv_logger=True
-        )
+        output_dir = configurator.get_output_dir()
+
+        if output_dir is not None:
+            subprocess.run(["mkdir", "-p", output_dir])  # Create output directory
+            self._metrics_logger = Logger(
+                __name__, output_dir + "/adaptivity-metrics.csv", rank, csv_logger=True
+            )
+        else:
+            self._metrics_logger = Logger(
+                __name__, "adaptivity-metrics.csv", rank=rank, csv_logger=True
+            )
 
         self._metrics_logger.log_info_one_rank(
             "Time Window,Avg Active Sims,Avg Inactive Sims,Max Active,Max Inactive"

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -50,7 +50,7 @@ class AdaptivityCalculator:
                 __name__, "adaptivity-metrics.csv", rank=rank, csv_logger=True
             )
 
-        self._metrics_logger.log_info_one_rank(
+        self._metrics_logger.log_info_rank_zero(
             "Time Window,Avg Active Sims,Avg Inactive Sims,Max Active,Max Inactive"
         )
 

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -28,6 +28,8 @@ class AdaptivityCalculator:
         self._hist_param = configurator.get_adaptivity_hist_param()
         self._adaptivity_data_names = configurator.get_data_for_adaptivity()
         self._adaptivity_type = configurator.get_adaptivity_type()
+        self._micro_file_name = configurator.get_micro_file_name()
+        self._lazy_init = configurator.initialize_sims_lazily()
 
         self._coarse_tol = 0.0
         self._ref_tol = 0.0

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -5,12 +5,13 @@ import sys
 from math import exp
 from typing import Callable
 from warnings import warn
+from micro_manager.tools.logging_wrapper import Logger
 
 import numpy as np
 
 
 class AdaptivityCalculator:
-    def __init__(self, configurator) -> None:
+    def __init__(self, configurator, rank) -> None:
         """
         Class constructor.
 
@@ -18,7 +19,8 @@ class AdaptivityCalculator:
         ----------
         configurator : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
-        logger : Logger defined from the standard package logging
+        rank : int
+            Rank of the MPI communicator.
         """
         self._refine_const = configurator.get_adaptivity_refining_const()
         self._coarse_const = configurator.get_adaptivity_coarsening_const()
@@ -29,8 +31,18 @@ class AdaptivityCalculator:
         self._coarse_tol = 0.0
         self._ref_tol = 0.0
 
+        self._rank = rank
+
         self._similarity_measure = self._get_similarity_measure(
             configurator.get_adaptivity_similarity_measure()
+        )
+
+        self._metrics_logger = Logger(
+            "Adaptivity", "adaptivity-metrics.csv", rank, csv_logger=True
+        )
+
+        self._metrics_logger.log_info_one_rank(
+            "Time Window,Avg Active Sims,Avg Inactive Sims,Max Active,Max Inactive"
         )
 
     def _get_similarity_dists(

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -78,7 +78,7 @@ class AdaptivityCalculator:
 
         data_diff = np.zeros_like(_similarity_dists)
         for name in data.keys():
-            data_vals = data[name]
+            data_vals = np.array(data[name])
             if data_vals.ndim == 1:
                 # If the adaptivity data is a scalar for each simulation,
                 # expand the dimension to make it a 2D array to unify the calculation.

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -10,7 +10,7 @@ import numpy as np
 
 
 class AdaptivityCalculator:
-    def __init__(self, configurator, logger) -> None:
+    def __init__(self, configurator) -> None:
         """
         Class constructor.
 
@@ -25,8 +25,6 @@ class AdaptivityCalculator:
         self._hist_param = configurator.get_adaptivity_hist_param()
         self._adaptivity_data_names = configurator.get_data_for_adaptivity()
         self._adaptivity_type = configurator.get_adaptivity_type()
-
-        self._logger = logger
 
         self._coarse_tol = 0.0
         self._ref_tol = 0.0

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -20,7 +20,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         self,
         configurator,
         logger,
-        global_number_of_sims: float,
+        global_number_of_sims: int,
         global_ids: list,
         rank: int,
         comm,
@@ -34,8 +34,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             Object which has getter functions to get parameters defined in the configuration file.
         logger : object of logging
             Logger defined from the standard package logging
-        global_number_of_sims : float
-            List of booleans. True if simulation is on this rank, False otherwise.
+        global_number_of_sims : int
+            Total number of simulations in the macro-micro coupled problem.
         global_ids : list
             List of global IDs of simulations living on this rank.
         rank : int

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -176,7 +176,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         return micro_sims_output
 
-    def log_metrics(self, n: int, adaptivity_cpu_time: float) -> None:
+    def log_metrics(self, n: int) -> None:
         """
         Log metrics for global adaptivity.
 
@@ -184,20 +184,17 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         n : int
             Time step count at which the metrics are logged
-        adaptivity_cpu_time : float
-            CPU time taken for adaptivity calculation
         """
         global_active_sims = np.count_nonzero(self._is_sim_active)
         global_inactive_sims = np.count_nonzero(self._is_sim_active == False)
 
         self._metrics_logger.log_info_one_rank(
-            "{},{},{},{},{},{}".format(
+            "{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),
                 np.mean(global_inactive_sims),
                 np.max(global_active_sims),
                 np.max(global_inactive_sims),
-                adaptivity_cpu_time,
             )
         )
 

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -179,7 +179,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         return micro_sims_output
 
-    def log_metrics(self, n: int) -> None:
+    def log_metrics(self, n: int, adaptivity_cpu_time: float) -> None:
         """
         Log metrics for global adaptivity.
 
@@ -187,17 +187,20 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         n : int
             Time step count at which the metrics are logged
+        adaptivity_cpu_time : float
+            CPU time taken for adaptivity calculation
         """
         global_active_sims = np.count_nonzero(self._is_sim_active)
         global_inactive_sims = np.count_nonzero(self._is_sim_active == False)
 
         self._metrics_logger.log_info_one_rank(
-            "{},{},{},{},{}".format(
+            "{},{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),
                 np.mean(global_inactive_sims),
                 np.max(global_active_sims),
                 np.max(global_inactive_sims),
+                adaptivity_cpu_time,
             )
         )
 

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -70,9 +70,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         self,
         dt: float,
         micro_sims: list,
-        similarity_dists_nm1: np.ndarray,
-        is_sim_active_nm1: np.ndarray,
-        sim_is_associated_to_nm1: np.ndarray,
+        adaptivity_data_nm1: list,
         data_for_adaptivity: dict,
     ) -> tuple:
         """
@@ -84,21 +82,21 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             Current time step of the macro-micro coupled problem
         micro_sims : list
             List of objects of class MicroProblem, which are the micro simulations
-        similarity_dists_nm1 : numpy array
-            2D array having similarity distances between each micro simulation pair
-        is_sim_active_nm1 : numpy array
-            1D array having state (active or inactive) of each micro simulation on this rank
-        sim_is_associated_to_nm1 : numpy array
-            1D array with values of associated simulations of inactive simulations. Active simulations have None
+        adaptivity_data_nm1 : list
+            List of numpy arrays:
+                similarity_dists (2D array having similarity distances between each micro simulation pair)
+                is_sim_active (1D array having state (active or inactive) of each micro simulation)
+                sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
         data_for_adaptivity : dict
             Dictionary with keys as names of data to be used in the similarity calculation, and values as the respective data for the micro simulations
 
         Results
         -------
-        similarity_dists : numpy array
-            2D array having similarity distances between each micro simulation pair
-        is_sim_active : numpy array
-            1D array having state (active or inactive) of each micro simulation
+        list
+            List of numpy arrays:
+                similarity_dists (2D array having similarity distances between each micro simulation pair)
+                is_sim_active (1D array having state (active or inactive) of each micro simulation)
+                sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
         """
         for name in data_for_adaptivity.keys():
             if name not in self._adaptivity_data_names:
@@ -115,13 +113,15 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             global_data_for_adaptivity[name] = np.concatenate((data_as_list[:]), axis=0)
 
         similarity_dists = self._get_similarity_dists(
-            dt, similarity_dists_nm1, global_data_for_adaptivity
+            dt, adaptivity_data_nm1[0], global_data_for_adaptivity
         )
 
-        is_sim_active = self._update_active_sims(similarity_dists, is_sim_active_nm1)
+        is_sim_active = self._update_active_sims(
+            similarity_dists, adaptivity_data_nm1[1]
+        )
 
         is_sim_active, sim_is_associated_to = self._update_inactive_sims(
-            similarity_dists, is_sim_active, sim_is_associated_to_nm1, micro_sims
+            similarity_dists, is_sim_active, adaptivity_data_nm1[2], micro_sims
         )
         sim_is_associated_to = self._associate_inactive_to_active(
             similarity_dists, is_sim_active, sim_is_associated_to
@@ -139,12 +139,73 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             )
         )
 
-        return similarity_dists, is_sim_active, sim_is_associated_to
+        return [similarity_dists, is_sim_active, sim_is_associated_to]
 
-    def communicate_micro_output(
+    def get_active_sim_ids(self, is_sim_active: np.array) -> np.ndarray:
+        """
+        Get the ids of active simulations.
+
+        Parameters
+        ----------
+        is_sim_active : numpy array
+            1D array having state (active or inactive) of each micro simulation
+
+        Returns
+        -------
+        numpy array
+            1D array of active simulation ids
+        """
+        return np.where(is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1])[
+            0
+        ]
+
+    def get_inactive_sim_ids(self, is_sim_active: np.array) -> np.ndarray:
+        """
+        Get the ids of inactive simulations.
+
+        Parameters
+        ----------
+        is_sim_active : numpy array
+            1D array having state (active or inactive) of each micro simulation
+
+        Returns
+        -------
+        numpy array
+            1D array of inactive simulation ids
+        """
+        return np.where(
+            is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1] == False
+        )[0]
+
+    def get_full_field_micro_output(
+        self, adaptivity_data: list, micro_output: list
+    ) -> list:
+        """
+        Get the full field micro output from active simulations to inactive simulations.
+
+        Parameters
+        ----------
+        adaptivity_data : list
+            List of numpy arrays:
+                similarity_dists (2D array having similarity distances between each micro simulation pair)
+                is_sim_active (1D array having state (active or inactive) of each micro simulation)
+                sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
+        micro_output : list
+            List of dicts having individual output of each simulation. Only the active simulation outputs are entered.
+
+        Returns
+        -------
+        micro_output : list
+            List of dicts having individual output of each simulation. Active and inactive simulation outputs are entered.
+        """
+        micro_sims_output = deepcopy(micro_output)
+        self._communicate_micro_output(adaptivity_data[1:3], micro_sims_output)
+
+        return micro_sims_output
+
+    def _communicate_micro_output(
         self,
-        is_sim_active: np.ndarray,
-        sim_is_associated_to: np.ndarray,
+        adaptivity_data: list,
         micro_output: list,
     ) -> None:
         """
@@ -155,13 +216,16 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         micro_sims : list
             List of objects of class MicroProblem, which are the micro simulations
-        is_sim_active : numpy array
-            1D array having state (active or inactive) of each micro simulation on this rank
-        sim_is_associated_to : numpy array
-            1D array with values of associated simulations of inactive simulations. Active simulations have -2
+        adaptivity_data : list
+            List of numpy arrays:
+                is_sim_active (1D array having state (active or inactive) of each micro simulation)
+                sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
         micro_output : list
             List of dicts having individual output of each simulation. Only the active simulation outputs are entered.
         """
+        is_sim_active = adaptivity_data[0]
+        sim_is_associated_to = adaptivity_data[1]
+
         inactive_local_ids = np.where(
             is_sim_active[self._global_ids[0] : self._global_ids[-1] + 1] == False
         )[0]

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -6,6 +6,7 @@ on each rank is done.
 Note: All ID variables used in the methods of this class are global IDs, unless they have *local* in their name.
 """
 import hashlib
+import importlib
 from copy import deepcopy
 from typing import Dict
 
@@ -13,6 +14,7 @@ import numpy as np
 from mpi4py import MPI
 
 from .adaptivity import AdaptivityCalculator
+from ..micro_simulation import create_simulation_class
 
 
 class GlobalAdaptivityCalculator(AdaptivityCalculator):
@@ -78,6 +80,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         self._is_sim_active_cp = None
         self._sim_is_associated_to_cp = None
 
+        self._updating_inactive_sims = self._get_update_inactive_sims_variant()
+
     def compute_adaptivity(
         self,
         dt: float,
@@ -116,7 +120,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         is_sim_active = self._update_active_sims(similarity_dists, self._is_sim_active)
 
-        is_sim_active, sim_is_associated_to = self._update_inactive_sims(
+        is_sim_active, sim_is_associated_to = self._updating_inactive_sims(
             similarity_dists, is_sim_active, self._sim_is_associated_to, micro_sims
         )
 
@@ -366,6 +370,135 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 micro_sims[local_id].set_state(state)
 
         return _is_sim_active, _sim_is_associated_to_updated
+
+    def _update_inactive_sims_lazy_init(
+        self,
+        similarity_dists: np.ndarray,
+        is_sim_active: np.ndarray,
+        sim_is_associated_to: np.ndarray,
+        micro_sims: list,
+    ) -> tuple:
+        """
+        Update set of inactive micro simulations. Each inactive micro simulation is compared to all active ones and if it is not similar to any of them, it is activated.
+
+        If a micro simulation which has been inactive since the start of the simulation is activated for the
+        first time, the simulation object is created and initialized.
+
+        Parameters
+        ----------
+        similarity_dists : numpy array
+            2D array having similarity distances between each micro simulation pair
+        is_sim_active : numpy array
+            1D array having state (active or inactive) of each micro simulation
+        sim_is_associated_to : numpy array
+            1D array with values of associated simulations of inactive simulations. Active simulations have None
+        micro_sims : list
+            List of objects of class MicroProblem, which are the micro simulations
+
+        Returns
+        -------
+        _is_sim_active : numpy array
+            Updated 1D array having state (active or inactive) of each micro simulation
+        _sim_is_associated_to : numpy array
+            1D array with values of associated simulations of inactive simulations. Active simulations have None
+        """
+        self._ref_tol = self._refine_const * np.amax(similarity_dists)
+
+        _is_sim_active = np.copy(
+            is_sim_active
+        )  # Input is_sim_active is not longer used after this point
+        _sim_is_associated_to = np.copy(sim_is_associated_to)
+        _sim_is_associated_to_updated = np.copy(sim_is_associated_to)
+
+        # Check inactive simulations for activation and collect IDs of those to be activated
+        to_be_activated_ids = []  # Global IDs to be activated
+        for i in range(_is_sim_active.size):
+            if not _is_sim_active[i]:  # if id is inactive
+                if self._check_for_activation(i, similarity_dists, _is_sim_active):
+                    _is_sim_active[i] = True
+                    _sim_is_associated_to_updated[
+                        i
+                    ] = -2  # Active sim cannot have an associated sim
+                    if self._is_sim_on_this_rank[i]:
+                        to_be_activated_ids.append(i)
+
+        local_sim_is_associated_to = _sim_is_associated_to[
+            self._global_ids[0] : self._global_ids[-1] + 1
+        ]
+
+        # Keys are global IDs of active sims not on this rank, values are lists of local and
+        # global IDs of inactive sims associated to the active sims which are on this rank
+        to_be_activated_map: Dict[int, list] = dict()
+
+        for i in to_be_activated_ids:
+            # Only handle activation of simulations on this rank -- LOCAL SCOPE HERE ON
+            if self._is_sim_on_this_rank[i]:
+                to_be_activated_local_id = self._global_ids.index(i)
+                if (
+                    micro_sims[to_be_activated_local_id] == 0
+                ):  # 0 indicates that the micro simulation object has not been created yet
+                    micro_problem = getattr(
+                        importlib.import_module(
+                            self._micro_file_name, "MicroSimulation"
+                        ),
+                        "MicroSimulation",
+                    )
+                    micro_sims[to_be_activated_local_id] = create_simulation_class(
+                        micro_problem
+                    )(i)
+                assoc_active_id = local_sim_is_associated_to[to_be_activated_local_id]
+
+                if self._is_sim_on_this_rank[
+                    assoc_active_id
+                ]:  # Associated active simulation is on the same rank
+                    assoc_active_local_id = self._global_ids.index(assoc_active_id)
+                    micro_sims[to_be_activated_local_id].set_state(
+                        micro_sims[assoc_active_local_id].get_state()
+                    )
+                else:  # Associated active simulation is not on this rank
+                    if assoc_active_id in to_be_activated_map:
+                        to_be_activated_map[assoc_active_id].append(
+                            to_be_activated_local_id
+                        )
+                    else:
+                        to_be_activated_map[assoc_active_id] = [
+                            to_be_activated_local_id
+                        ]
+
+        # TODO: could be moved to before the lazy initialization above
+        sim_states_and_global_ids = []
+        for local_id, sim in enumerate(micro_sims):
+            if sim == 0:
+                sim_states_and_global_ids.append((None, self._global_ids[local_id]))
+            else:
+                sim_states_and_global_ids.append((sim.get_state(), sim.get_global_id()))
+
+        recv_reqs = self._p2p_comm(
+            list(to_be_activated_map.keys()), sim_states_and_global_ids
+        )
+
+        # Use received micro sims to activate the required simulations
+        for req in recv_reqs:
+            state, global_id = req.wait()
+            local_ids = to_be_activated_map[global_id]
+            for local_id in local_ids:
+                micro_sims[local_id].set_state(state)
+
+        return _is_sim_active, _sim_is_associated_to_updated
+
+    def _get_update_inactive_sims_variant(self):
+        """
+        Get the variant of the function _update_inactive_sims.
+
+        Returns
+        -------
+        function
+            Function which updates the set of inactive micro simulations.
+        """
+        if self._lazy_init:
+            return self._update_inactive_sims_lazy_init
+        else:
+            return self._update_inactive_sims
 
     def _create_tag(self, sim_id: int, src_rank: int, dest_rank: int) -> int:
         """

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -31,8 +31,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         configurator : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
-        logger : object of logging
-            Logger defined from the standard package logging
         global_number_of_sims : int
             Total number of simulations in the macro-micro coupled problem.
         global_ids : list

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -188,7 +188,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         global_active_sims = np.count_nonzero(self._is_sim_active)
         global_inactive_sims = np.count_nonzero(self._is_sim_active == False)
 
-        self._metrics_logger.log_info_one_rank(
+        self._metrics_logger.log_info_rank_zero(
             "{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -10,7 +10,7 @@ from .adaptivity import AdaptivityCalculator
 
 
 class LocalAdaptivityCalculator(AdaptivityCalculator):
-    def __init__(self, configurator, comm) -> None:
+    def __init__(self, configurator, rank, comm, num_sims) -> None:
         """
         Class constructor.
 
@@ -20,17 +20,34 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             Object which has getter functions to get parameters defined in the configuration file.
         comm : MPI.COMM_WORLD
             Global communicator of MPI.
+        num_sims : int
+            Number of micro simulations.
         """
-        super().__init__(configurator)
+        super().__init__(configurator, rank)
         self._comm = comm
+
+        # similarity_dists: 2D array having similarity distances between each micro simulation pair
+        self._similarity_dists = np.zeros((num_sims, num_sims))
+
+        # is_sim_active: 1D array having state (active or inactive) of each micro simulation
+        # Start adaptivity calculation with all sims active
+        self._is_sim_active = np.array([True] * num_sims)
+
+        # sim_is_associated_to: 1D array with values of associated simulations of inactive simulations. Active simulations have None
+        # Active sims do not have an associated sim
+        self._sim_is_associated_to = np.full((num_sims), -2, dtype=np.intc)
+
+        # Copies of variables for checkpointing
+        self._similarity_dists_cp = None
+        self._is_sim_active_cp = None
+        self._sim_is_associated_to_cp = None
 
     def compute_adaptivity(
         self,
         dt,
         micro_sims,
-        adaptivity_data_nm1: list,
         data_for_adaptivity: dict,
-    ) -> tuple:
+    ) -> None:
         """
         Compute adaptivity locally (within a rank).
 
@@ -40,16 +57,10 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             Current time step
         micro_sims : list
             List containing simulation objects
-        adaptivity_data_nm1 : list
-            List of numpy arrays: similarity_dists (2D array having similarity distances between each micro simulation pair), is_sim_active (1D array having state (active or inactive) of each micro simulation), sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
         data_for_adaptivity : dict
             A dictionary containing the names of the data to be used in adaptivity as keys and information on whether
             the data are scalar or vector as values.
 
-        Returns
-        -------
-        list
-            List of numpy arrays: similarity_dists (2D array having similarity distances between each micro simulation pair), is_sim_active (1D array having state (active or inactive) of each micro simulation), sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
         """
         for name in data_for_adaptivity.keys():
             if name not in self._adaptivity_data_names:
@@ -60,69 +71,52 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
                 )
 
         similarity_dists = self._get_similarity_dists(
-            dt, adaptivity_data_nm1[0], data_for_adaptivity
+            dt, self._similarity_dists, data_for_adaptivity
         )
 
-        # Operation done globally if global adaptivity is chosen
-        is_sim_active = self._update_active_sims(
-            similarity_dists, adaptivity_data_nm1[1]
-        )
+        is_sim_active = self._update_active_sims(similarity_dists, self._is_sim_active)
 
         is_sim_active, sim_is_associated_to = self._update_inactive_sims(
-            similarity_dists, is_sim_active, adaptivity_data_nm1[2], micro_sims
+            similarity_dists, is_sim_active, self._sim_is_associated_to, micro_sims
         )
 
         sim_is_associated_to = self._associate_inactive_to_active(
             similarity_dists, is_sim_active, sim_is_associated_to
         )
 
-        return similarity_dists, is_sim_active, sim_is_associated_to
+        # Update member variables
+        self._similarity_dists = similarity_dists
+        self._is_sim_active = is_sim_active
+        self._sim_is_associated_to = sim_is_associated_to
 
-    def get_active_sim_ids(self, is_sim_active) -> np.ndarray:
+    def get_active_sim_ids(self) -> np.ndarray:
         """
         Get the ids of active simulations.
-
-        Parameters
-        ----------
-        is_sim_active : numpy array
-            1D array having state (active or inactive) of each micro simulation
 
         Returns
         -------
         numpy array
             1D array of active simulation ids
         """
-        return np.where(is_sim_active)[0]
+        return np.where(self._is_sim_active)[0]
 
-    def get_inactive_sim_ids(self, is_sim_active: np.array) -> np.ndarray:
+    def get_inactive_sim_ids(self) -> np.ndarray:
         """
         Get the ids of inactive simulations.
-
-        Parameters
-        ----------
-        is_sim_active : numpy array
-            1D array having state (active or inactive) of each micro simulation
 
         Returns
         -------
         numpy array
             1D array of inactive simulation ids
         """
-        return np.where(is_sim_active == False)[0]
+        return np.where(self._is_sim_active == False)[0]
 
-    def get_full_field_micro_output(
-        self, adaptivity_data: list, micro_output: list
-    ) -> list:
+    def get_full_field_micro_output(self, micro_output: list) -> list:
         """
         Get the full field micro output from active simulations to inactive simulations.
 
         Parameters
         ----------
-        adaptivity_data : list
-            List of numpy arrays:
-                similarity_dists (2D array having similarity distances between each micro simulation pair)
-                is_sim_active (1D array having state (active or inactive) of each micro simulation)
-                sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
         micro_output : list
             List of dicts having individual output of each simulation. Only the active simulation outputs are entered.
 
@@ -133,29 +127,30 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         """
         micro_sims_output = deepcopy(micro_output)
 
-        sim_is_associated_to = adaptivity_data[2]
-
-        inactive_sim_ids = self.get_inactive_sim_ids(adaptivity_data[1])
+        inactive_sim_ids = self.get_inactive_sim_ids()
 
         for inactive_id in inactive_sim_ids:
             micro_sims_output[inactive_id] = deepcopy(
-                micro_sims_output[sim_is_associated_to[inactive_id]]
+                micro_sims_output[self._sim_is_associated_to[inactive_id]]
             )
 
         return micro_sims_output
 
-    def log_metrics(self, logger, adaptivity_list: list, n: int) -> None:
-        """ """
-        is_sim_active = adaptivity_list[1]
+    def log_metrics(self, n: int) -> None:
+        """
+        Log metrics for local adaptivity.
 
+        Parameters
+        ----------
+        """
         # MPI Gather is necessary as local adaptivity only stores local data
-        local_active_sims = np.count_nonzero(is_sim_active)
+        local_active_sims = np.count_nonzero(self._is_sim_active)
         global_active_sims = self._comm.gather(local_active_sims)
 
-        local_inactive_sims = np.count_nonzero(is_sim_active == False)
+        local_inactive_sims = np.count_nonzero(self._is_sim_active == False)
         global_inactive_sims = self._comm.gather(local_inactive_sims)
 
-        logger.log_info_one_rank(
+        self._metrics_logger.log_info_one_rank(
             "{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),
@@ -164,6 +159,22 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
                 np.max(global_inactive_sims),
             )
         )
+
+    def write_checkpoint(self) -> None:
+        """
+        Write checkpoint.
+        """
+        self._similarity_dists_cp = np.copy(self._similarity_dists)
+        self._is_sim_active_cp = np.copy(self._is_sim_active)
+        self._sim_is_associated_to_cp = np.copy(self._sim_is_associated_to)
+
+    def read_checkpoint(self) -> None:
+        """
+        Read checkpoint.
+        """
+        self._similarity_dists = np.copy(self._similarity_dists_cp)
+        self._is_sim_active = np.copy(self._is_sim_active_cp)
+        self._sim_is_associated_to = np.copy(self._sim_is_associated_to_cp)
 
     def _update_inactive_sims(
         self,

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -18,6 +18,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         configurator : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
+        rank : int
+            Rank of the current MPI process.
         comm : MPI.COMM_WORLD
             Global communicator of MPI.
         num_sims : int
@@ -142,6 +144,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         Parameters
         ----------
+        n : int
+            Current time step
         """
         # MPI Gather is necessary as local adaptivity only stores local data
         local_active_sims = np.count_nonzero(self._is_sim_active)

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -10,7 +10,7 @@ from .adaptivity import AdaptivityCalculator
 
 
 class LocalAdaptivityCalculator(AdaptivityCalculator):
-    def __init__(self, configurator, logger) -> None:
+    def __init__(self, configurator, comm) -> None:
         """
         Class constructor.
 
@@ -18,10 +18,11 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         configurator : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
-        logger : object of logging
-            Logger defined from the standard package logging
+        comm : MPI.COMM_WORLD
+            Global communicator of MPI.
         """
-        super().__init__(configurator, logger)
+        super().__init__(configurator)
+        self._comm = comm
 
     def compute_adaptivity(
         self,
@@ -75,14 +76,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             similarity_dists, is_sim_active, sim_is_associated_to
         )
 
-        self._logger.info(
-            "{} active simulations, {} inactive simulations".format(
-                np.count_nonzero(is_sim_active),
-                np.count_nonzero(is_sim_active == False),
-            )
-        )
-
-        return [similarity_dists, is_sim_active, sim_is_associated_to]
+        return similarity_dists, is_sim_active, sim_is_associated_to
 
     def get_active_sim_ids(self, is_sim_active) -> np.ndarray:
         """
@@ -149,6 +143,27 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             )
 
         return micro_sims_output
+
+    def log_metrics(self, logger, adaptivity_list: list, n: int) -> None:
+        """ """
+        is_sim_active = adaptivity_list[1]
+
+        # MPI Gather is necessary as local adaptivity only stores local data
+        local_active_sims = np.count_nonzero(is_sim_active)
+        global_active_sims = self._comm.gather(local_active_sims)
+
+        local_inactive_sims = np.count_nonzero(is_sim_active == False)
+        global_inactive_sims = self._comm.gather(local_inactive_sims)
+
+        logger.log_info_one_rank(
+            "{},{},{},{},{}".format(
+                n,
+                np.mean(global_active_sims),
+                np.mean(global_inactive_sims),
+                np.max(global_active_sims),
+                np.max(global_inactive_sims),
+            )
+        )
 
     def _update_inactive_sims(
         self,

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -138,7 +138,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         return micro_sims_output
 
-    def log_metrics(self, n: int) -> None:
+    def log_metrics(self, n: int, adaptivity_cpu_time: float) -> None:
         """
         Log metrics for local adaptivity.
 
@@ -146,6 +146,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         n : int
             Current time step
+        adaptivity_cpu_time : float
+            CPU time taken for adaptivity calculation
         """
         # MPI Gather is necessary as local adaptivity only stores local data
         local_active_sims = np.count_nonzero(self._is_sim_active)
@@ -155,12 +157,13 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         global_inactive_sims = self._comm.gather(local_inactive_sims)
 
         self._metrics_logger.log_info_one_rank(
-            "{},{},{},{},{}".format(
+            "{},{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),
                 np.mean(global_inactive_sims),
                 np.max(global_active_sims),
                 np.max(global_inactive_sims),
+                adaptivity_cpu_time,
             )
         )
 

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -154,7 +154,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         local_inactive_sims = np.count_nonzero(self._is_sim_active == False)
         global_inactive_sims = self._comm.gather(local_inactive_sims)
 
-        self._metrics_logger.log_info_one_rank(
+        self._metrics_logger.log_info_rank_zero(
             "{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -138,7 +138,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         return micro_sims_output
 
-    def log_metrics(self, n: int, adaptivity_cpu_time: float) -> None:
+    def log_metrics(self, n: int) -> None:
         """
         Log metrics for local adaptivity.
 
@@ -146,8 +146,6 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         n : int
             Current time step
-        adaptivity_cpu_time : float
-            CPU time taken for adaptivity calculation
         """
         # MPI Gather is necessary as local adaptivity only stores local data
         local_active_sims = np.count_nonzero(self._is_sim_active)
@@ -157,13 +155,12 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         global_inactive_sims = self._comm.gather(local_inactive_sims)
 
         self._metrics_logger.log_info_one_rank(
-            "{},{},{},{},{},{}".format(
+            "{},{},{},{},{}".format(
                 n,
                 np.mean(global_active_sims),
                 np.mean(global_inactive_sims),
                 np.max(global_active_sims),
                 np.max(global_inactive_sims),
-                adaptivity_cpu_time,
             )
         )
 

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -4,6 +4,7 @@ in a local way. If the Micro Manager is run in parallel, simulations on one rank
 each other. A global comparison is not done.
 """
 import numpy as np
+from copy import deepcopy
 
 from .adaptivity import AdaptivityCalculator
 
@@ -26,9 +27,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         self,
         dt,
         micro_sims,
-        similarity_dists_nm1: np.ndarray,
-        is_sim_active_nm1: np.ndarray,
-        sim_is_associated_to_nm1: np.ndarray,
+        adaptivity_data_nm1: list,
         data_for_adaptivity: dict,
     ) -> tuple:
         """
@@ -40,22 +39,16 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             Current time step
         micro_sims : list
             List containing simulation objects
-        similarity_dists_nm1 : numpy array
-            2D array having similarity distances between each micro simulation pair.
-        is_sim_active_nm1 : numpy array
-            1D array having True if sim is active, False if sim is inactive.
-        sim_is_associated_to_nm1 : numpy array
-            1D array with values of associated simulations of inactive simulations. Active simulations have None.
+        adaptivity_data_nm1 : list
+            List of numpy arrays: similarity_dists (2D array having similarity distances between each micro simulation pair), is_sim_active (1D array having state (active or inactive) of each micro simulation), sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
         data_for_adaptivity : dict
             A dictionary containing the names of the data to be used in adaptivity as keys and information on whether
             the data are scalar or vector as values.
 
         Returns
         -------
-        similarity_dists : numpy array
-            2D array having similarity distances between each micro simulation pair.
-        is_sim_active : numpy array
-            1D array, True is sim is active, False if sim is inactive.
+        list
+            List of numpy arrays: similarity_dists (2D array having similarity distances between each micro simulation pair), is_sim_active (1D array having state (active or inactive) of each micro simulation), sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
         """
         for name in data_for_adaptivity.keys():
             if name not in self._adaptivity_data_names:
@@ -66,14 +59,16 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
                 )
 
         similarity_dists = self._get_similarity_dists(
-            dt, similarity_dists_nm1, data_for_adaptivity
+            dt, adaptivity_data_nm1[0], data_for_adaptivity
         )
 
         # Operation done globally if global adaptivity is chosen
-        is_sim_active = self._update_active_sims(similarity_dists, is_sim_active_nm1)
+        is_sim_active = self._update_active_sims(
+            similarity_dists, adaptivity_data_nm1[1]
+        )
 
         is_sim_active, sim_is_associated_to = self._update_inactive_sims(
-            similarity_dists, is_sim_active, sim_is_associated_to_nm1, micro_sims
+            similarity_dists, is_sim_active, adaptivity_data_nm1[2], micro_sims
         )
 
         sim_is_associated_to = self._associate_inactive_to_active(
@@ -87,7 +82,73 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             )
         )
 
-        return similarity_dists, is_sim_active, sim_is_associated_to
+        return [similarity_dists, is_sim_active, sim_is_associated_to]
+
+    def get_active_sim_ids(self, is_sim_active) -> np.ndarray:
+        """
+        Get the ids of active simulations.
+
+        Parameters
+        ----------
+        is_sim_active : numpy array
+            1D array having state (active or inactive) of each micro simulation
+
+        Returns
+        -------
+        numpy array
+            1D array of active simulation ids
+        """
+        return np.where(is_sim_active)[0]
+
+    def get_inactive_sim_ids(self, is_sim_active: np.array) -> np.ndarray:
+        """
+        Get the ids of inactive simulations.
+
+        Parameters
+        ----------
+        is_sim_active : numpy array
+            1D array having state (active or inactive) of each micro simulation
+
+        Returns
+        -------
+        numpy array
+            1D array of inactive simulation ids
+        """
+        return np.where(is_sim_active == False)[0]
+
+    def get_full_field_micro_output(
+        self, adaptivity_data: list, micro_output: list
+    ) -> list:
+        """
+        Get the full field micro output from active simulations to inactive simulations.
+
+        Parameters
+        ----------
+        adaptivity_data : list
+            List of numpy arrays:
+                similarity_dists (2D array having similarity distances between each micro simulation pair)
+                is_sim_active (1D array having state (active or inactive) of each micro simulation)
+                sim_is_associated_to (1D array with values of associated simulations of inactive simulations. Active simulations have None)
+        micro_output : list
+            List of dicts having individual output of each simulation. Only the active simulation outputs are entered.
+
+        Returns
+        -------
+        micro_output : list
+            List of dicts having individual output of each simulation. Active and inactive simulation outputs are entered.
+        """
+        micro_sims_output = deepcopy(micro_output)
+
+        sim_is_associated_to = adaptivity_data[2]
+
+        inactive_sim_ids = self.get_inactive_sim_ids(adaptivity_data[1])
+
+        for inactive_id in inactive_sim_ids:
+            micro_sims_output[inactive_id] = deepcopy(
+                micro_sims_output[sim_is_associated_to[inactive_id]]
+            )
+
+        return micro_sims_output
 
     def _update_inactive_sims(
         self,

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -38,7 +38,6 @@ class Config:
         self._diagnostics_data_names = dict()
 
         self._output_micro_sim_time = False
-        self._output_micro_mem_use = False
 
         self._interpolate_crash = False
 
@@ -141,18 +140,6 @@ class Config:
         except BaseException:
             self._logger.log_info_one_rank(
                 "Micro manager will not output time required to solve each micro simulation."
-            )
-
-        try:
-            if self._data["diagnostics"]["output_micro_sim_solve_mem_use"] == "True":
-                self._output_micro_mem_use = True
-                self._write_data_names["solve_mem_use"] = False
-                self._logger.log_info_one_rank(
-                    "Calculating memory usage of the solve call of each micro micro simulation will slow down the Micro Manager. This option is intended for diagnostic purposes."
-                )
-        except BaseException:
-            self._logger.log_info_one_rank(
-                "Micro manager will not output memory usage for solving each micro simulation."
             )
 
     def read_json_micro_manager(self):
@@ -483,17 +470,6 @@ class Config:
             True if micro simulation solve time is required.
         """
         return self._output_micro_sim_time
-
-    def write_micro_mem_use(self):
-        """
-        Depending on user input, micro manager will calculate memory usage of solve() step of every micro simulation
-
-        Returns
-        -------
-        output_micro_mem_use : bool
-            True if micro simulation memory usage is required.
-        """
-        return self._output_micro_mem_use
 
     def turn_on_adaptivity(self):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -94,7 +94,7 @@ class Config:
         try:
             self._output_dir = self._data["output_dir"]
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "No output directory provided. Output (including logging) will be saved in the current working directory."
             )
 
@@ -104,7 +104,7 @@ class Config:
                 self._write_data_names, list
             ), "Write data entry is not a list"
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "No write data names provided. Micro manager will only read data from preCICE."
             )
 
@@ -114,7 +114,7 @@ class Config:
                 self._read_data_names, list
             ), "Read data entry is not a list"
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "No read data names provided. Micro manager will only write data to preCICE."
             )
 
@@ -125,7 +125,7 @@ class Config:
                 self._output_micro_sim_time = True
                 self._write_data_names.append("solve_cpu_time")
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "Micro manager will not output time required to solve each micro simulation."
             )
 
@@ -148,7 +148,7 @@ class Config:
         try:
             self._ranks_per_axis = self._data["simulation_params"]["decomposition"]
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "Domain decomposition is not specified, so the Micro Manager will expect to be run in serial."
             )
 
@@ -166,7 +166,7 @@ class Config:
                         "Adaptivity settings are provided but adaptivity is turned off."
                     )
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "Micro Manager will not adaptively run micro simulations, but instead will run all micro simulations."
             )
 
@@ -189,7 +189,7 @@ class Config:
             ]["data"]
 
             if self._data_for_adaptivity == self._write_data_names:
-                self._logger.log_info_one_rank(
+                self._logger.log_info_rank_zero(
                     "Only micro simulation data is used for similarity computation in adaptivity. This would lead to the"
                     " same set of active and inactive simulations for the entire simulation time. If this is not intended,"
                     " please include macro simulation data as well."
@@ -200,7 +200,7 @@ class Config:
                     "adaptivity_settings"
                 ]["output_n"]
             except BaseException:
-                self._logger.log_info_one_rank(
+                self._logger.log_info_rank_zero(
                     "No output interval for adaptivity provided. Adaptivity metrics will be output every time window."
                 )
 
@@ -222,7 +222,7 @@ class Config:
                     "adaptivity_settings"
                 ]["similarity_measure"]
             else:
-                self._logger.log_info_one_rank(
+                self._logger.log_info_rank_zero(
                     "No similarity measure provided, using L1 norm as default"
                 )
                 self._adaptivity_similarity_measure = "L1"
@@ -237,7 +237,7 @@ class Config:
                 self._adaptivity_every_implicit_iteration = False
 
             if not self._adaptivity_every_implicit_iteration:
-                self._logger.log_info_one_rank(
+                self._logger.log_info_rank_zero(
                     "Micro Manager will compute adaptivity once at the start of every time window"
                 )
 
@@ -254,14 +254,14 @@ class Config:
                 diagnostics_data_names, list
             ), "Diagnostics data is not a list"
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "No diagnostics data is defined. Micro Manager will not output any diagnostics data."
             )
 
         try:
             self._micro_output_n = self._data["diagnostics"]["micro_output_n"]
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "Output interval of micro simulations not specified, if output is available then it will be called "
                 "in every time window."
             )
@@ -284,7 +284,7 @@ class Config:
                 .replace(".py", "")
             )
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "No post-processing file name provided. Snapshot computation will not perform any post-processing."
             )
             self._postprocessing_file_name = None
@@ -295,7 +295,7 @@ class Config:
                 diagnostics_data_names, list
             ), "Diagnostics data is not a list"
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "No diagnostics data is defined. Snapshot computation will not output any diagnostics data."
             )
 
@@ -303,7 +303,7 @@ class Config:
             if self._data["snapshot_params"]["initialize_once"] == "True":
                 self._initialize_once = True
         except BaseException:
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "For each snapshot a new micro simulation object will be created"
             )
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -58,6 +58,8 @@ class Config:
         self._postprocessing_file_name = None
         self._initialize_once = False
 
+        self._output_dir = None
+
     def set_logger(self, logger):
         """
         Set the logger for the Config class.
@@ -90,6 +92,13 @@ class Config:
             .replace("\\", ".")
             .replace(".py", "")
         )
+
+        try:
+            self._output_dir = self._data["output_dir"]
+        except BaseException:
+            self._logger.log_info_one_rank(
+                "No output directory provided. Output (including logging) will be saved in the current working directory."
+            )
 
         try:
             self._write_data_names = self._data["coupling_params"]["write_data_names"]
@@ -640,3 +649,14 @@ class Config:
             True if initialization is done only once, False otherwise.
         """
         return self._initialize_once
+
+    def get_output_dir(self):
+        """
+        Get the name of the output directory.
+
+        Returns
+        -------
+        output_dir : string
+            Name of the output folder.
+        """
+        return self._output_dir

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -13,20 +13,20 @@ class Config:
     the config class in https://github.com/precice/fenics-adapter/tree/develop/fenicsadapter
     """
 
-    def __init__(self, logger, config_filename):
+    def __init__(self, config_file_name):
         """
         Constructor of the Config class.
 
         Parameters
         ----------
-        config_filename : string
+        config_file_name : string
             Name of the JSON configuration file
         """
-        self._logger = logger
-
+        self._config_file_name = config_file_name
+        self._logger = None
         self._micro_file_name = None
 
-        self._config_file_name = None
+        self._precice_config_file_name = None
         self._macro_mesh_name = None
         self._read_data_names = dict()
         self._write_data_names = dict()
@@ -38,6 +38,7 @@ class Config:
         self._diagnostics_data_names = dict()
 
         self._output_micro_sim_time = False
+        self._output_micro_mem_use = False
 
         self._interpolate_crash = False
 
@@ -49,6 +50,9 @@ class Config:
         self._adaptivity_refining_constant = 0.5
         self._adaptivity_every_implicit_iteration = False
         self._adaptivity_similarity_measure = "L1"
+        self._adaptivity_output_n = -2
+        self._adaptivity_output_cpu_time = False
+        self._adaptivity_output_mem_usage = False
 
         # Snapshot information
         self._parameter_file_name = None
@@ -57,19 +61,28 @@ class Config:
 
         self._output_micro_sim_time = False
 
-        self.read_json(config_filename)
+    def set_logger(self, logger):
+        """
+        Set the logger for the Config class.
 
-    def read_json(self, config_filename):
+        Parameters
+        ----------
+        logger : object of logging
+            Logger defined from the standard package logging
+        """
+        self._logger = logger
+
+    def _read_json(self, config_file_name):
         """
         Reads JSON configuration file.
 
         Parameters
         ----------
-        config_filename : string
+        config_file_name : string
             Name of the JSON configuration file
         """
-        self._folder = os.path.dirname(os.path.join(os.getcwd(), config_filename))
-        path = os.path.join(self._folder, os.path.basename(config_filename))
+        self._folder = os.path.dirname(os.path.join(os.getcwd(), config_file_name))
+        path = os.path.join(self._folder, os.path.basename(config_file_name))
         with open(path, "r") as read_file:
             self._data = json.load(read_file)
 
@@ -96,7 +109,7 @@ class Config:
                         "Write data dictionary as a value other than 'scalar' or 'vector'"
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No write data names provided. Micro manager will only read data from preCICE."
             )
 
@@ -115,19 +128,31 @@ class Config:
                         "Read data dictionary as a value other than 'scalar' or 'vector'"
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No read data names provided. Micro manager will only write data to preCICE."
             )
 
         self._micro_dt = self._data["simulation_params"]["micro_dt"]
 
         try:
-            if self._data["diagnostics"]["output_micro_sim_solve_time"]:
+            if self._data["diagnostics"]["output_micro_sim_solve_time"] == "True":
                 self._output_micro_sim_time = True
-                self._write_data_names["micro_sim_time"] = False
+                self._write_data_names["solve_cpu_time"] = False
         except BaseException:
-            self._logger.info(
-                "Micro manager will not output time required to solve each micro simulation in each time step."
+            self._logger.log_info_one_rank(
+                "Micro manager will not output time required to solve each micro simulation."
+            )
+
+        try:
+            if self._data["diagnostics"]["output_micro_sim_solve_mem_use"] == "True":
+                self._output_micro_mem_use = True
+                self._write_data_names["solve_mem_use"] = False
+                self._logger.log_info_one_rank(
+                    "Calculating memory usage of the solve call of each micro micro simulation will slow down the Micro Manager. This option is intended for diagnostic purposes."
+                )
+        except BaseException:
+            self._logger.log_info_one_rank(
+                "Micro manager will not output memory usage for solving each micro simulation."
             )
 
     def read_json_micro_manager(self):
@@ -135,8 +160,10 @@ class Config:
         Reads Micro Manager relevant information from JSON configuration file
         and saves the data to the respective instance attributes.
         """
-        self._config_file_name = os.path.join(
-            self._folder, self._data["coupling_params"]["config_file_name"]
+        self._read_json(self._config_file_name)  # Read base information
+
+        self._precice_config_file_name = os.path.join(
+            self._folder, self._data["coupling_params"]["precice_config_file_name"]
         )
         self._macro_mesh_name = self._data["coupling_params"]["macro_mesh_name"]
 
@@ -147,7 +174,7 @@ class Config:
         try:
             self._ranks_per_axis = self._data["simulation_params"]["decomposition"]
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "Domain decomposition is not specified, so the Micro Manager will expect to be run in serial."
             )
 
@@ -165,7 +192,7 @@ class Config:
                         "Adaptivity settings are provided but adaptivity is turned off."
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "Micro Manager will not adaptively run micro simulations, but instead will run all micro simulations."
             )
 
@@ -188,10 +215,19 @@ class Config:
                 self._data_for_adaptivity[dname] = exchange_data[dname]
 
             if self._data_for_adaptivity.keys() == self._write_data_names.keys():
-                warn(
+                self._logger.log_info_one_rank(
                     "Only micro simulation data is used for similarity computation in adaptivity. This would lead to the"
                     " same set of active and inactive simulations for the entire simulation time. If this is not intended,"
                     " please include macro simulation data as well."
+                )
+
+            try:
+                self._adaptivity_output_n = self._data["simulation_params"][
+                    "adaptivity_settings"
+                ]["output_n"]
+            except BaseException:
+                self._logger.log_info_one_rank(
+                    "No output interval for adaptivity provided. Adaptivity metrics will be output every time window."
                 )
 
             self._adaptivity_history_param = self._data["simulation_params"][
@@ -212,7 +248,7 @@ class Config:
                     "adaptivity_settings"
                 ]["similarity_measure"]
             else:
-                self._logger.info(
+                self._logger.log_info_one_rank(
                     "No similarity measure provided, using L1 norm as default"
                 )
                 self._adaptivity_similarity_measure = "L1"
@@ -227,12 +263,40 @@ class Config:
                 self._adaptivity_every_implicit_iteration = False
 
             if not self._adaptivity_every_implicit_iteration:
-                self._logger.info(
+                self._logger.log_info_one_rank(
                     "Micro Manager will compute adaptivity once at the start of every time window"
                 )
 
             self._write_data_names["active_state"] = False
             self._write_data_names["active_steps"] = False
+
+            try:
+                if (
+                    self._data["simulation_params"]["adaptivity_settings"][
+                        "output_cpu_time"
+                    ]
+                    == "True"
+                ):
+                    self._adaptivity_output_cpu_time = True
+                    self._write_data_names["adaptivity_cpu_time"] = False
+            except BaseException:
+                self._logger.log_info_one_rank(
+                    "Micro Manager will not output CPU time of the adaptivity computation."
+                )
+
+            try:
+                if (
+                    self._data["simulation_params"]["adaptivity_settings"][
+                        "output_mem_usage"
+                    ]
+                    == "True"
+                ):
+                    self._adaptivity_output_mem_usage = True
+                    self._write_data_names["adaptivity_mem_usage"] = False
+            except BaseException:
+                self._logger.log_info_one_rank(
+                    "Micro Manager will not output CPU time of the adaptivity computation."
+                )
 
         if "interpolate_crash" in self._data["simulation_params"]:
             if self._data["simulation_params"]["interpolate_crash"] == "True":
@@ -253,19 +317,24 @@ class Config:
                         "Diagnostics data dictionary as a value other than 'scalar' or 'vector'"
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No diagnostics data is defined. Micro Manager will not output any diagnostics data."
             )
 
         try:
             self._micro_output_n = self._data["diagnostics"]["micro_output_n"]
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "Output interval of micro simulations not specified, if output is available then it will be called "
                 "in every time window."
             )
 
     def read_json_snapshot(self):
+        """
+        Reads Snapshot relevant information from JSON configuration file
+        """
+        self._read_json(self._config_file_name)  # Read base information
+
         self._parameter_file_name = os.path.join(
             self._folder, self._data["coupling_params"]["parameter_file_name"]
         )
@@ -278,7 +347,7 @@ class Config:
                 .replace(".py", "")
             )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No post-processing file name provided. Snapshot computation will not perform any post-processing."
             )
             self._postprocessing_file_name = None
@@ -298,7 +367,7 @@ class Config:
                         "Diagnostics data dictionary has a value other than 'scalar' or 'vector'"
                     )
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "No diagnostics data is defined. Snapshot computation will not output any diagnostics data."
             )
 
@@ -306,20 +375,20 @@ class Config:
             if self._data["snapshot_params"]["initialize_once"] == "True":
                 self._initialize_once = True
         except BaseException:
-            self._logger.info(
+            self._logger.log_info_one_rank(
                 "For each snapshot a new micro simulation object will be created"
             )
 
-    def get_config_file_name(self):
+    def get_precice_config_file_name(self):
         """
-        Get the name of the JSON configuration file.
+        Get the name of the preCICE XML configuration file.
 
         Returns
         -------
         config_file_name : string
-            Name of the JSON configuration file provided to the Config class.
+            Name of the preCICE XML configuration file.
         """
-        return self._config_file_name
+        return self._precice_config_file_name
 
     def get_macro_mesh_name(self):
         """
@@ -415,6 +484,17 @@ class Config:
         """
         return self._output_micro_sim_time
 
+    def write_micro_mem_use(self):
+        """
+        Depending on user input, micro manager will calculate memory usage of solve() step of every micro simulation
+
+        Returns
+        -------
+        output_micro_mem_use : bool
+            True if micro simulation memory usage is required.
+        """
+        return self._output_micro_mem_use
+
     def turn_on_adaptivity(self):
         """
         Boolean stating whether adaptivity is ot or not.
@@ -449,6 +529,17 @@ class Config:
             the data are scalar or vector as values.
         """
         return self._data_for_adaptivity
+
+    def get_adaptivity_output_n(self):
+        """
+        Get the output frequency of adaptivity metrics.
+
+        Returns
+        -------
+        adaptivity_output_n : int
+            Output frequency of adaptivity metrics, so output every N timesteps
+        """
+        return self._adaptivity_output_n
 
     def get_adaptivity_hist_param(self):
         """
@@ -508,6 +599,17 @@ class Config:
             True if adaptivity needs to be calculated in every time iteration, False otherwise.
         """
         return self._adaptivity_every_implicit_iteration
+
+    def output_adaptivity_cpu_time(self):
+        """
+        Check if CPU time of the adaptivity computation needs to be output.
+
+        Returns
+        -------
+        adaptivity_cpu_time : bool
+            True if CPU time of the adaptivity computation needs to be output, False otherwise.
+        """
+        return self._adaptivity_output_cpu_time
 
     def get_micro_dt(self):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -50,8 +50,6 @@ class Config:
         self._adaptivity_every_implicit_iteration = False
         self._adaptivity_similarity_measure = "L1"
         self._adaptivity_output_n = 1
-        self._adaptivity_output_cpu_time = False
-        self._adaptivity_output_mem_usage = False
 
         # Snapshot information
         self._parameter_file_name = None
@@ -245,34 +243,6 @@ class Config:
 
             self._write_data_names.append("active_state")
             self._write_data_names.append("active_steps")
-
-            try:
-                if (
-                    self._data["simulation_params"]["adaptivity_settings"][
-                        "output_cpu_time"
-                    ]
-                    == "True"
-                ):
-                    self._adaptivity_output_cpu_time = True
-                    self._write_data_names.append("adaptivity_cpu_time")
-            except BaseException:
-                self._logger.log_info_one_rank(
-                    "Micro Manager will not output CPU time of the adaptivity computation."
-                )
-
-            try:
-                if (
-                    self._data["simulation_params"]["adaptivity_settings"][
-                        "output_mem_usage"
-                    ]
-                    == "True"
-                ):
-                    self._adaptivity_output_mem_usage = True
-                    self._write_data_names.append("adaptivity_mem_usage")
-            except BaseException:
-                self._logger.log_info_one_rank(
-                    "Micro Manager will not output CPU time of the adaptivity computation."
-                )
 
         if "interpolate_crash" in self._data["simulation_params"]:
             if self._data["simulation_params"]["interpolate_crash"] == "True":
@@ -546,17 +516,6 @@ class Config:
             True if adaptivity needs to be calculated in every time iteration, False otherwise.
         """
         return self._adaptivity_every_implicit_iteration
-
-    def output_adaptivity_cpu_time(self):
-        """
-        Check if CPU time of the adaptivity computation needs to be output.
-
-        Returns
-        -------
-        adaptivity_cpu_time : bool
-            True if CPU time of the adaptivity computation needs to be output, False otherwise.
-        """
-        return self._adaptivity_output_cpu_time
 
     def get_micro_dt(self):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -50,7 +50,7 @@ class Config:
         self._adaptivity_refining_constant = 0.5
         self._adaptivity_every_implicit_iteration = False
         self._adaptivity_similarity_measure = "L1"
-        self._adaptivity_output_n = -2
+        self._adaptivity_output_n = 1
         self._adaptivity_output_cpu_time = False
         self._adaptivity_output_mem_usage = False
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -58,6 +58,8 @@ class Config:
 
         self._output_dir = None
 
+        self._lazy_initialization = False
+
     def set_logger(self, logger):
         """
         Set the logger for the Config class.
@@ -183,6 +185,14 @@ class Config:
                 self._adaptivity_type = "global"
             else:
                 raise Exception("Adaptivity type can be either local or global.")
+
+            if (
+                self._data["simulation_params"]["adaptivity_settings"].get(
+                    "lazy_initialization"
+                )
+                == "True"
+            ):
+                self._lazy_initialization = True
 
             self._data_for_adaptivity = self._data["simulation_params"][
                 "adaptivity_settings"
@@ -516,6 +526,18 @@ class Config:
             True if adaptivity needs to be calculated in every time iteration, False otherwise.
         """
         return self._adaptivity_every_implicit_iteration
+
+    def initialize_sims_lazily(self):
+        """
+        Check if simulations are to be created only when they are required to be active for the very first time.
+
+        Returns
+        -------
+        adaptivity : bool
+            True if micro simulations are created only when needed, False otherwise.
+
+        """
+        return self._lazy_initialization
 
     def get_micro_dt(self):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -58,8 +58,6 @@ class Config:
         self._postprocessing_file_name = None
         self._initialize_once = False
 
-        self._output_micro_sim_time = False
-
     def set_logger(self, logger):
         """
         Set the logger for the Config class.

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -6,14 +6,12 @@ import numpy as np
 
 
 class DomainDecomposer:
-    def __init__(self, logger, dims, rank, size) -> None:
+    def __init__(self, dims, rank, size) -> None:
         """
         Class constructor.
 
         Parameters
         ----------
-        logger : object of logging
-            Logger defined from the standard package logging.
         dims : int
             Dimensions of the problem.
         rank : int
@@ -21,7 +19,6 @@ class DomainDecomposer:
         size : int
             Total number of MPI processes.
         """
-        self._logger = logger
         self._rank = rank
         self._size = size
         self._dims = dims
@@ -97,7 +94,5 @@ class DomainDecomposer:
             # Adjust the maximum bound to be exactly the domain size
             if rank_in_axis[d] + 1 == ranks_per_axis[d]:
                 mesh_bounds[d * 2 + 1] = macro_bounds[d * 2 + 1]
-
-        self._logger.info("Bounding box limits are {}".format(mesh_bounds))
 
         return mesh_bounds

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -6,14 +6,12 @@ import numpy as np
 
 
 class DomainDecomposer:
-    def __init__(self, dims, rank, size) -> None:
+    def __init__(self, rank, size) -> None:
         """
         Class constructor.
 
         Parameters
         ----------
-        dims : int
-            Dimensions of the problem.
         rank : int
             MPI rank.
         size : int
@@ -21,7 +19,6 @@ class DomainDecomposer:
         """
         self._rank = rank
         self._size = size
-        self._dims = dims
 
     def decompose_macro_domain(self, macro_bounds: list, ranks_per_axis: list) -> list:
         """
@@ -48,42 +45,34 @@ class DomainDecomposer:
             np.prod(ranks_per_axis) == self._size
         ), "Total number of processors provided in the Micro Manager configuration and in the MPI execution command do not match."
 
+        dims = len(ranks_per_axis)
+
+        if dims == 3:
+            for z in range(ranks_per_axis[2]):
+                for y in range(ranks_per_axis[1]):
+                    for x in range(ranks_per_axis[0]):
+                        n = (
+                            x
+                            + y * ranks_per_axis[0]
+                            + z * ranks_per_axis[0] * ranks_per_axis[1]
+                        )
+                        if n == self._rank:
+                            rank_in_axis = [x, y, z]
+        elif dims == 2:
+            for y in range(ranks_per_axis[1]):
+                for x in range(ranks_per_axis[0]):
+                    n = x + y * ranks_per_axis[0]
+                    if n == self._rank:
+                        rank_in_axis = [x, y]
+
         dx = []
-        for d in range(self._dims):
+        for d in range(dims):
             dx.append(
                 abs(macro_bounds[d * 2 + 1] - macro_bounds[d * 2]) / ranks_per_axis[d]
             )
 
-        rank_in_axis: list[int] = [0] * self._dims
-        if ranks_per_axis[0] == 1:  # if serial in x axis
-            rank_in_axis[0] = 0
-        else:
-            rank_in_axis[0] = self._rank % ranks_per_axis[0]  # x axis
-
-        if self._dims == 2:
-            if ranks_per_axis[1] == 1:  # if serial in y axis
-                rank_in_axis[1] = 0
-            else:
-                rank_in_axis[1] = int(self._rank / ranks_per_axis[0])  # y axis
-        elif self._dims == 3:
-            if ranks_per_axis[2] == 1:  # if serial in z axis
-                rank_in_axis[2] = 0
-            else:
-                rank_in_axis[2] = int(
-                    self._rank / (ranks_per_axis[0] * ranks_per_axis[1])
-                )  # z axis
-
-            if ranks_per_axis[1] == 1:  # if serial in y axis
-                rank_in_axis[1] = 0
-            else:
-                rank_in_axis[1] = (
-                    self._rank - ranks_per_axis[0] * ranks_per_axis[1] * rank_in_axis[2]
-                ) % ranks_per_axis[
-                    2
-                ]  # y axis
-
         mesh_bounds = []
-        for d in range(self._dims):
+        for d in range(dims):
             if rank_in_axis[d] > 0:
                 mesh_bounds.append(macro_bounds[d * 2] + rank_in_axis[d] * dx[d])
                 mesh_bounds.append(macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx[d])

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -31,7 +31,7 @@ class Interpolation:
             Local indices of the k nearest neighbors in all local points.
         """
         if len(coords) < k:
-            self._logger.log_info_any_rank(
+            self._logger.log_info(
                 "Number of desired neighbors k = {} is larger than the number of available neighbors {}. Resetting k = {}.".format(
                     k, len(coords), len(coords)
                 )

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -31,7 +31,7 @@ class Interpolation:
             Local indices of the k nearest neighbors in all local points.
         """
         if len(coords) < k:
-            self._logger.info(
+            self._logger.log_info_any_rank(
                 "Number of desired neighbors k = {} is larger than the number of available neighbors {}. Resetting k = {}.".format(
                     k, len(coords), len(coords)
                 )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -57,9 +57,7 @@ class MicroManagerCoupling(MicroManager):
         """
         super().__init__(config_file)
 
-        self._logger = Logger(
-            "MicroManagerCoupling", "micro-manager-coupling.log", self._rank
-        )
+        self._logger = Logger(__name__, None, self._rank)
 
         self._config.set_logger(self._logger)
         self._config.read_json_micro_manager()

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -186,20 +186,20 @@ class MicroManagerCoupling(MicroManager):
                         is_sim_active_cp = np.copy(is_sim_active)
                         sim_is_associated_to_cp = np.copy(sim_is_associated_to)
 
-                    if self._adaptivity_type == "local":
-                        active_sim_ids = np.where(is_sim_active)[0]
-                    elif self._adaptivity_type == "global":
-                        active_sim_ids = np.where(
-                            is_sim_active[
-                                self._global_ids_of_local_sims[
-                                    0
-                                ] : self._global_ids_of_local_sims[-1]
-                                + 1
-                            ]
-                        )[0]
+                        if self._adaptivity_type == "local":
+                            active_sim_ids = np.where(is_sim_active)[0]
+                        elif self._adaptivity_type == "global":
+                            active_sim_ids = np.where(
+                                is_sim_active[
+                                    self._global_ids_of_local_sims[
+                                        0
+                                    ] : self._global_ids_of_local_sims[-1]
+                                    + 1
+                                ]
+                            )[0]
 
-                    for active_id in active_sim_ids:
-                        self._micro_sims_active_steps[active_id] += 1
+                        for active_id in active_sim_ids:
+                            self._micro_sims_active_steps[active_id] += 1
 
             micro_sims_input = self._read_data_from_precice(dt)
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -662,7 +662,7 @@ class MicroManagerCoupling(MicroManager):
             List of dicts in which keys are names of data and the values are the data of the output of the micro
             simulations.
         """
-        micro_sims_output = [None] * self._local_number_of_sims
+        micro_sims_output: list[dict] = [None] * self._local_number_of_sims
 
         for count, sim in enumerate(self._micro_sims):
             # If micro simulation has not crashed in a previous iteration, attempt to solve it

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -26,7 +26,6 @@ import precice
 
 from .micro_manager_base import MicroManager
 
-from .adaptivity.adaptivity import AdaptivityCalculator
 from .adaptivity.global_adaptivity import GlobalAdaptivityCalculator
 from .adaptivity.local_adaptivity import LocalAdaptivityCalculator
 
@@ -423,12 +422,12 @@ class MicroManagerCoupling(MicroManager):
 
         if self._is_adaptivity_on:
             if self._adaptivity_type == "local":
-                self._adaptivity_controller: AdaptivityCalculator = (
+                self._adaptivity_controller: LocalAdaptivityCalculator = (
                     LocalAdaptivityCalculator(self._config, self._logger)
                 )
                 self._number_of_sims_for_adaptivity = self._local_number_of_sims
             elif self._adaptivity_type == "global":
-                self._adaptivity_controller: AdaptivityCalculator = (
+                self._adaptivity_controller: GlobalAdaptivityCalculator = (
                     GlobalAdaptivityCalculator(
                         self._config,
                         self._logger,

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -83,7 +83,7 @@ class MicroManagerCoupling(MicroManager):
         self._interpolate_crashed_sims = self._config.interpolate_crashed_micro_sim()
         if self._interpolate_crashed_sims:
             if Interpolation is None:
-                self._logger.log_info_one_rank(
+                self._logger.log_info_rank_zero(
                     "Interpolation is turned off as the required package is not installed."
                 )
                 self._interpolate_crashed_sims = False
@@ -149,7 +149,7 @@ class MicroManagerCoupling(MicroManager):
         if self._is_adaptivity_on:
             # If micro simulations have been initialized, compute adaptivity before starting the coupling
             if self._micro_sims_init:
-                self._logger.log_info_one_rank(
+                self._logger.log_info_rank_zero(
                     "Micro simulations have been initialized, so adaptivity will be computed before the coupling begins."
                 )
 
@@ -211,7 +211,7 @@ class MicroManagerCoupling(MicroManager):
                     )
 
                 if crash_ratio > self._crash_threshold:
-                    self._logger.log_info_any_rank(
+                    self._logger.log_info(
                         "{:.1%} of the micro simulations have crashed exceeding the threshold of {:.1%}. "
                         "Exiting simulation.".format(crash_ratio, self._crash_threshold)
                     )
@@ -252,7 +252,7 @@ class MicroManagerCoupling(MicroManager):
                 ):
                     self._adaptivity_controller.log_metrics(n)
 
-                self._logger.log_info_one_rank("Time window {} converged.".format(n))
+                self._logger.log_info_rank_zero("Time window {} converged.".format(n))
 
         self._participant.finalize()
 
@@ -302,7 +302,7 @@ class MicroManagerCoupling(MicroManager):
 
         if self._local_number_of_sims == 0:
             if self._is_parallel:
-                self._logger.log_info_any_rank(
+                self._logger.log_info(
                     "Rank {} has no micro simulations and hence will not do any computation.".format(
                         self._rank
                     )
@@ -323,18 +323,18 @@ class MicroManagerCoupling(MicroManager):
         if (
             max_nms != min_nms
         ):  # if the number of maximum and minimum micro simulations per rank are different
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "The following ranks have the maximum number of micro simulations ({}): {}".format(
                     max_nms, np.where(nms_all_ranks == max_nms)[0]
                 )
             )
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "The following ranks have the minimum number of micro simulations ({}): {}".format(
                     min_nms, np.where(nms_all_ranks == min_nms)[0]
                 )
             )
         else:  # if the number of maximum and minimum micro simulations per rank are the same
-            self._logger.log_info_one_rank(
+            self._logger.log_info_rank_zero(
                 "All ranks have the same number of micro simulations: {}".format(
                     max_nms
                 )
@@ -343,7 +343,7 @@ class MicroManagerCoupling(MicroManager):
         # Get global number of micro simulations
         self._global_number_of_sims: int = np.sum(nms_all_ranks)
 
-        self._logger.log_info_one_rank(
+        self._logger.log_info_rank_zero(
             "Total number of micro simulations: {}".format(self._global_number_of_sims)
         )
 
@@ -433,7 +433,7 @@ class MicroManagerCoupling(MicroManager):
                         "The initialize() method of the Micro simulation has an incorrect number of arguments."
                     )
             except TypeError:
-                self._logger.log_info_one_rank(
+                self._logger.log_info_rank_zero(
                     "The signature of initialize() method of the micro simulation cannot be determined. Trying to determine the signature by calling the method."
                 )
                 # Try to get the signature of the initialize() method, if it is not written in Python
@@ -441,7 +441,7 @@ class MicroManagerCoupling(MicroManager):
                     self._micro_sims[0].initialize()
                     is_initial_data_required = False
                 except TypeError:
-                    self._logger.log_info_one_rank(
+                    self._logger.log_info_rank_zero(
                         "The initialize() method of the micro simulation has arguments. Attempting to call it again with initial data."
                     )
                     try:  # Try to call the initialize() method with initial data
@@ -632,13 +632,13 @@ class MicroManagerCoupling(MicroManager):
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
-                    self._logger.log_error_any_rank(
+                    self._logger.log_error(
                         "Micro simulation at macro coordinates {} with input {} has experienced an error. "
                         "See next entry on this rank for error message.".format(
                             self._mesh_vertex_coords[count], micro_sims_input[count]
                         )
                     )
-                    self._logger.log_error_any_rank(error_message)
+                    self._logger.log_error(error_message)
                     self._has_sim_crashed[count] = True
 
         # If interpolate is off, terminate after crash
@@ -648,7 +648,7 @@ class MicroManagerCoupling(MicroManager):
                 np.sum(self._has_sim_crashed), crashed_sims_on_all_ranks
             )
             if sum(crashed_sims_on_all_ranks) > 0:
-                self._logger.log_info_any_rank(
+                self._logger.log_info(
                     "Exiting simulation after micro simulation crash."
                 )
                 sys.exit()
@@ -661,7 +661,7 @@ class MicroManagerCoupling(MicroManager):
         # Iterate over all crashed simulations to interpolate output
         if self._interpolate_crashed_sims:
             for unset_sim in unset_sims:
-                self._logger.log_info_any_rank(
+                self._logger.log_info(
                     "Interpolating output for crashed simulation at macro vertex {}.".format(
                         self._mesh_vertex_coords[unset_sim]
                     )
@@ -720,13 +720,13 @@ class MicroManagerCoupling(MicroManager):
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
-                    self._logger.log_error_any_rank(
+                    self._logger.log_error(
                         "Micro simulation at macro coordinates {} has experienced an error. "
                         "See next entry on this rank for error message.".format(
                             self._mesh_vertex_coords[active_id]
                         )
                     )
-                    self._logger.log_error_any_rank(error_message)
+                    self._logger.log_error(error_message)
                     self._has_sim_crashed[active_id] = True
 
         # If interpolate is off, terminate after crash
@@ -736,7 +736,7 @@ class MicroManagerCoupling(MicroManager):
                 np.sum(self._has_sim_crashed), crashed_sims_on_all_ranks
             )
             if sum(crashed_sims_on_all_ranks) > 0:
-                self._logger.log_error_any_rank(
+                self._logger.log_error(
                     "Exiting simulation after micro simulation crash."
                 )
                 sys.exit()
@@ -750,7 +750,7 @@ class MicroManagerCoupling(MicroManager):
         # Iterate over all crashed simulations to interpolate output
         if self._interpolate_crashed_sims:
             for unset_sim in unset_sims:
-                self._logger.log_info_any_rank(
+                self._logger.log_info(
                     "Interpolating output for crashed simulation at macro vertex {}.".format(
                         self._mesh_vertex_coords[unset_sim]
                     )
@@ -856,7 +856,7 @@ class MicroManagerCoupling(MicroManager):
                 micro_sims_active_values.append(micro_sims_output[i].copy())
         # Find nearest neighbors
         if len(micro_sims_active_input_lists) == 0:
-            self._logger.log_error_any_rank(
+            self._logger.log_error(
                 "No active neighbors available for interpolation at macro vertex {}. Value cannot be interpolated".format(
                     self._mesh_vertex_coords[unset_sim]
                 )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -282,9 +282,13 @@ class MicroManagerCoupling(MicroManager):
         assert len(self._macro_bounds) / 2 == self._participant.get_mesh_dimensions(
             self._macro_mesh_name
         ), "Provided macro mesh bounds are of incorrect dimension"
+
         if self._is_parallel:
+            assert len(self._ranks_per_axis) == self._participant.get_mesh_dimensions(
+                self._macro_mesh_name
+            ), "Provided ranks combination is of incorrect dimension"
+
             domain_decomposer = DomainDecomposer(
-                self._participant.get_mesh_dimensions(self._macro_mesh_name),
                 self._rank,
                 self._size,
             )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -23,6 +23,8 @@ from warnings import warn
 from typing import Callable
 
 import numpy as np
+import time
+
 import precice
 
 from .micro_manager_base import MicroManager
@@ -33,6 +35,8 @@ from .adaptivity.local_adaptivity import LocalAdaptivityCalculator
 from .domain_decomposition import DomainDecomposer
 
 from .micro_simulation import create_simulation_class
+from .tools.logging_wrapper import Logger
+
 
 try:
     from .interpolation import Interpolation
@@ -53,11 +57,28 @@ class MicroManagerCoupling(MicroManager):
             Name of the JSON configuration file (provided by the user).
         """
         super().__init__(config_file)
-        self._config.read_json_micro_manager()
-        # Define the preCICE Participant
-        self._participant = precice.Participant(
-            "Micro-Manager", self._config.get_config_file_name(), self._rank, self._size
+
+        self._logger = Logger(
+            "MicroManagerCoupling", "micro-manager-coupling.log", self._rank
         )
+
+        self._config.set_logger(self._logger)
+        self._config.read_json_micro_manager()
+
+        # Data names of data to output to the snapshot database
+        self._write_data_names = self._config.get_write_data_names()
+
+        # Data names of data to read as input parameter to the simulations
+        self._read_data_names = self._config.get_read_data_names()
+
+        self._micro_dt = self._config.get_micro_dt()
+
+        self._is_micro_solve_time_required = self._config.write_micro_solve_time()
+
+        self._is_micro_solve_mem_use_required = self._config.write_micro_mem_use()
+
+        if self._is_micro_solve_mem_use_required:
+            tracemalloc = importlib.import_module("tracemalloc")
 
         self._macro_mesh_name = self._config.get_macro_mesh_name()
 
@@ -70,7 +91,7 @@ class MicroManagerCoupling(MicroManager):
         self._interpolate_crashed_sims = self._config.interpolate_crashed_micro_sim()
         if self._interpolate_crashed_sims:
             if Interpolation is None:
-                self._logger.info(
+                self._logger.log_info_one_rank(
                     "Interpolation is turned off as the required package is not installed."
                 )
                 self._interpolate_crashed_sims = False
@@ -85,6 +106,14 @@ class MicroManagerCoupling(MicroManager):
         self._is_adaptivity_on = self._config.turn_on_adaptivity()
 
         if self._is_adaptivity_on:
+            self._adaptivity_logger = Logger(
+                "Adaptivity", "adaptivity-metrics.csv", self._rank, csv_logger=True
+            )
+
+            self._adaptivity_logger.log_info_one_rank(
+                "Time Window,Avg Active Sims,Avg Inactive Sims,Max Active,Max Inactive"
+            )
+
             self._number_of_sims_for_adaptivity: int = 0
 
             self._data_for_adaptivity: Dict[str, np.ndarray] = dict()
@@ -94,6 +123,7 @@ class MicroManagerCoupling(MicroManager):
 
             # Names of macro data to be used for adaptivity computation
             self._adaptivity_macro_data_names = dict()
+
             # Names of micro data to be used for adaptivity computation
             self._adaptivity_micro_data_names = dict()
             for name, is_data_vector in self._adaptivity_data_names.items():
@@ -105,6 +135,18 @@ class MicroManagerCoupling(MicroManager):
             self._adaptivity_in_every_implicit_step = (
                 self._config.is_adaptivity_required_in_every_implicit_iteration()
             )
+            self._micro_sims_active_steps = None
+
+        self._adaptivity_output_n = self._config.get_adaptivity_output_n()
+        self._output_adaptivity_cpu_time = self._config.output_adaptivity_cpu_time()
+
+        # Define the preCICE Participant
+        self._participant = precice.Participant(
+            "Micro-Manager",
+            self._config.get_precice_config_file_name(),
+            self._rank,
+            self._size,
+        )
 
     # **************
     # Public methods
@@ -154,6 +196,10 @@ class MicroManagerCoupling(MicroManager):
 
             # If micro simulations have been initialized, compute adaptivity before starting the coupling
             if self._micro_sims_init:
+                self._logger.log_info_one_rank(
+                    "Micro simulations have been initialized, so adaptivity will be computed before the coupling begins."
+                )
+
                 adaptivity_data = self._adaptivity_controller.compute_adaptivity(
                     dt,
                     self._micro_sims,
@@ -162,6 +208,8 @@ class MicroManagerCoupling(MicroManager):
                 )
 
         while self._participant.is_coupling_ongoing():
+
+            adaptivity_cpu_time = 0.0
 
             dt = min(self._participant.get_max_time_step_size(), self._micro_dt)
 
@@ -174,6 +222,7 @@ class MicroManagerCoupling(MicroManager):
 
                 if self._is_adaptivity_on:
                     if not self._adaptivity_in_every_implicit_step:
+                        start_time = time.process_time()
                         adaptivity_data = (
                             self._adaptivity_controller.compute_adaptivity(
                                 dt,
@@ -182,6 +231,9 @@ class MicroManagerCoupling(MicroManager):
                                 self._data_for_adaptivity,
                             )
                         )
+                        end_time = time.process_time()
+
+                        adaptivity_cpu_time = end_time - start_time
 
                         # Only checkpoint the adaptivity configuration if adaptivity is computed
                         # once in every time window
@@ -197,6 +249,10 @@ class MicroManagerCoupling(MicroManager):
             micro_sims_input = self._read_data_from_precice(dt)
 
             micro_sims_output = micro_sim_solve(micro_sims_input, dt, adaptivity_data)
+
+            if self._output_adaptivity_cpu_time:
+                for i in range(self._local_number_of_sims):
+                    micro_sims_output[i]["adaptivity_cpu_time"] = adaptivity_cpu_time
 
             # Check if more than a certain percentage of the micro simulations have crashed and terminate if threshold is exceeded
             if self._interpolate_crashed_sims:
@@ -215,7 +271,7 @@ class MicroManagerCoupling(MicroManager):
                     )
 
                 if crash_ratio > self._crash_threshold:
-                    self._logger.info(
+                    self._logger.log_info_any_rank(
                         "{:.1%} of the micro simulations have crashed exceeding the threshold of {:.1%}. "
                         "Exiting simulation.".format(crash_ratio, self._crash_threshold)
                     )
@@ -225,6 +281,7 @@ class MicroManagerCoupling(MicroManager):
 
             t += dt  # increase internal time when time step is done.
             n += 1  # increase counter
+
             self._participant.advance(
                 dt
             )  # notify preCICE that time step of size dt is complete
@@ -244,18 +301,21 @@ class MicroManagerCoupling(MicroManager):
             if (
                 self._participant.is_time_window_complete()
             ):  # Time window has converged, now micro output can be generated
-                self._logger.info(
-                    "Micro simulations {} - {} have converged at t = {}".format(
-                        self._micro_sims[0].get_global_id(),
-                        self._micro_sims[-1].get_global_id(),
-                        t,
-                    )
-                )
-
                 if self._micro_sims_have_output:
                     if n % self._micro_n_out == 0:
                         for sim in self._micro_sims:
                             sim.output()
+
+                if (
+                    self._is_adaptivity_on
+                    and n % self._adaptivity_output_n == 0
+                    and self._rank == 0
+                ):
+                    self._adaptivity_controller.log_metrics(
+                        self._adaptivity_logger, adaptivity_data, n
+                    )
+
+                self._logger.log_info_one_rank("Time window {} converged.".format(n))
 
         self._participant.finalize()
 
@@ -274,7 +334,6 @@ class MicroManagerCoupling(MicroManager):
         ), "Provided macro mesh bounds are of incorrect dimension"
         if self._is_parallel:
             domain_decomposer = DomainDecomposer(
-                self._logger,
                 self._participant.get_mesh_dimensions(self._macro_mesh_name),
                 self._rank,
                 self._size,
@@ -299,13 +358,10 @@ class MicroManagerCoupling(MicroManager):
         assert self._mesh_vertex_coords.size != 0, "Macro mesh has no vertices."
 
         self._local_number_of_sims, _ = self._mesh_vertex_coords.shape
-        self._logger.info(
-            "Number of local micro simulations = {}".format(self._local_number_of_sims)
-        )
 
         if self._local_number_of_sims == 0:
             if self._is_parallel:
-                self._logger.info(
+                self._logger.log_info_any_rank(
                     "Rank {} has no micro simulations and hence will not do any computation.".format(
                         self._rank
                     )
@@ -320,8 +376,35 @@ class MicroManagerCoupling(MicroManager):
         # the correct global IDs
         self._comm.Allgatherv(np.array(self._local_number_of_sims), nms_all_ranks)
 
+        max_nms = np.max(nms_all_ranks)
+        min_nms = np.min(nms_all_ranks)
+
+        if (
+            max_nms != min_nms
+        ):  # if the number of maximum and minimum micro simulations per rank are different
+            self._logger.log_info_one_rank(
+                "The following ranks have the maximum number of micro simulations ({}): {}".format(
+                    max_nms, np.where(nms_all_ranks == max_nms)[0]
+                )
+            )
+            self._logger.log_info_one_rank(
+                "The following ranks have the minimum number of micro simulations ({}): {}".format(
+                    min_nms, np.where(nms_all_ranks == min_nms)[0]
+                )
+            )
+        else:  # if the number of maximum and minimum micro simulations per rank are the same
+            self._logger.log_info_one_rank(
+                "All ranks have the same number of micro simulations: {}".format(
+                    max_nms
+                )
+            )
+
         # Get global number of micro simulations
         self._global_number_of_sims: int = np.sum(nms_all_ranks)
+
+        self._logger.log_info_one_rank(
+            "Total number of micro simulations: {}".format(self._global_number_of_sims)
+        )
 
         if self._is_adaptivity_on:
             for name, is_data_vector in self._adaptivity_data_names.items():
@@ -367,23 +450,16 @@ class MicroManagerCoupling(MicroManager):
                 )
             )
 
-        self._logger.info(
-            "Micro simulations with global IDs {} - {} created.".format(
-                self._global_ids_of_local_sims[0], self._global_ids_of_local_sims[-1]
-            )
-        )
-
         if self._is_adaptivity_on:
             if self._adaptivity_type == "local":
                 self._adaptivity_controller: LocalAdaptivityCalculator = (
-                    LocalAdaptivityCalculator(self._config, self._logger)
+                    LocalAdaptivityCalculator(self._config, self._comm)
                 )
                 self._number_of_sims_for_adaptivity = self._local_number_of_sims
             elif self._adaptivity_type == "global":
                 self._adaptivity_controller: GlobalAdaptivityCalculator = (
                     GlobalAdaptivityCalculator(
                         self._config,
-                        self._logger,
                         self._global_number_of_sims,
                         self._global_ids_of_local_sims,
                         self._rank,
@@ -428,7 +504,7 @@ class MicroManagerCoupling(MicroManager):
                         "The initialize() method of the Micro simulation has an incorrect number of arguments."
                     )
             except TypeError:
-                self._logger.info(
+                self._logger.log_info_one_rank(
                     "The signature of initialize() method of the micro simulation cannot be determined. Trying to determine the signature by calling the method."
                 )
                 # Try to get the signature of the initialize() method, if it is not written in Python
@@ -436,7 +512,7 @@ class MicroManagerCoupling(MicroManager):
                     self._micro_sims[0].initialize()
                     is_initial_data_required = False
                 except TypeError:
-                    self._logger.info(
+                    self._logger.log_info_one_rank(
                         "The initialize() method of the micro simulation has arguments. Attempting to call it again with initial data."
                     )
                     try:  # Try to call the initialize() method with initial data
@@ -625,24 +701,24 @@ class MicroManagerCoupling(MicroManager):
             if not self._has_sim_crashed[count]:
                 # Attempt to solve the micro simulation
                 try:
-                    start_time = time.time()
+                    start_time = time.process_time()
                     micro_sims_output[count] = sim.solve(micro_sims_input[count], dt)
-                    end_time = time.time()
+                    end_time = time.process_time()
                     # Write solve time of the macro simulation if required and the simulation has not crashed
                     if self._is_micro_solve_time_required:
-                        micro_sims_output[count]["micro_sim_time"] = (
+                        micro_sims_output[count]["solve_cpu_time"] = (
                             end_time - start_time
                         )
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
-                    self._logger.error(
+                    self._logger.log_error_any_rank(
                         "Micro simulation at macro coordinates {} with input {} has experienced an error. "
                         "See next entry on this rank for error message.".format(
                             self._mesh_vertex_coords[count], micro_sims_input[count]
                         )
                     )
-                    self._logger.error(error_message)
+                    self._logger.log_error_any_rank(error_message)
                     self._has_sim_crashed[count] = True
 
         # If interpolate is off, terminate after crash
@@ -652,7 +728,9 @@ class MicroManagerCoupling(MicroManager):
                 np.sum(self._has_sim_crashed), crashed_sims_on_all_ranks
             )
             if sum(crashed_sims_on_all_ranks) > 0:
-                self._logger.info("Exiting simulation after micro simulation crash.")
+                self._logger.log_info_any_rank(
+                    "Exiting simulation after micro simulation crash."
+                )
                 sys.exit()
 
         # Interpolate result for crashed simulation
@@ -663,7 +741,7 @@ class MicroManagerCoupling(MicroManager):
         # Iterate over all crashed simulations to interpolate output
         if self._interpolate_crashed_sims:
             for unset_sim in unset_sims:
-                self._logger.info(
+                self._logger.log_info_any_rank(
                     "Interpolating output for crashed simulation at macro vertex {}.".format(
                         self._mesh_vertex_coords[unset_sim]
                     )
@@ -681,7 +759,7 @@ class MicroManagerCoupling(MicroManager):
         adaptivity_data: list,
     ) -> list:
         """
-        Solve all micro simulations and assemble the micro simulations outputs in a list of dicts format.
+        Adaptively solve micro simulations and assemble the micro simulations outputs in a list of dicts format.
 
         Parameters
         ----------
@@ -729,14 +807,14 @@ class MicroManagerCoupling(MicroManager):
             if not self._has_sim_crashed[active_id]:
                 # Attempt to solve the micro simulation
                 try:
-                    start_time = time.time()
+                    start_time = time.process_time()
                     micro_sims_output[active_id] = self._micro_sims[active_id].solve(
                         micro_sims_input[active_id], dt
                     )
-                    end_time = time.time()
+                    end_time = time.process_time()
                     # Write solve time of the macro simulation if required and the simulation has not crashed
                     if self._is_micro_solve_time_required:
-                        micro_sims_output[active_id]["micro_sim_time"] = (
+                        micro_sims_output[active_id]["solve_cpu_time"] = (
                             end_time - start_time
                         )
 
@@ -748,13 +826,13 @@ class MicroManagerCoupling(MicroManager):
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
-                    self._logger.error(
+                    self._logger.log_error_any_rank(
                         "Micro simulation at macro coordinates {} has experienced an error. "
                         "See next entry on this rank for error message.".format(
                             self._mesh_vertex_coords[active_id]
                         )
                     )
-                    self._logger.error(error_message)
+                    self._logger.log_error_any_rank(error_message)
                     self._has_sim_crashed[active_id] = True
 
         # If interpolate is off, terminate after crash
@@ -764,8 +842,11 @@ class MicroManagerCoupling(MicroManager):
                 np.sum(self._has_sim_crashed), crashed_sims_on_all_ranks
             )
             if sum(crashed_sims_on_all_ranks) > 0:
-                self._logger.info("Exiting simulation after micro simulation crash.")
+                self._logger.log_error_any_rank(
+                    "Exiting simulation after micro simulation crash."
+                )
                 sys.exit()
+
         # Interpolate result for crashed simulation
         unset_sims = []
         for active_id in active_sim_ids:
@@ -775,7 +856,7 @@ class MicroManagerCoupling(MicroManager):
         # Iterate over all crashed simulations to interpolate output
         if self._interpolate_crashed_sims:
             for unset_sim in unset_sims:
-                self._logger.info(
+                self._logger.log_info_any_rank(
                     "Interpolating output for crashed simulation at macro vertex {}.".format(
                         self._mesh_vertex_coords[unset_sim]
                     )
@@ -797,7 +878,7 @@ class MicroManagerCoupling(MicroManager):
             ] = self._micro_sims_active_steps[inactive_id]
 
             if self._is_micro_solve_time_required:
-                micro_sims_output[inactive_id]["micro_sim_time"] = 0
+                micro_sims_output[inactive_id]["solve_cpu_time"] = 0
 
         # Collect micro sim output for adaptivity calculation
         for i in range(self._local_number_of_sims):
@@ -879,7 +960,7 @@ class MicroManagerCoupling(MicroManager):
                 micro_sims_active_values.append(micro_sims_output[i].copy())
         # Find nearest neighbors
         if len(micro_sims_active_input_lists) == 0:
-            self._logger.error(
+            self._logger.log_error_any_rank(
                 "No active neighbors available for interpolation at macro vertex {}. Value cannot be interpolated".format(
                     self._mesh_vertex_coords[unset_sim]
                 )
@@ -900,13 +981,13 @@ class MicroManagerCoupling(MicroManager):
             if self._is_adaptivity_on:
                 interpol_space.append(micro_sims_active_input_lists[neighbor].copy())
                 interpol_values.append(micro_sims_active_values[neighbor].copy())
-                interpol_values[-1].pop("micro_sim_time", None)
+                interpol_values[-1].pop("solve_cpu_time", None)
                 interpol_values[-1].pop("active_state", None)
                 interpol_values[-1].pop("active_steps", None)
             else:
                 interpol_space.append(micro_sims_active_input_lists[neighbor].copy())
                 interpol_values.append(micro_sims_active_values[neighbor].copy())
-                interpol_values[-1].pop("micro_sim_time", None)
+                interpol_values[-1].pop("solve_cpu_time", None)
 
         # Interpolate for each parameter
         output_interpol = dict()
@@ -920,7 +1001,7 @@ class MicroManagerCoupling(MicroManager):
             )
         # Reintroduce removed information
         if self._is_micro_solve_time_required:
-            output_interpol["micro_sim_time"] = 0
+            output_interpol["solve_cpu_time"] = 0
         if self._is_adaptivity_on:
             output_interpol["active_state"] = 1
             output_interpol["active_steps"] = self._micro_sims_active_steps[unset_sim]

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -635,9 +635,8 @@ class MicroManagerCoupling(MicroManager):
 
         Returns
         -------
-        micro_sims_output : list
-            List of dicts in which keys are names of data and the values are the data of the output of the micro
-            simulations.
+        tuple
+            A tuple of micro_sims_output (list of Dicts) and dummy adaptivity computation CPU time.
         """
         micro_sims_output: list[dict] = [None] * self._local_number_of_sims
 
@@ -713,9 +712,8 @@ class MicroManagerCoupling(MicroManager):
 
         Returns
         -------
-        micro_sims_output : list
-            List of dicts in which keys are names of data and the values are the data of the output of the micro
-            simulations.
+        tuple
+            A tuple of micro_sims_output (list of Dicts) and adaptivity computation CPU time.
         """
         adaptivity_cpu_time = 0.0
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -25,9 +25,13 @@ import numpy as np
 import precice
 
 from .micro_manager_base import MicroManager
+
+from .adaptivity.adaptivity import AdaptivityCalculator
 from .adaptivity.global_adaptivity import GlobalAdaptivityCalculator
 from .adaptivity.local_adaptivity import LocalAdaptivityCalculator
+
 from .domain_decomposition import DomainDecomposer
+
 from .micro_simulation import create_simulation_class
 
 try:
@@ -81,7 +85,7 @@ class MicroManagerCoupling(MicroManager):
         self._is_adaptivity_on = self._config.turn_on_adaptivity()
 
         if self._is_adaptivity_on:
-            self._number_of_sims_for_adaptivity = 0
+            self._number_of_sims_for_adaptivity: int = 0
 
             self._data_for_adaptivity: Dict[str, np.ndarray] = dict()
             self._adaptivity_type = self._config.get_adaptivity_type()
@@ -101,7 +105,6 @@ class MicroManagerCoupling(MicroManager):
             self._adaptivity_in_every_implicit_step = (
                 self._config.is_adaptivity_required_in_every_implicit_iteration()
             )
-            self._micro_sims_active_steps = None
 
     # **************
     # Public methods
@@ -364,7 +367,7 @@ class MicroManagerCoupling(MicroManager):
         self._comm.Allgatherv(np.array(self._local_number_of_sims), nms_all_ranks)
 
         # Get global number of micro simulations
-        self._global_number_of_sims = np.sum(nms_all_ranks)
+        self._global_number_of_sims: int = np.sum(nms_all_ranks)
 
         if self._is_adaptivity_on:
             for name, is_data_vector in self._adaptivity_data_names.items():
@@ -389,7 +392,7 @@ class MicroManagerCoupling(MicroManager):
             self._global_ids_of_local_sims.append(sim_id)
             sim_id += 1
 
-        self._micro_sims = [None] * self._local_number_of_sims  # DECLARATION
+        # self._micro_sims = [None] * self._local_number_of_sims  # DECLARATION
 
         # Setup for simulation crashes
         self._has_sim_crashed = [False] * self._local_number_of_sims
@@ -404,9 +407,12 @@ class MicroManagerCoupling(MicroManager):
         )
 
         # Create micro simulation objects
+        self._micro_sims = []
         for i in range(self._local_number_of_sims):
-            self._micro_sims[i] = create_simulation_class(micro_problem)(
-                self._global_ids_of_local_sims[i]
+            self._micro_sims.append(
+                create_simulation_class(micro_problem)(
+                    self._global_ids_of_local_sims[i]
+                )
             )
 
         self._logger.info(
@@ -417,22 +423,26 @@ class MicroManagerCoupling(MicroManager):
 
         if self._is_adaptivity_on:
             if self._adaptivity_type == "local":
-                self._adaptivity_controller = LocalAdaptivityCalculator(
-                    self._config, self._logger
+                self._adaptivity_controller: AdaptivityCalculator = (
+                    LocalAdaptivityCalculator(self._config, self._logger)
                 )
                 self._number_of_sims_for_adaptivity = self._local_number_of_sims
             elif self._adaptivity_type == "global":
-                self._adaptivity_controller = GlobalAdaptivityCalculator(
-                    self._config,
-                    self._logger,
-                    self._global_number_of_sims,
-                    self._global_ids_of_local_sims,
-                    self._rank,
-                    self._comm,
+                self._adaptivity_controller: AdaptivityCalculator = (
+                    GlobalAdaptivityCalculator(
+                        self._config,
+                        self._logger,
+                        self._global_number_of_sims,
+                        self._global_ids_of_local_sims,
+                        self._rank,
+                        self._comm,
+                    )
                 )
                 self._number_of_sims_for_adaptivity = self._global_number_of_sims
 
-            self._micro_sims_active_steps = np.zeros(self._local_number_of_sims)
+            self._micro_sims_active_steps = np.zeros(
+                self._local_number_of_sims
+            )  # DECLARATION
 
         self._micro_sims_init = False  # DECLARATION
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -98,7 +98,7 @@ class MicroManagerCoupling(MicroManager):
         self._is_adaptivity_on = self._config.turn_on_adaptivity()
 
         if self._is_adaptivity_on:
-            self._data_for_adaptivity: Dict[str, np.ndarray] = dict()
+            self._data_for_adaptivity: Dict[str, list] = dict()
 
             self._adaptivity_data_names = self._config.get_data_for_adaptivity()
 
@@ -357,7 +357,7 @@ class MicroManagerCoupling(MicroManager):
 
         if self._is_adaptivity_on:
             for name in self._adaptivity_data_names:
-                self._data_for_adaptivity[name] = np.zeros((self._local_number_of_sims))
+                self._data_for_adaptivity[name] = [0] * self._local_number_of_sims
 
         # Create lists of local and global IDs
         sim_id = np.sum(nms_all_ranks[: self._rank])
@@ -725,7 +725,7 @@ class MicroManagerCoupling(MicroManager):
         active_sim_ids = self._adaptivity_controller.get_active_sim_ids()
         inactive_sim_ids = self._adaptivity_controller.get_inactive_sim_ids()
 
-        micro_sims_output = [None] * self._local_number_of_sims
+        micro_sims_output = [0] * self._local_number_of_sims
 
         # Solve all active micro simulations
         for active_id in active_sim_ids:
@@ -776,7 +776,7 @@ class MicroManagerCoupling(MicroManager):
         # Interpolate result for crashed simulation
         unset_sims = []
         for active_id in active_sim_ids:
-            if micro_sims_output[active_id] is None:
+            if micro_sims_output[active_id] == 0:
                 unset_sims.append(active_id)
 
         # Iterate over all crashed simulations to interpolate output

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -103,15 +103,15 @@ class MicroManagerCoupling(MicroManager):
             self._adaptivity_data_names = self._config.get_data_for_adaptivity()
 
             # Names of macro data to be used for adaptivity computation
-            self._adaptivity_macro_data_names = dict()
+            self._adaptivity_macro_data_names: list = []
 
             # Names of micro data to be used for adaptivity computation
-            self._adaptivity_micro_data_names = dict()
-            for name, is_data_vector in self._adaptivity_data_names.items():
+            self._adaptivity_micro_data_names: list = []
+            for name in self._adaptivity_data_names:
                 if name in self._read_data_names:
-                    self._adaptivity_macro_data_names[name] = is_data_vector
+                    self._adaptivity_macro_data_names.append(name)
                 if name in self._write_data_names:
-                    self._adaptivity_micro_data_names[name] = is_data_vector
+                    self._adaptivity_micro_data_names.append(name)
 
             self._adaptivity_in_every_implicit_step = (
                 self._config.is_adaptivity_required_in_every_implicit_iteration()
@@ -356,20 +356,8 @@ class MicroManagerCoupling(MicroManager):
         )
 
         if self._is_adaptivity_on:
-            for name, is_data_vector in self._adaptivity_data_names.items():
-                if is_data_vector:
-                    self._data_for_adaptivity[name] = np.zeros(
-                        (
-                            self._local_number_of_sims,
-                            self._participant.get_data_dimensions(
-                                self._macro_mesh_name, name
-                            ),
-                        )
-                    )
-                else:
-                    self._data_for_adaptivity[name] = np.zeros(
-                        (self._local_number_of_sims)
-                    )
+            for name in self._adaptivity_data_names:
+                self._data_for_adaptivity[name] = np.zeros((self._local_number_of_sims))
 
         # Create lists of local and global IDs
         sim_id = np.sum(nms_all_ranks[: self._rank])
@@ -572,10 +560,11 @@ class MicroManagerCoupling(MicroManager):
             List of dicts in which keys are names of data being read and the values are the data from preCICE.
         """
         read_data: Dict[str, list] = dict()
-        for name in self._read_data_names.keys():
+
+        for name in self._read_data_names:
             read_data[name] = []
 
-        for name in self._read_data_names.keys():
+        for name in self._read_data_names:
             read_data.update(
                 {
                     name: self._participant.read_data(
@@ -608,7 +597,7 @@ class MicroManagerCoupling(MicroManager):
                 for name, values in d.items():
                     data_dict[name].append(values)
 
-            for dname in self._write_data_names.keys():
+            for dname in self._write_data_names:
                 self._participant.write_data(
                     self._macro_mesh_name,
                     dname,
@@ -616,7 +605,7 @@ class MicroManagerCoupling(MicroManager):
                     data_dict[dname],
                 )
         else:
-            for dname in self._write_data_names.keys():
+            for dname in self._write_data_names:
                 self._participant.write_data(
                     self._macro_mesh_name, dname, [], np.array([])
                 )

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -8,7 +8,6 @@ For more details see the MicroManagerCoupling class or the documentation at http
 """
 
 from mpi4py import MPI
-import logging
 from abc import ABC, abstractmethod
 
 from .config import Config
@@ -52,20 +51,6 @@ class MicroManager(MicroManagerInterface):
         self._rank = self._comm.Get_rank()
         self._size = self._comm.Get_size()
 
-        self._logger = logging.getLogger(__name__)
-        self._logger.setLevel(level=logging.INFO)
-
-        # Create file handler which logs messages
-        fh = logging.FileHandler("micro-manager.log")
-        fh.setLevel(logging.INFO)
-
-        # Create formatter and add it to handlers
-        formatter = logging.Formatter(
-            "[" + str(self._rank) + "] %(name)s -  %(levelname)s - %(message)s"
-        )
-        fh.setFormatter(formatter)
-        self._logger.addHandler(fh)  # add the handlers to the logger
-
         self._is_parallel = self._size > 1
         self._micro_sims_have_output = False
 
@@ -73,18 +58,7 @@ class MicroManager(MicroManagerInterface):
         self._global_number_of_sims = 0
         self._is_rank_empty = False
 
-        self._logger.info("Provided configuration file: {}".format(config_file))
-        self._config = Config(self._logger, config_file)
-
-        # Data names of data to output to the snapshot database
-        self._write_data_names = self._config.get_write_data_names()
-
-        # Data names of data to read as input parameter to the simulations
-        self._read_data_names = self._config.get_read_data_names()
-
-        self._micro_dt = self._config.get_micro_dt()
-
-        self._is_micro_solve_time_required = self._config.write_micro_solve_time()
+        self._config = Config(config_file)
 
     def initialize(self):
         """

--- a/micro_manager/snapshot/dataset.py
+++ b/micro_manager/snapshot/dataset.py
@@ -219,7 +219,7 @@ class ReadWriteHDF:
 
     def set_status(self, file_path: str, status: str):
         """
-        Set the status of the file to "finished" to indicate that it is no longer accessed.
+        Set the status of file to the given status.
 
         Parameters
         ----------

--- a/micro_manager/snapshot/dataset.py
+++ b/micro_manager/snapshot/dataset.py
@@ -172,17 +172,17 @@ class ReadWriteHDF:
         parameter_data = dict()
         output = []
         # Read data by iterating over the relevant datasets
-        for key in data_names.keys():
-            parameter_data[key] = np.asarray(parameter_file[key][start:end])
-            my_key = (
-                key  # Save one key to be able to iterate over the length of the data
+        for name in data_names:
+            parameter_data[name] = np.asarray(parameter_file[name][start:end])
+            my_name = (
+                name  # Save one name to be able to iterate over the length of the data
             )
         # Iterate over len of data. In each iteration write data from all macro data sets
         # to a dictionary and append it to the output list of dicts.
-        for i in range(len(parameter_data[my_key])):
+        for i in range(len(parameter_data[my_name])):
             current_data = dict()
-            for key in data_names.keys():
-                current_data[key] = parameter_data[key][i]
+            for name in data_names:
+                current_data[name] = parameter_data[name][i]
             output.append(current_data)
         return output
 

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -113,12 +113,12 @@ class MicroManagerSnapshot(MicroManager):
                                 micro_sims_output
                             )
                         else:
-                            self._logger.log_info_one_rank(
+                            self._logger.log_info_rank_zero(
                                 "No post-processing script with the provided path found. Skipping post-processing."
                             )
                             self._post_processing_file_name = None
                     except Exception:
-                        self._logger.log_info_one_rank(
+                        self._logger.log_info_rank_zero(
                             "No post-processing script with the provided path found. Skipping post-processing."
                         )
                         self._post_processing_file_name = None
@@ -131,7 +131,7 @@ class MicroManagerSnapshot(MicroManager):
                 )
             # Log error and write macro data to database if simulation has crashed
             else:
-                self._logger.log_info_one_rank(
+                self._logger.log_info_rank_zero(
                     "Skipping snapshot storage for crashed simulation."
                 )
                 self._data_storage.write_output_to_hdf(
@@ -152,7 +152,7 @@ class MicroManagerSnapshot(MicroManager):
 
         # Merge output files
         if self._is_parallel:
-            self._logger.log_info_any_rank(
+            self._logger.log_info(
                 "Snapshots have been computed and stored. Merging output files"
             )
             self._data_storage.set_status(self._output_file_path, "reading/deleting")
@@ -166,7 +166,7 @@ class MicroManagerSnapshot(MicroManager):
         else:
             self._data_storage.set_status(self._output_file_path, "finished")
         if self._rank == 0:
-            self._logger.log_info_one_rank("Snapshot computation completed.")
+            self._logger.log_info_rank_zero("Snapshot computation completed.")
 
     def initialize(self) -> None:
         """
@@ -219,17 +219,15 @@ class MicroManagerSnapshot(MicroManager):
             self._output_subdirectory, self._file_name
         )
         self._data_storage.create_file(self._output_file_path)
-        self._logger.log_error_any_rank(
-            "Output file created: {}".format(self._output_file_path)
-        )
+        self._logger.log_error("Output file created: {}".format(self._output_file_path))
         self._local_number_of_sims = len(self._macro_parameters)
-        self._logger.log_info_any_rank(
+        self._logger.log_info(
             "Number of local micro simulations = {}".format(self._local_number_of_sims)
         )
 
         if self._local_number_of_sims == 0:
             if self._is_parallel:
-                self._logger.log_info_any_rank(
+                self._logger.log_info(
                     "Rank {} has no micro simulations and hence will not do any computation.".format(
                         self._rank
                     )
@@ -297,7 +295,7 @@ class MicroManagerSnapshot(MicroManager):
             return micro_sims_output
         # Handle simulation crash
         except Exception as e:
-            self._logger.log_error_any_rank(
+            self._logger.log_error(
                 "Micro simulation with input {} has crashed. See next entry on this rank for error message".format(
                     micro_sims_input
                 )

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -19,6 +19,8 @@ import numpy as np
 from micro_manager.micro_manager import MicroManager
 from .dataset import ReadWriteHDF
 from micro_manager.micro_simulation import create_simulation_class
+from micro_manager.tools.logging_wrapper import Logger
+
 
 sys.path.append(os.getcwd())
 
@@ -34,7 +36,23 @@ class MicroManagerSnapshot(MicroManager):
             Name of the JSON configuration file (provided by the user).
         """
         super().__init__(config_file)
+
+        self._logger = Logger(
+            "MicroManagerSnapshot", "micro-manager-snapshot.log", self._rank
+        )
+
+        self._config.set_logger(self._logger)
         self._config.read_json_snapshot()
+
+        # Data names of data to output to the snapshot database
+        self._write_data_names = self._config.get_write_data_names()
+
+        # Data names of data to read as input parameter to the simulations
+        self._read_data_names = self._config.get_read_data_names()
+
+        self._micro_dt = self._config.get_micro_dt()
+
+        self._is_micro_solve_time_required = self._config.write_micro_solve_time()
 
         # Path to the parameter file containing input parameters for micro simulations
         self._parameter_file = self._config.get_parameter_file_name()
@@ -95,12 +113,12 @@ class MicroManagerSnapshot(MicroManager):
                                 micro_sims_output
                             )
                         else:
-                            self._logger.info(
+                            self._logger.log_info_one_rank(
                                 "No post-processing script with the provided path found. Skipping post-processing."
                             )
                             self._post_processing_file_name = None
                     except Exception:
-                        self._logger.info(
+                        self._logger.log_info_one_rank(
                             "No post-processing script with the provided path found. Skipping post-processing."
                         )
                         self._post_processing_file_name = None
@@ -113,7 +131,9 @@ class MicroManagerSnapshot(MicroManager):
                 )
             # Log error and write macro data to database if simulation has crashed
             else:
-                self._logger.info("Skipping snapshot storage for crashed simulation.")
+                self._logger.log_info_one_rank(
+                    "Skipping snapshot storage for crashed simulation."
+                )
                 self._data_storage.write_output_to_hdf(
                     self._output_file_path,
                     micro_sims_input,
@@ -132,7 +152,7 @@ class MicroManagerSnapshot(MicroManager):
 
         # Merge output files
         if self._is_parallel:
-            self._logger.info(
+            self._logger.log_info_any_rank(
                 "Snapshots have been computed and stored. Merging output files"
             )
             self._data_storage.set_status(self._output_file_path, "reading/deleting")
@@ -146,7 +166,7 @@ class MicroManagerSnapshot(MicroManager):
         else:
             self._data_storage.set_status(self._output_file_path, "finished")
         if self._rank == 0:
-            self._logger.info("Snapshot computation completed.")
+            self._logger.log_info_one_rank("Snapshot computation completed.")
 
     def initialize(self) -> None:
         """
@@ -199,15 +219,17 @@ class MicroManagerSnapshot(MicroManager):
             self._output_subdirectory, self._file_name
         )
         self._data_storage.create_file(self._output_file_path)
-        self._logger.info("Output file created: {}".format(self._output_file_path))
+        self._logger.log_error_any_rank(
+            "Output file created: {}".format(self._output_file_path)
+        )
         self._local_number_of_sims = len(self._macro_parameters)
-        self._logger.info(
+        self._logger.log_info_any_rank(
             "Number of local micro simulations = {}".format(self._local_number_of_sims)
         )
 
         if self._local_number_of_sims == 0:
             if self._is_parallel:
-                self._logger.info(
+                self._logger.log_info_any_rank(
                     "Rank {} has no micro simulations and hence will not do any computation.".format(
                         self._rank
                     )
@@ -265,17 +287,17 @@ class MicroManagerSnapshot(MicroManager):
             simulations. The return type is None if the simulation has crashed.
         """
         try:
-            start_time = time.time()
+            start_time = time.process_time()
             micro_sims_output = self._micro_sims.solve(micro_sims_input, self._micro_dt)
-            end_time = time.time()
+            end_time = time.process_time()
 
             if self._is_micro_solve_time_required:
-                micro_sims_output["micro_sim_time"] = end_time - start_time
+                micro_sims_output["solve_cpu_time"] = end_time - start_time
 
             return micro_sims_output
         # Handle simulation crash
         except Exception as e:
-            self._logger.error(
+            self._logger.log_error_any_rank(
                 "Micro simulation with input {} has crashed. See next entry on this rank for error message".format(
                     micro_sims_input
                 )

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -129,7 +129,6 @@ class MicroManagerSnapshot(MicroManager):
             self._data_storage.write_crashed_snapshots(
                 self._output_file_path, self._crashed_snapshots
             )
-        self._data_storage.set_status(self._output_file_path, "none")
 
         # Merge output files
         if self._is_parallel:
@@ -144,7 +143,10 @@ class MicroManagerSnapshot(MicroManager):
                     list_of_output_files,
                     self._parameter_space_size,
                 )
-        self._logger.info("Snapshot computation completed.")
+        else:
+            self._data_storage.set_status(self._output_file_path, "finished")
+        if self._rank == 0:
+            self._logger.info("Snapshot computation completed.")
 
     def initialize(self) -> None:
         """

--- a/micro_manager/tools/logging_wrapper.py
+++ b/micro_manager/tools/logging_wrapper.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Provides a logging wrapper for the Micro Manager classes.
+"""
+import logging
+
+
+class Logger:
+    """
+    Provides a logging wrapper for the Micro Manager classes.
+    """
+
+    def __init__(self, name, log_file, rank=0, level=logging.INFO, csv_logger=False):
+        """
+        Set up a logger.
+
+        Parameters
+        ----------
+        name : string
+            Name of the logger.
+        log_file : string
+            Name of the log file.
+        rank : int, optional
+            Rank of the logger (default is 0).
+        level : int, optional
+            Logging level (default is logging.INFO).
+        csv_logger : bool, optional
+            If True, the logger will log in CSV format (default is False).
+        """
+
+        self._rank = rank
+
+        handler = logging.FileHandler(log_file)
+        handler.setLevel(level)
+
+        if csv_logger:
+            formatter = logging.Formatter("%(message)s")
+        else:
+            formatter = logging.Formatter(
+                "["
+                + str(self._rank)
+                + "] %(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            )
+
+        handler.setFormatter(formatter)
+
+        self._logger = logging.getLogger(name)
+        self._logger.setLevel(level)
+        self._logger.addHandler(handler)
+
+    def get_logger(self):
+        """
+        Get the logger.
+
+        Returns
+        -------
+        logger : object of logging
+            Logger defined from the standard package logging
+        """
+        return self._logger
+
+    def log_info_one_rank(self, message):
+        """
+        Log a message. Only the rank 0 logs the message.
+
+        Parameters
+        ----------
+        message : string
+            Message to log.
+        """
+        if self._rank == 0:
+            self._logger.info(message)
+
+    def log_info_any_rank(self, message):
+        """
+        Log a message. All ranks log the message.
+
+        Parameters
+        ----------
+        message : string
+            Message to log.
+        """
+        self._logger.info(message)
+
+    def log_error_any_rank(self, message):
+        """
+        Log an error message. Only the rank 0 logs the message.
+
+        Parameters
+        ----------
+        message : string
+            Message to log.
+        """
+        self._logger.error(message)

--- a/micro_manager/tools/logging_wrapper.py
+++ b/micro_manager/tools/logging_wrapper.py
@@ -67,9 +67,9 @@ class Logger:
         """
         return self._logger
 
-    def log_info_one_rank(self, message):
+    def log_info_rank_zero(self, message):
         """
-        Log a message. Only the rank 0 logs the message.
+        Rank 0 logs a message.
 
         Parameters
         ----------
@@ -79,9 +79,9 @@ class Logger:
         if self._rank == 0:
             self._logger.info(message)
 
-    def log_info_any_rank(self, message):
+    def log_info(self, message):
         """
-        Log a message. All ranks log the message.
+        Log a message.
 
         Parameters
         ----------
@@ -90,9 +90,9 @@ class Logger:
         """
         self._logger.info(message)
 
-    def log_error_any_rank(self, message):
+    def log_error(self, message):
         """
-        Log an error message. Only the rank 0 logs the message.
+        Log an error message.
 
         Parameters
         ----------
@@ -100,3 +100,26 @@ class Logger:
             Message to log.
         """
         self._logger.error(message)
+
+    def log_warning_rank_zero(self, message):
+        """
+        Rank 0 logs a warning.
+
+        Parameters
+        ----------
+        message : string
+            Message to log.
+        """
+        if self._rank == 0:
+            self._logger.warning(message)
+
+    def log_warning(self, message):
+        """
+        Log a warning.
+
+        Parameters
+        ----------
+        message : string
+            Message to log.
+        """
+        self._logger.warning(message)

--- a/micro_manager/tools/logging_wrapper.py
+++ b/micro_manager/tools/logging_wrapper.py
@@ -3,6 +3,7 @@
 Provides a logging wrapper for the Micro Manager classes.
 """
 import logging
+import sys
 
 
 class Logger:
@@ -10,7 +11,9 @@ class Logger:
     Provides a logging wrapper for the Micro Manager classes.
     """
 
-    def __init__(self, name, log_file, rank=0, level=logging.INFO, csv_logger=False):
+    def __init__(
+        self, name, log_file=None, rank=0, level=logging.INFO, csv_logger=False
+    ):
         """
         Set up a logger.
 
@@ -19,7 +22,7 @@ class Logger:
         name : string
             Name of the logger.
         log_file : string
-            Name of the log file.
+            Name of the log file (default is None).
         rank : int, optional
             Rank of the logger (default is 0).
         level : int, optional
@@ -30,16 +33,21 @@ class Logger:
 
         self._rank = rank
 
-        handler = logging.FileHandler(log_file)
+        if log_file is None:
+            handler = logging.StreamHandler(sys.stdout)
+        else:
+            handler = logging.FileHandler(log_file)
+
         handler.setLevel(level)
 
         if csv_logger:
             formatter = logging.Formatter("%(message)s")
         else:
             formatter = logging.Formatter(
-                "["
+                "("
                 + str(self._rank)
-                + "] %(asctime)s - %(name)s - %(levelname)s - %(message)s"
+                + ") %(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                datefmt="%m/%d/%Y %I:%M:%S %p",
             )
 
         handler.setFormatter(formatter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Repository = "https://github.com/precice/micro-manager"
 micro-manager-precice = "micro_manager:main"
 
 [tool.setuptools]
-packages=["micro_manager", "micro_manager.adaptivity", "micro_manager.snapshot"]
+packages=["micro_manager", "micro_manager.adaptivity", "micro_manager.snapshot", "micro_manager.tools"]
 
 [tool.setuptools-git-versioning]
 enabled = true

--- a/tests/integration/test_unit_cube/clean-test.sh
+++ b/tests/integration/test_unit_cube/clean-test.sh
@@ -9,3 +9,4 @@ rm -fv *.err
 rm -fv output/*.vtu
 rm -fv output/*.pvtu
 rm -r -fv __pycache__
+rm -fv *.csv

--- a/tests/integration/test_unit_cube/clean-test.sh
+++ b/tests/integration/test_unit_cube/clean-test.sh
@@ -1,12 +1,9 @@
 rm -fv *-events-summary.json
 rm -fv *-events.json
 rm -fv *.log
-rm -r -fv precice-run/
-rm -r -fv precice-profiling/
+rm -rfv precice-run/ precice-profiling/
 rm -fv *.vtk
 rm -fv *.out
 rm -fv *.err
-rm -fv output/*.vtu
-rm -fv output/*.pvtu
-rm -r -fv __pycache__
+rm -rfv __pycache__ output/ .venv/ adaptivity_output/
 rm -fv *.csv

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -1,5 +1,6 @@
 {
     "micro_file_name": "micro_dummy",
+    "output_dir": "adaptivity_output",
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -4,8 +4,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
@@ -17,7 +17,11 @@
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "True"
+            "every_implicit_iteration": "True",
+	        "output_cpu_time": "True"
         }
+    },
+    "diagnostics": {
+        "output_micro_sim_solve_time": "True"
     }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
-        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
+        "write_data_names": ["micro-data-1", "micro-data-2"],
+        "read_data_names": ["macro-data-1"]
     },
     "simulation_params": {
         "micro_dt": 1.0,
@@ -12,7 +12,7 @@
         "adaptivity": "True",
         "adaptivity_settings": {
             "type": "global",
-            "data": ["macro-scalar-data", "macro-vector-data"],
+            "data": ["micro-data-1", "micro-data-2"],
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,

--- a/tests/integration/test_unit_cube/micro-manager-config-load-balancing.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-load-balancing.json
@@ -4,8 +4,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "write_data_names": ["micro-data-1", "micro-data-2"],
-        "read_data_names": ["macro-data-1"]
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,
@@ -14,11 +14,17 @@
         "adaptivity": "True",
         "adaptivity_settings": {
             "type": "global",
-            "data": ["micro-data-1", "micro-data-2"],
-            "history_param": 1.0,
+            "load_balancing": "True",
+            "load_balancing_settings": {
+                "load_balancing_n": 5,
+                "two_step_load_balancing": "True",
+                "balancing_threshold": 2
+            },
+            "data": ["macro-scalar-data", "micro-vector-data"],
+            "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "False",
+            "every_implicit_iteration": "True",
 	        "output_cpu_time": "True"
         }
     },

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
-        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
+        "write_data_names": ["micro-data-1", "micro-data-2"],
+        "read_data_names": ["macro-data-1"]
     },
     "simulation_params": {
         "micro_dt": 1.0,
@@ -12,7 +12,7 @@
         "adaptivity": "True",
         "adaptivity_settings": {
             "type": "local",
-            "data": ["macro-scalar-data", "macro-vector-data"],
+            "data": ["micro-data-1", "micro-data-2"],
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
-        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
+        "write_data_names": ["micro-data-1", "micro-data-2"],
+        "read_data_names": ["macro-data-1"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
-        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
+        "write_data_names": ["micro-data-1", "micro-data-2"],
+        "read_data_names": ["macro-data-1"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "micro_dummy",
     "coupling_params": {
-        "config_file_name": "precice-config.xml",
+        "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "macro-cube-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/integration/test_unit_cube/micro_dummy.py
+++ b/tests/integration/test_unit_cube/micro_dummy.py
@@ -2,6 +2,9 @@
 Micro simulation
 In this script we solve a dummy micro problem to just show the working of the macro-micro coupling
 """
+import copy
+import random
+import time
 
 
 class MicroSimulation:
@@ -10,28 +13,38 @@ class MicroSimulation:
         Constructor of MicroSimulation class.
         """
         self._sim_id = sim_id
-        self._micro_scalar_data = None
-        self._micro_vector_data = None
-        self._checkpoint = None
+
+        sim_types = [4, 88, 37, 12, 1, 23, 134]
+
+        self._this_sim_type = random.choice(sim_types)
+
+        # Artificial state of 100 floats
+        self._state = [x * 0.1 for x in range(100)]
 
     def initialize(self):
-        self._micro_scalar_data = 0
-        self._micro_vector_data = []
-        self._checkpoint = 0
+        return {
+            "micro-data-1": self._this_sim_type * 0.5,
+            "micro-data-2": [
+                self._this_sim_type * 2,
+                self._this_sim_type * 3,
+                self._this_sim_type * 4,
+            ],
+        }
 
     def solve(self, macro_data, dt):
-        assert dt != 0
-        self._micro_vector_data = macro_data["macro-vector-data"]
-        self._micro_scalar_data = macro_data["macro-scalar-data"]
+        time.sleep(self._this_sim_type * 0.001)
 
         return {
-            "micro-scalar-data": self._micro_scalar_data,
-            "micro-vector-data": self._micro_vector_data,
+            "micro-data-1": self._this_sim_type * 0.5,
+            "micro-data-2": [
+                self._this_sim_type * 2,
+                self._this_sim_type * 3,
+                self._this_sim_type * 4,
+            ],
         }
 
     def get_state(self):
-        return [self._micro_scalar_data, self._micro_vector_data]
+        return copy.deepcopy(self._state)
 
     def set_state(self, state):
-        self._micro_scalar_data = state[0]
-        self._micro_vector_data = state[0]
+        self._state = copy.deepcopy(state)

--- a/tests/integration/test_unit_cube/precice-config.xml
+++ b/tests/integration/test_unit_cube/precice-config.xml
@@ -9,7 +9,6 @@
   <data:scalar name="macro-data-1" />
   <data:scalar name="active_state" />
   <data:scalar name="active_steps" />
-  <data:scalar name="adaptivity_cpu_time" />
   <data:scalar name="solve_cpu_time" />
 
   <mesh name="macro-cube-mesh" dimensions="3">
@@ -18,7 +17,6 @@
     <use-data name="macro-data-1" />
     <use-data name="active_state" />
     <use-data name="active_steps" />
-    <use-data name="adaptivity_cpu_time" />
     <use-data name="solve_cpu_time" />
   </mesh>
 
@@ -36,7 +34,6 @@
     <write-data name="micro-data-2" mesh="macro-cube-mesh" />
     <write-data name="active_state" mesh="macro-cube-mesh" />
     <write-data name="active_steps" mesh="macro-cube-mesh" />
-    <write-data name="adaptivity_cpu_time" mesh="macro-cube-mesh" />
     <write-data name="solve_cpu_time" mesh="macro-cube-mesh" />
     <export:vtu directory="output" />
   </participant>

--- a/tests/integration/test_unit_cube/precice-config.xml
+++ b/tests/integration/test_unit_cube/precice-config.xml
@@ -4,20 +4,18 @@
     <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true" />
   </log>
 
-  <data:scalar name="macro-scalar-data" />
-  <data:vector name="macro-vector-data" />
-  <data:scalar name="micro-scalar-data" />
-  <data:vector name="micro-vector-data" />
+  <data:scalar name="micro-data-1" />
+  <data:vector name="micro-data-2" />
+  <data:scalar name="macro-data-1" />
   <data:scalar name="active_state" />
   <data:scalar name="active_steps" />
   <data:scalar name="adaptivity_cpu_time" />
   <data:scalar name="solve_cpu_time" />
 
   <mesh name="macro-cube-mesh" dimensions="3">
-    <use-data name="macro-scalar-data" />
-    <use-data name="macro-vector-data" />
-    <use-data name="micro-scalar-data" />
-    <use-data name="micro-vector-data" />
+    <use-data name="micro-data-1" />
+    <use-data name="micro-data-2" />
+    <use-data name="macro-data-1" />
     <use-data name="active_state" />
     <use-data name="active_steps" />
     <use-data name="adaptivity_cpu_time" />
@@ -26,18 +24,16 @@
 
   <participant name="macro-cube">
     <provide-mesh name="macro-cube-mesh" />
-    <read-data name="micro-scalar-data" mesh="macro-cube-mesh" />
-    <read-data name="micro-vector-data" mesh="macro-cube-mesh" />
-    <write-data name="macro-scalar-data" mesh="macro-cube-mesh" />
-    <write-data name="macro-vector-data" mesh="macro-cube-mesh" />
+    <read-data name="micro-data-1" mesh="macro-cube-mesh" />
+    <read-data name="micro-data-2" mesh="macro-cube-mesh" />
+    <write-data name="macro-data-1" mesh="macro-cube-mesh" />
   </participant>
 
   <participant name="Micro-Manager">
     <receive-mesh name="macro-cube-mesh" from="macro-cube" direct-access="true" safety-factor="0" />
-    <read-data name="macro-scalar-data" mesh="macro-cube-mesh" />
-    <read-data name="macro-vector-data" mesh="macro-cube-mesh" />
-    <write-data name="micro-scalar-data" mesh="macro-cube-mesh" />
-    <write-data name="micro-vector-data" mesh="macro-cube-mesh" />
+    <read-data name="macro-data-1" mesh="macro-cube-mesh" />
+    <write-data name="micro-data-1" mesh="macro-cube-mesh" />
+    <write-data name="micro-data-2" mesh="macro-cube-mesh" />
     <write-data name="active_state" mesh="macro-cube-mesh" />
     <write-data name="active_steps" mesh="macro-cube-mesh" />
     <write-data name="adaptivity_cpu_time" mesh="macro-cube-mesh" />
@@ -51,25 +47,8 @@
     <participants first="Micro-Manager" second="macro-cube" />
     <max-time value="10" />
     <time-window-size value="1" />
-    <exchange
-      data="micro-scalar-data"
-      mesh="macro-cube-mesh"
-      from="Micro-Manager"
-      to="macro-cube" />
-    <exchange
-      data="micro-vector-data"
-      mesh="macro-cube-mesh"
-      from="Micro-Manager"
-      to="macro-cube" />
-    <exchange
-      data="macro-scalar-data"
-      mesh="macro-cube-mesh"
-      from="macro-cube"
-      to="Micro-Manager" />
-    <exchange
-      data="macro-vector-data"
-      mesh="macro-cube-mesh"
-      from="macro-cube"
-      to="Micro-Manager" />
+    <exchange data="micro-data-1" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube" />
+    <exchange data="micro-data-2" mesh="macro-cube-mesh" from="Micro-Manager" to="macro-cube" />
+    <exchange data="macro-data-1" mesh="macro-cube-mesh" from="macro-cube" to="Micro-Manager" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/tests/integration/test_unit_cube/precice-config.xml
+++ b/tests/integration/test_unit_cube/precice-config.xml
@@ -8,18 +8,20 @@
   <data:vector name="macro-vector-data" />
   <data:scalar name="micro-scalar-data" />
   <data:vector name="micro-vector-data" />
-  <data:scalar name="micro_sim_time" />
   <data:scalar name="active_state" />
   <data:scalar name="active_steps" />
+  <data:scalar name="adaptivity_cpu_time" />
+  <data:scalar name="solve_cpu_time" />
 
   <mesh name="macro-cube-mesh" dimensions="3">
     <use-data name="macro-scalar-data" />
     <use-data name="macro-vector-data" />
     <use-data name="micro-scalar-data" />
     <use-data name="micro-vector-data" />
-    <use-data name="micro_sim_time" />
     <use-data name="active_state" />
     <use-data name="active_steps" />
+    <use-data name="adaptivity_cpu_time" />
+    <use-data name="solve_cpu_time" />
   </mesh>
 
   <participant name="macro-cube">
@@ -36,9 +38,10 @@
     <read-data name="macro-vector-data" mesh="macro-cube-mesh" />
     <write-data name="micro-scalar-data" mesh="macro-cube-mesh" />
     <write-data name="micro-vector-data" mesh="macro-cube-mesh" />
-    <write-data name="micro_sim_time" mesh="macro-cube-mesh" />
     <write-data name="active_state" mesh="macro-cube-mesh" />
     <write-data name="active_steps" mesh="macro-cube-mesh" />
+    <write-data name="adaptivity_cpu_time" mesh="macro-cube-mesh" />
+    <write-data name="solve_cpu_time" mesh="macro-cube-mesh" />
     <export:vtu directory="output" />
   </participant>
 

--- a/tests/integration/test_unit_cube/unit_cube.py
+++ b/tests/integration/test_unit_cube/unit_cube.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 #
 
+import argparse
 import numpy as np
 import precice
 
@@ -9,19 +10,20 @@ def main():
     """
     Dummy macro simulation which is coupled to a set of micro simulations via preCICE and the Micro Manager
     """
-    n = n_checkpoint = 0
-    t = t_checkpoint = 0
 
-    t_end = 10
+    parser = argparse.ArgumentParser(description="Macro simulation")
+    parser.add_argument("np_axis", type=int, help="Number of points in each axis")
+    args = parser.parse_args()
+
+    t = 0
 
     # preCICE setup
     participant = precice.Participant("macro-cube", "precice-config.xml", 0, 1)
     mesh_name = "macro-cube-mesh"
-    read_data_names = {"micro-scalar-data": 0, "micro-vector-data": 1}
-    write_data_names = {"macro-scalar-data": 0, "macro-vector-data": 1}
+    read_data_names = {"micro-data-1": 0, "micro-data-2": 1}
 
     # Coupling mesh - unit cube with 5 points in each direction
-    np_axis = 5
+    np_axis = args.np_axis
     x_coords, y_coords, z_coords = np.meshgrid(
         np.linspace(0, 1, np_axis),
         np.linspace(0, 1, np_axis),
@@ -43,29 +45,6 @@ def main():
     # Define points on entire domain as coupling mesh
     vertex_ids = participant.set_mesh_vertices(mesh_name, coords)
 
-    write_data = []
-    write_data.append(np.zeros(nv))
-    write_data.append(np.zeros((nv, participant.get_mesh_dimensions(mesh_name))))
-
-    # Define initial data to write to preCICE
-    scalar_value = 1.0
-    vector_value = [2.0, 3.0, 4.0]
-    for z in range(np_axis):
-        for y in range(np_axis):
-            for x in range(np_axis):
-                n = x + y * np_axis + z * np_axis * np_axis
-                write_data[0][n] = scalar_value
-                write_data[1][n, 0] = vector_value[0]
-                write_data[1][n, 1] = vector_value[1]
-                write_data[1][n, 2] = vector_value[2]
-        scalar_value += 1
-        vector_value = [x + 1 for x in vector_value]
-
-    # Write initial data to preCICE
-    if participant.requires_initial_data():
-        for count, data_name in enumerate(write_data_names.keys()):
-            participant.write_data(mesh_name, data_name, vertex_ids, write_data[count])
-
     participant.initialize()
 
     read_data = [None, None]
@@ -73,50 +52,18 @@ def main():
 
     # time loop
     while participant.is_coupling_ongoing():
-        # write checkpoint
-        if participant.requires_writing_checkpoint():
-            print("Saving macro state")
-            t_checkpoint = t
-            n_checkpoint = n
-
         # Read data from preCICE
         for count, data_name in enumerate(read_data_names.keys()):
             read_data[count] = participant.read_data(
                 mesh_name, data_name, vertex_ids, 1.0
             )
 
-        # Set the read data as the write data with an increment
-        write_data[0] = read_data[0] + 1
-        write_data[1] = read_data[1] + 1
-
-        # Define new data to write to preCICE midway through the simulation
-        if t == t_end / 2:
-            scalar_value = 1.0
-            vector_value = [2.0, 3.0, 4.0]
-            for z in range(np_axis):
-                for y in range(np_axis):
-                    for x in range(np_axis):
-                        n = x + y * np_axis + z * np_axis * np_axis
-                        write_data[0][n] = scalar_value
-                        write_data[1][n, 0] = vector_value[0]
-                        write_data[1][n, 1] = vector_value[1]
-                        write_data[1][n, 2] = vector_value[2]
-
-        # Write data to preCICE
-        for count, data_name in enumerate(write_data_names.keys()):
-            participant.write_data(mesh_name, data_name, vertex_ids, write_data[count])
+        participant.write_data(mesh_name, "macro-data-1", vertex_ids, np.ones(nv))
 
         participant.advance(dt)
         dt = participant.get_max_time_step_size()
 
-        # advance variables
-        n += 1
         t += dt
-
-        if participant.requires_reading_checkpoint():
-            print("Reverting to old macro state")
-            t = t_checkpoint
-            n = n_checkpoint
 
     participant.finalize()
 

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "test_micro_manager",
     "coupling_params": {
-        "config_file_name": "dummy-config.xml",
+        "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 0.1,

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -1,7 +1,7 @@
 {
     "micro_file_name": "test_micro_simulation_crash_handling",
     "coupling_params": {
-        "config_file_name": "dummy-config.xml",
+        "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
         "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
         "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -3,8 +3,8 @@
     "coupling_params": {
         "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "dummy-macro-mesh",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0,

--- a/tests/unit/snapshot-config.json
+++ b/tests/unit/snapshot-config.json
@@ -2,8 +2,8 @@
     "micro_file_name": "test_snapshot_computation",
     "coupling_params": {
         "parameter_file_name": "test_parameter.hdf5",
-        "read_data_names": {"macro-scalar-data": "scalar", "macro-vector-data": "vector"},
-        "write_data_names": {"micro-scalar-data": "scalar", "micro-vector-data": "vector"}
+        "read_data_names": ["macro-scalar-data", "macro-vector-data"],
+        "write_data_names": ["micro-scalar-data", "micro-vector-data"]
     },
     "simulation_params": {
         "micro_dt": 1.0

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -30,6 +30,8 @@ class TestGlobalAdaptivity(TestCase):
 
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
+        configurator.get_output_dir = MagicMock(return_value="output_dir")
+
         adaptivity_controller = GlobalAdaptivityCalculator(
             configurator, 5, global_ids, rank=self._rank, comm=self._comm
         )
@@ -108,6 +110,7 @@ class TestGlobalAdaptivity(TestCase):
         configurator.get_adaptivity_refining_const = MagicMock(return_value=0.05)
         configurator.get_adaptivity_coarsening_const = MagicMock(return_value=0.2)
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L2rel")
+        configurator.get_output_dir = MagicMock(return_value="output_dir")
 
         adaptivity_controller = GlobalAdaptivityCalculator(
             configurator, 5, global_ids, rank=self._rank, comm=self._comm
@@ -175,6 +178,8 @@ class TestGlobalAdaptivity(TestCase):
 
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
+        configurator.get_output_dir = MagicMock(return_value="output_dir")
+
         adaptivity_controller = GlobalAdaptivityCalculator(
             configurator, 5, global_ids, rank=self._rank, comm=self._comm
         )

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -93,9 +93,13 @@ class TestGlobalAdaptivity(TestCase):
             global_ids = [3, 4]
             data_for_adaptivity = {"data1": [1.0, 1.0], "data2": [13.0, 13.0]}
 
-        similarity_dists = np.zeros((5, 5))
-        is_sim_active = np.array([True, True, True, True, True])
-        sim_is_associated_to = [-2, -2, -2, -2, -2]
+        adaptivity_data = []
+        adaptivity_data.append(np.zeros((5, 5)))  # similarity_dists
+        adaptivity_data.append(
+            np.array([True, True, True, True, True])
+        )  # is_sim_active
+        adaptivity_data.append([-2, -2, -2, -2, -2])  # sim_is_associated_to
+
         expected_is_sim_active = np.array([False, False, False, False, True])
         expected_sim_is_associated_to = [4, 4, 4, 4, -2]
 
@@ -132,22 +136,16 @@ class TestGlobalAdaptivity(TestCase):
         for i in global_ids:
             dummy_micro_sims.append(MicroSimulation(i))
 
-        (
-            _,
-            is_sim_active,
-            sim_is_associated_to,
-        ) = adaptivity_controller.compute_adaptivity(
+        adaptivity_data = adaptivity_controller.compute_adaptivity(
             0.1,
             dummy_micro_sims,
-            similarity_dists,
-            is_sim_active,
-            sim_is_associated_to,
+            adaptivity_data,
             data_for_adaptivity,
         )
 
-        self.assertTrue(np.array_equal(expected_is_sim_active, is_sim_active))
+        self.assertTrue(np.array_equal(expected_is_sim_active, adaptivity_data[1]))
         self.assertTrue(
-            np.array_equal(expected_sim_is_associated_to, sim_is_associated_to)
+            np.array_equal(expected_sim_is_associated_to, adaptivity_data[2])
         )
 
     def test_communicate_micro_output(self):
@@ -167,8 +165,11 @@ class TestGlobalAdaptivity(TestCase):
             sim_output = [output_1, None]
             expected_sim_output = [output_1, output_0]
 
-        is_sim_active = np.array([False, False, True, True, False])
-        sim_is_associated_to = [3, 3, -2, -2, 2]
+        adaptivity_data = []
+        adaptivity_data.append(
+            np.array([False, False, True, True, False])
+        )  # is_sim_active
+        adaptivity_data.append([3, 3, -2, -2, 2])  # sim_is_associated_to
 
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
@@ -176,8 +177,6 @@ class TestGlobalAdaptivity(TestCase):
             configurator, MagicMock(), 5, global_ids, rank=self._rank, comm=self._comm
         )
 
-        adaptivity_controller.communicate_micro_output(
-            is_sim_active, sim_is_associated_to, sim_output
-        )
+        adaptivity_controller._communicate_micro_output(adaptivity_data, sim_output)
 
         self.assertTrue(np.array_equal(expected_sim_output, sim_output))

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -31,7 +31,7 @@ class TestGlobalAdaptivity(TestCase):
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
         adaptivity_controller = GlobalAdaptivityCalculator(
-            configurator, MagicMock(), 5, global_ids, rank=self._rank, comm=self._comm
+            configurator, 5, global_ids, rank=self._rank, comm=self._comm
         )
 
         # Force the activation of sim #0 and #4
@@ -109,7 +109,7 @@ class TestGlobalAdaptivity(TestCase):
         configurator.get_adaptivity_coarsening_const = MagicMock(return_value=0.2)
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L2rel")
         adaptivity_controller = GlobalAdaptivityCalculator(
-            configurator, MagicMock(), 5, global_ids, rank=self._rank, comm=self._comm
+            configurator, 5, global_ids, rank=self._rank, comm=self._comm
         )
 
         adaptivity_controller._adaptivity_data_names = {
@@ -174,7 +174,7 @@ class TestGlobalAdaptivity(TestCase):
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
         adaptivity_controller = GlobalAdaptivityCalculator(
-            configurator, MagicMock(), 5, global_ids, rank=self._rank, comm=self._comm
+            configurator, 5, global_ids, rank=self._rank, comm=self._comm
         )
 
         adaptivity_controller._communicate_micro_output(adaptivity_data, sim_output)

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -68,7 +68,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator, logger=MagicMock())
+        adaptivity_controller = AdaptivityCalculator(configurator)
         adaptivity_controller._hist_param = 0.5
         adaptivity_controller._adaptivity_data_names = [
             "micro-scalar-data",
@@ -102,7 +102,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator, logger=MagicMock())
+        adaptivity_controller = AdaptivityCalculator(configurator)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [
@@ -127,8 +127,7 @@ class TestLocalAdaptivity(TestCase):
         """
         Test functionality for calculating similarity criteria between pairs of simulations using different norms in class AdaptivityCalculator.
         """
-        logger = MagicMock()
-        calc = AdaptivityCalculator(Config(logger, "micro-manager-config.json"), logger)
+        calc = AdaptivityCalculator(Config("micro-manager-config.json"))
 
         fake_data = np.array([[1], [2], [3]])
         self.assertTrue(
@@ -209,7 +208,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator, logger=MagicMock())
+        adaptivity_controller = AdaptivityCalculator(configurator)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [
@@ -236,9 +235,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = LocalAdaptivityCalculator(
-            configurator, logger=MagicMock()
-        )
+        adaptivity_controller = LocalAdaptivityCalculator(configurator, MagicMock())
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -68,6 +68,8 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
+        configurator.get_output_dir = MagicMock(return_value="output_dir")
+
         adaptivity_controller = AdaptivityCalculator(configurator, 0)
         adaptivity_controller._hist_param = 0.5
         adaptivity_controller._adaptivity_data_names = [
@@ -102,6 +104,8 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
+        configurator.get_output_dir = MagicMock(return_value="output_dir")
+
         adaptivity_controller = AdaptivityCalculator(configurator, 0)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
@@ -208,6 +212,8 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
+        configurator.get_output_dir = MagicMock(return_value="output_dir")
+
         adaptivity_controller = AdaptivityCalculator(configurator, 0)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
@@ -235,6 +241,8 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
+        configurator.get_output_dir = MagicMock(return_value="output_dir")
+
         adaptivity_controller = LocalAdaptivityCalculator(
             configurator, 0, MagicMock(), 5
         )

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -68,7 +68,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator)
+        adaptivity_controller = AdaptivityCalculator(configurator, 0)
         adaptivity_controller._hist_param = 0.5
         adaptivity_controller._adaptivity_data_names = [
             "micro-scalar-data",
@@ -102,7 +102,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator)
+        adaptivity_controller = AdaptivityCalculator(configurator, 0)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [
@@ -127,7 +127,7 @@ class TestLocalAdaptivity(TestCase):
         """
         Test functionality for calculating similarity criteria between pairs of simulations using different norms in class AdaptivityCalculator.
         """
-        calc = AdaptivityCalculator(Config("micro-manager-config.json"))
+        calc = AdaptivityCalculator(Config("micro-manager-config.json"), 0)
 
         fake_data = np.array([[1], [2], [3]])
         self.assertTrue(
@@ -208,7 +208,7 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = AdaptivityCalculator(configurator)
+        adaptivity_controller = AdaptivityCalculator(configurator, 0)
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [
@@ -235,7 +235,9 @@ class TestLocalAdaptivity(TestCase):
         """
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L1")
-        adaptivity_controller = LocalAdaptivityCalculator(configurator, MagicMock())
+        adaptivity_controller = LocalAdaptivityCalculator(
+            configurator, 0, MagicMock(), 5
+        )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
         adaptivity_controller._adaptivity_data_names = [

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -1,8 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock
-
 import numpy as np
-
 from micro_manager.domain_decomposition import DomainDecomposer
 
 
@@ -17,6 +14,43 @@ class TestDomainDecomposition(TestCase):
             8,
         ]  # Cuboid which is not symmetric around origin
 
+        self._macro_bounds_2d = [
+            0,
+            1,
+            0,
+            2,
+        ]
+
+    def test_rank2_out_of_4_2d(self):
+        """
+        Check bounds for rank 2 in a setting of axis-wise ranks: [2, 2]
+        """
+        rank = 2
+        size = 4
+        ranks_per_axis = [2, 2]
+        domain_decomposer = DomainDecomposer(rank, size)
+        domain_decomposer._dims = 2
+        mesh_bounds = domain_decomposer.decompose_macro_domain(
+            self._macro_bounds_2d, ranks_per_axis
+        )
+
+        self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, 1, 2]))
+
+    def test_rank1_out_of_4_3d(self):
+        """
+        Check bounds for rank 1 in a setting of axis-wise ranks: [2, 2, 1]
+        """
+        rank = 1
+        size = 4
+        ranks_per_axis = [2, 2, 1]
+        domain_decomposer = DomainDecomposer(rank, size)
+        domain_decomposer._dims = 3
+        mesh_bounds = domain_decomposer.decompose_macro_domain(
+            self._macro_bounds_3d, ranks_per_axis
+        )
+
+        self.assertTrue(np.allclose(mesh_bounds, [0.0, 1, -2, 0.0, -2, 8]))
+
     def test_rank5_outof_10_3d(self):
         """
         Test domain decomposition for rank 5 in a setting of axis-wise ranks: [1, 2, 5]
@@ -24,7 +58,7 @@ class TestDomainDecomposition(TestCase):
         rank = 5
         size = 10
         ranks_per_axis = [1, 2, 5]
-        domain_decomposer = DomainDecomposer(3, rank, size)
+        domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -39,7 +73,7 @@ class TestDomainDecomposition(TestCase):
         rank = 10
         size = 32
         ranks_per_axis = [4, 1, 8]
-        domain_decomposer = DomainDecomposer(3, rank, size)
+        domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -54,7 +88,7 @@ class TestDomainDecomposition(TestCase):
         rank = 7
         size = 16
         ranks_per_axis = [8, 2, 1]
-        domain_decomposer = DomainDecomposer(3, rank, size)
+        domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -8,7 +8,6 @@ from micro_manager.domain_decomposition import DomainDecomposer
 
 class TestDomainDecomposition(TestCase):
     def setUp(self) -> None:
-        self._logger = MagicMock()
         self._macro_bounds_3d = [
             -1,
             1,
@@ -25,7 +24,7 @@ class TestDomainDecomposition(TestCase):
         rank = 5
         size = 10
         ranks_per_axis = [1, 2, 5]
-        domain_decomposer = DomainDecomposer(self._logger, 3, rank, size)
+        domain_decomposer = DomainDecomposer(3, rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -40,7 +39,7 @@ class TestDomainDecomposition(TestCase):
         rank = 10
         size = 32
         ranks_per_axis = [4, 1, 8]
-        domain_decomposer = DomainDecomposer(self._logger, 3, rank, size)
+        domain_decomposer = DomainDecomposer(3, rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis
@@ -55,7 +54,7 @@ class TestDomainDecomposition(TestCase):
         rank = 7
         size = 16
         ranks_per_axis = [8, 2, 1]
-        domain_decomposer = DomainDecomposer(self._logger, 3, rank, size)
+        domain_decomposer = DomainDecomposer(3, rank, size)
         domain_decomposer._dims = 3
         mesh_bounds = domain_decomposer.decompose_macro_domain(
             self._macro_bounds_3d, ranks_per_axis

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -102,9 +102,7 @@ class TestFunctioncalls(TestCase):
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
         manager._micro_sims_active_steps = np.zeros(4, dtype=np.int32)
 
-        micro_sims_output, _ = manager._solve_micro_simulations(
-            self.fake_read_data, 1.0
-        )
+        micro_sims_output = manager._solve_micro_simulations(self.fake_read_data, 1.0)
 
         for data, fake_data in zip(micro_sims_output, self.fake_write_data):
             self.assertEqual(data["micro-scalar-data"], 2)

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -24,20 +24,17 @@ class MicroSimulation:
 
 class TestFunctioncalls(TestCase):
     def setUp(self):
-        self.fake_read_data_names = {
-            "macro-scalar-data": False,
-            "macro-vector-data": True,
-        }
+        self.fake_read_data_names = ["macro-scalar-data", "macro-vector-data"]
         self.fake_read_data = [
             {"macro-scalar-data": 1, "macro-vector-data": np.array([0, 1, 2])}
         ] * 4
-        self.fake_write_data_names = {
-            "micro-scalar-data": False,
-            "micro-vector-data": True,
-            "solve_cpu_time": False,
-            "active_state": False,
-            "active_steps": False,
-        }
+        self.fake_write_data_names = [
+            "micro-scalar-data",
+            "micro-vector-data",
+            "solve_cpu_time",
+            "active_state",
+            "active_steps",
+        ]
         self.fake_write_data = [
             {
                 "micro-scalar-data": 1,
@@ -56,8 +53,8 @@ class TestFunctioncalls(TestCase):
         manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
 
         self.assertListEqual(manager._macro_bounds, self.macro_bounds)
-        self.assertDictEqual(manager._read_data_names, self.fake_read_data_names)
-        self.assertDictEqual(self.fake_write_data_names, manager._write_data_names)
+        self.assertListEqual(manager._read_data_names, self.fake_read_data_names)
+        self.assertListEqual(self.fake_write_data_names, manager._write_data_names)
         self.assertEqual(manager._micro_n_out, 10)
 
     def test_initialization(self):
@@ -75,8 +72,8 @@ class TestFunctioncalls(TestCase):
         self.assertEqual(
             manager._micro_sims[0].very_important_value, 0
         )  # test inheritance
-        self.assertDictEqual(manager._read_data_names, self.fake_read_data_names)
-        self.assertDictEqual(self.fake_write_data_names, manager._write_data_names)
+        self.assertListEqual(manager._read_data_names, self.fake_read_data_names)
+        self.assertListEqual(self.fake_write_data_names, manager._write_data_names)
 
     def test_read_write_data_from_precice(self):
         """
@@ -130,10 +127,10 @@ class TestFunctioncalls(TestCase):
         self.assertEqual(config._micro_file_name, "test_micro_manager")
         self.assertEqual(config._macro_mesh_name, "dummy-macro-mesh")
         self.assertEqual(config._micro_output_n, 10)
-        self.assertDictEqual(config._read_data_names, self.fake_read_data_names)
-        self.assertDictEqual(self.fake_write_data_names, config._write_data_names)
+        self.assertListEqual(config._read_data_names, self.fake_read_data_names)
+        self.assertListEqual(self.fake_write_data_names, config._write_data_names)
         self.assertEqual(config._adaptivity, True)
-        self.assertDictEqual(config._data_for_adaptivity, self.fake_read_data_names)
+        self.assertListEqual(config._data_for_adaptivity, self.fake_read_data_names)
         self.assertEqual(config._adaptivity_type, "local")
         self.assertEqual(config._adaptivity_history_param, 0.5)
         self.assertEqual(config._adaptivity_coarsening_constant, 0.3)

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -105,7 +105,9 @@ class TestFunctioncalls(TestCase):
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
         manager._micro_sims_active_steps = np.zeros(4, dtype=np.int32)
 
-        micro_sims_output = manager._solve_micro_simulations(self.fake_read_data, 1.0)
+        micro_sims_output, _ = manager._solve_micro_simulations(
+            self.fake_read_data, 1.0
+        )
 
         for data, fake_data in zip(micro_sims_output, self.fake_write_data):
             self.assertEqual(data["micro-scalar-data"], 2)

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -34,7 +34,7 @@ class TestFunctioncalls(TestCase):
         self.fake_write_data_names = {
             "micro-scalar-data": False,
             "micro-vector-data": True,
-            "micro_sim_time": False,
+            "solve_cpu_time": False,
             "active_state": False,
             "active_steps": False,
         }
@@ -42,7 +42,7 @@ class TestFunctioncalls(TestCase):
             {
                 "micro-scalar-data": 1,
                 "micro-vector-data": np.array([0, 1, 2]),
-                "micro_sim_time": 0,
+                "solve_cpu_time": 0,
                 "active_state": 0,
                 "active_steps": 0,
             }
@@ -119,9 +119,12 @@ class TestFunctioncalls(TestCase):
         """
         Test if the functions in the Config class work.
         """
-        config = micro_manager.Config(MagicMock(), "micro-manager-config.json")
+        config = micro_manager.Config("micro-manager-config.json")
+        config.set_logger(MagicMock())
         config.read_json_micro_manager()
-        self.assertEqual(config._config_file_name.split("/")[-1], "dummy-config.xml")
+        self.assertEqual(
+            config._precice_config_file_name.split("/")[-1], "dummy-config.xml"
+        )
         self.assertEqual(config._micro_file_name, "test_micro_manager")
         self.assertEqual(config._macro_mesh_name, "dummy-macro-mesh")
         self.assertEqual(config._micro_output_n, 10)

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -52,7 +52,7 @@ class TestSimulationCrashHandling(TestCase):
         )
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
 
-        micro_sims_output, _ = manager._solve_micro_simulations(macro_data, 1.0)
+        micro_sims_output = manager._solve_micro_simulations(macro_data, 1.0)
 
         # Crashed simulation has interpolated value
         data_crashed = micro_sims_output[2]
@@ -106,7 +106,7 @@ class TestSimulationCrashHandling(TestCase):
             [-2, -2, -2, -2, 2]
         )
 
-        micro_sims_output, _ = manager._solve_micro_simulations_with_adaptivity(
+        micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
             macro_data, 1.0
         )
 

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -98,15 +98,16 @@ class TestSimulationCrashHandling(TestCase):
         )
         manager._micro_sims = [MicroSimulation(i) for i in range(5)]
 
-        adaptivity_data = []
-        adaptivity_data.append(np.array([0, 0, 0, 0, 0]))  # similarity_dists
-        adaptivity_data.append(
-            np.array([True, True, True, True, False])
-        )  # is_sim_active
-        adaptivity_data.append(np.array([-2, -2, -2, -2, 2]))  # sim_is_associated_to
+        manager._adaptivity_controller._similarity_dists = np.array([0, 0, 0, 0, 0])
+        manager._adaptivity_controller._is_sim_active = np.array(
+            [True, True, True, True, False]
+        )
+        manager._adaptivity_controller._sim_is_associated_to = np.array(
+            [-2, -2, -2, -2, 2]
+        )
 
         micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
-            macro_data, 1.0, adaptivity_data
+            macro_data, 1.0
         )
 
         # Crashed simulation has interpolated value

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -52,7 +52,7 @@ class TestSimulationCrashHandling(TestCase):
         )
         manager._micro_sims = [MicroSimulation(i) for i in range(4)]
 
-        micro_sims_output = manager._solve_micro_simulations(macro_data, 1.0)
+        micro_sims_output, _ = manager._solve_micro_simulations(macro_data, 1.0)
 
         # Crashed simulation has interpolated value
         data_crashed = micro_sims_output[2]
@@ -106,7 +106,7 @@ class TestSimulationCrashHandling(TestCase):
             [-2, -2, -2, -2, 2]
         )
 
-        micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
+        micro_sims_output, _ = manager._solve_micro_simulations_with_adaptivity(
             macro_data, 1.0
         )
 

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -98,10 +98,15 @@ class TestSimulationCrashHandling(TestCase):
         )
         manager._micro_sims = [MicroSimulation(i) for i in range(5)]
 
-        is_sim_active = np.array([True, True, True, True, False])
-        sim_is_associated_to = np.array([-2, -2, -2, -2, 2])
+        adaptivity_data = []
+        adaptivity_data.append(np.array([0, 0, 0, 0, 0]))  # similarity_dists
+        adaptivity_data.append(
+            np.array([True, True, True, True, False])
+        )  # is_sim_active
+        adaptivity_data.append(np.array([-2, -2, -2, -2, 2]))  # sim_is_associated_to
+
         micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
-            macro_data, is_sim_active, sim_is_associated_to, 1.0
+            macro_data, 1.0, adaptivity_data
         )
 
         # Crashed simulation has interpolated value

--- a/tests/unit/test_snapshot_computation.py
+++ b/tests/unit/test_snapshot_computation.py
@@ -136,7 +136,8 @@ class TestFunctionCalls(TestCase):
         """
         Test if the functions in the SnapshotConfig class work.
         """
-        config = Config(MagicMock(), "snapshot-config.json")
+        config = Config("snapshot-config.json")
+        config.set_logger(MagicMock())
         config.read_json_snapshot()
 
         self.assertEqual(

--- a/tests/unit/test_snapshot_computation.py
+++ b/tests/unit/test_snapshot_computation.py
@@ -22,19 +22,13 @@ class MicroSimulation:
 
 class TestFunctionCalls(TestCase):
     def setUp(self):
-        self.fake_read_data_names = {
-            "macro-scalar-data": False,
-            "macro-vector-data": True,
-        }
+        self.fake_read_data_names = ["macro-scalar-data", "macro-vector-data"]
         self.fake_read_data = {
             "macro-scalar-data": 1,
             "macro-vector-data": np.array([0, 1, 2]),
         }
 
-        self.fake_write_data_names = {
-            "micro-scalar-data": False,
-            "micro-vector-data": True,
-        }
+        self.fake_write_data_names = ["micro-scalar-data", "micro-vector-data"]
         self.fake_write_data = [
             {
                 "micro-scalar-data": 1,
@@ -48,10 +42,10 @@ class TestFunctionCalls(TestCase):
         """
         snapshot_object = MicroManagerSnapshot("snapshot-config.json")
 
-        self.assertDictEqual(
+        self.assertListEqual(
             snapshot_object._read_data_names, self.fake_read_data_names
         )
-        self.assertDictEqual(
+        self.assertListEqual(
             snapshot_object._write_data_names, self.fake_write_data_names
         )
         self.assertEqual(
@@ -72,10 +66,10 @@ class TestFunctionCalls(TestCase):
 
         snapshot_object.initialize()
         self.assertEqual(snapshot_object._global_number_of_sims, 1)
-        self.assertDictEqual(
+        self.assertListEqual(
             snapshot_object._read_data_names, self.fake_read_data_names
         )
-        self.assertDictEqual(
+        self.assertListEqual(
             snapshot_object._write_data_names, self.fake_write_data_names
         )
         self.assertTrue(os.path.isfile(complete_path))
@@ -144,8 +138,8 @@ class TestFunctionCalls(TestCase):
             config._parameter_file_name.split("/")[-1], "test_parameter.hdf5"
         )
         self.assertEqual(config._micro_file_name, "test_snapshot_computation")
-        self.assertDictEqual(config._read_data_names, self.fake_read_data_names)
-        self.assertDictEqual(config._write_data_names, self.fake_write_data_names)
+        self.assertListEqual(config._read_data_names, self.fake_read_data_names)
+        self.assertListEqual(config._write_data_names, self.fake_write_data_names)
         self.assertEqual(config._postprocessing_file_name, "snapshot_post_processing")
         self.assertTrue(config._initialize_once)
 


### PR DESCRIPTION
This release contains

- Add functionality for lazy creation and initialization of micro simulations https://github.com/precice/micro-manager/pull/117
- Improve logging wrapper function names to be more clear https://github.com/precice/micro-manager/pull/153
- Remove adaptivity computation CPU time export functionality https://github.com/precice/micro-manager/pull/152
- Replace `Allgatherv` with `allgather` to avoid running into the error of size buffer https://github.com/precice/micro-manager/pull/151
- Update Actions workflows due to updates in `precice/precice:nightly` https://github.com/precice/micro-manager/pull/150
- Move adaptivity CPU time output from preCICE export to metrics logging https://github.com/precice/micro-manager/pull/149
- Fix bug in the domain decomposition which was returning incorrect bounding box limits for the decomposition of `[2, 2, 1]` and similar https://github.com/precice/micro-manager/pull/146
- Fix bug in calling of the adaptivity computation for explicit coupling scenarios https://github.com/precice/micro-manager/pull/145
- Fix bug in handling of vector data returned by the MicroSimulation `solve()` method, for scenarios with adaptivity https://github.com/precice/micro-manager/pull/143
- Remove the `scalar` and `vector` keyword values from data names in configuration https://github.com/precice/micro-manager/pull/142
- Set default logger to stdout and add output directory setting option for file loggers https://github.com/precice/micro-manager/pull/139
- Remove the `adaptivity_data` data structure and handle all adaptivity data internally https://github.com/precice/micro-manager/pull/137
- Improve logging by wrapping Python logger in a class https://github.com/precice/micro-manager/pull/133
- Refactor large parts of solve and adaptivity to group datasets and simplify handling https://github.com/precice/micro-manager/pull/135
- Add information about adaptivity tuning parameters https://github.com/precice/micro-manager/pull/131
- Put computation of counting active steps inside the adaptivity variant `if` condition https://github.com/precice/micro-manager/pull/130
