### PR TITLE
Fix adaptivity metrics logging and add logging documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fix adaptivity metrics logging and add logging documentation https://github.com/precice/micro-manager/pull/160
 - Checkpoint lazily created simulation only if a checkpoint is necessary https://github.com/precice/micro-manager/pull/161
 
 ## v0.6.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,8 @@ This example configuration file is in [`examples/micro-manager-config.json`](htt
 
 The path to the file containing the Python importable micro simulation class is specified in the `micro_file_name` parameter. If the file is not in the working directory, give the relative path.
 
+Set the output [log](tooling-micro-manager-logging.html) directory using the parameter `output_dir`.
+
 There are three main sections in the configuration file, the `coupling_params`, the `simulation_params` and the optional `diagnostics`.
 
 ## Coupling Parameters

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,55 @@
+---
+title: Logging in the Micro Manager
+permalink: tooling-micro-manager-logging.html
+keywords: tooling, macro-micro, two-scale
+summary: The Micro Manager logs relevant information and adaptivity metrics.
+---
+
+The Micro Manager uses the Python [logging](https://docs.python.org/3/library/logging.html) functionality. The format is:
+
+```bash
+(<rank>) <date and time> <part/functionality of Micro Manager> <log level> <message>
+```
+
+For example:
+
+```bash
+(0) 04/17/2025 02:54:02 PM - micro_manager.micro_manager - INFO - Time window 1 converged.
+```
+
+The information (`INFO` level) message `Time window 1 converged.` from the file `micro_manager/micro_manager.py` is logged by rank `0` at `02:54:02 PM` on `04/17/2025`.
+
+## Logging adaptivity metrics
+
+If the Micro Manager is run with adaptivity, rank-wise and global metrics are output in CSV files. By default, the files are created in the working directory. To have the Micro Manager create the files in a specific folder, provide the folder path via the configuration parameter `output_dir`.
+
+The following global metrics are logged to the file `adaptivity-metrics-global.csv`:
+
+- Time window at which the metrics are logged
+- Average number of active simulations
+- Average number of inactive simulations
+- Maximum number of active simulations
+- Maximum number of inactive simulations
+
+The CSV file heading is `n,avg active,avg inactive,max active,max inactive`.
+
+The following local metrics are logged to the file `adaptivity-metrics-`rank`.csv`:
+
+for local adaptivity:
+
+- Time window at which the metrics are logged
+- Number of active simulations
+- Number of inactive simulations
+
+The CSV file heading is `n,n active,n inactive`.
+
+for global adaptivity:
+
+- Time window at which the metrics are logged
+- Number of active simulations
+- Number of inactive simulations
+- Ranks to which inactive simulations on this rank are associated
+
+The CSV file heading is `n,n active,n inactive,assoc ranks`.
+
+To set the output interval of adaptivity metrics, set `output_n` in the [adaptivity configuration](tooling-micro-manager-configuration.html/#adaptivity).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -11,7 +11,7 @@ The Micro Manager uses the Python [logging](https://docs.python.org/3/library/lo
 (<rank>) <date and time> <part/functionality of Micro Manager> <log level> <message>
 ```
 
-For example:
+For example
 
 ```bash
 (0) 04/17/2025 02:54:02 PM - micro_manager.micro_manager - INFO - Time window 1 converged.
@@ -21,7 +21,7 @@ The information (`INFO` level) message `Time window 1 converged.` from the file 
 
 ## Logging adaptivity metrics
 
-If the Micro Manager is run with adaptivity, rank-wise and global metrics are output in CSV files. By default, the files are created in the working directory. To have the Micro Manager create the files in a specific folder, provide the folder path via the configuration parameter `output_dir`.
+If the Micro Manager is run with adaptivity, rank-wise and global metrics are written to CSV files. By default, the files are created in the working directory. To create the files in a specific folder, provide the folder path via the configuration parameter `output_dir`. More information is in the [configuration section](tooling-micro-manager-configuration.html).
 
 The following global metrics are logged to the file `adaptivity-metrics-global.csv`:
 

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -57,7 +57,7 @@ class AdaptivityCalculator:
             )
 
             self._global_metrics_logger.log_info(
-                "t,avg active,avg inactive,max active,max inactive"
+                "n,avg active,avg inactive,max active,max inactive"
             )
 
         self._metrics_logger = Logger(

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -44,16 +44,27 @@ class AdaptivityCalculator:
 
         if output_dir is not None:
             subprocess.run(["mkdir", "-p", output_dir])  # Create output directory
-            self._metrics_logger = Logger(
-                __name__, output_dir + "/adaptivity-metrics.csv", rank, csv_logger=True
-            )
+            metrics_output_dir = output_dir + "/adaptivity-metrics"
         else:
-            self._metrics_logger = Logger(
-                __name__, "adaptivity-metrics.csv", rank=rank, csv_logger=True
+            metrics_output_dir = "adaptivity-metrics"
+
+        if self._rank == 0:
+            self._global_metrics_logger = Logger(
+                "global-metrics-logger",
+                metrics_output_dir + "-global.csv",
+                rank,
+                csv_logger=True,
             )
 
-        self._metrics_logger.log_info_rank_zero(
-            "Time Window,Avg Active Sims,Avg Inactive Sims,Max Active,Max Inactive"
+            self._global_metrics_logger.log_info(
+                "t,avg active,avg inactive,max active,max inactive"
+            )
+
+        self._metrics_logger = Logger(
+            "metrics-logger",
+            metrics_output_dir + "-" + str(rank) + ".csv",
+            rank,
+            csv_logger=True,
         )
 
     def _get_similarity_dists(

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -82,6 +82,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         self._updating_inactive_sims = self._get_update_inactive_sims_variant()
 
+        self._metrics_logger.log_info("n,n active,n inactive,assoc ranks")
+
     def compute_adaptivity(
         self,
         dt: float,
@@ -182,7 +184,20 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
     def log_metrics(self, n: int) -> None:
         """
-        Log metrics.
+        Log the following metrics:
+
+        Metrics on this rank:
+        - Time window at which the metrics are logged
+        - Number of active simulations
+        - Number of inactive simulations
+        - Ranks to which inactive simulations on this rank are associated
+
+        Global metrics:
+        - Time window at which the metrics are logged
+        - Average number of active simulations
+        - Average number of inactive simulations
+        - Maximum number of active simulations
+        - Maximum number of inactive simulations
 
         Parameters
         ----------

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -48,7 +48,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         self._updating_inactive_sims = self._get_update_inactive_sims_variant()
 
-        self._metrics_logger.log_info("t,n active,n inactive")
+        self._metrics_logger.log_info("n,n active,n inactive")
 
     def compute_adaptivity(
         self,
@@ -146,7 +146,18 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
     def log_metrics(self, n: int) -> None:
         """
-        Log metrics.
+        Log the following metrics:
+
+        Metrics on this rank:
+        - Time window at which the metrics are logged
+        - Number of active simulations
+        - Number of inactive simulations
+
+        Global metrics:
+        - Average number of active simulations per rank
+        - Average number of inactive simulations per rank
+        - Maximum number of active simulations on a rank
+        - Maximum number of inactive simulations on a rank
 
         Parameters
         ----------

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -48,6 +48,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         self._updating_inactive_sims = self._get_update_inactive_sims_variant()
 
+        self._metrics_logger.log_info("t,n active,n inactive")
+
     def compute_adaptivity(
         self,
         dt,
@@ -144,29 +146,44 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
     def log_metrics(self, n: int) -> None:
         """
-        Log metrics for local adaptivity.
+        Log metrics.
 
         Parameters
         ----------
         n : int
             Current time step
         """
-        # MPI Gather is necessary as local adaptivity only stores local data
-        local_active_sims = np.count_nonzero(self._is_sim_active)
-        global_active_sims = self._comm.gather(local_active_sims)
+        active_sims_on_this_rank = 0
+        inactive_sims_on_this_rank = 0
+        for local_id in range(self._is_sim_active.size):
+            if self._is_sim_active[local_id]:
+                active_sims_on_this_rank += 1
+            else:
+                inactive_sims_on_this_rank += 1
 
-        local_inactive_sims = np.count_nonzero(self._is_sim_active == False)
-        global_inactive_sims = self._comm.gather(local_inactive_sims)
-
-        self._metrics_logger.log_info_rank_zero(
-            "{},{},{},{},{}".format(
+        self._metrics_logger.log_info(
+            "{},{},{}".format(
                 n,
-                np.mean(global_active_sims),
-                np.mean(global_inactive_sims),
-                np.max(global_active_sims),
-                np.max(global_inactive_sims),
+                active_sims_on_this_rank,
+                inactive_sims_on_this_rank,
             )
         )
+
+        active_sims_rankwise = self._comm.gather(active_sims_on_this_rank, root=0)
+        inactive_sims_rankwise = self._comm.gather(inactive_sims_on_this_rank, root=0)
+
+        if self._rank == 0:
+            size = self._comm.Get_size()
+
+            self._global_metrics_logger.log_info_rank_zero(
+                "{},{},{},{},{}".format(
+                    n,
+                    sum(active_sims_rankwise) / size,
+                    sum(inactive_sims_rankwise) / size,
+                    max(active_sims_rankwise),
+                    max(inactive_sims_rankwise),
+                )
+            )
 
     def write_checkpoint(self) -> None:
         """

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -208,7 +208,10 @@ class MicroManagerCoupling(MicroManager):
                     for active_id in active_sim_ids:
                         self._micro_sims_active_steps[active_id] += 1
 
-                        if sim_states_cp[active_id] == None:
+                        if (
+                            sim_states_cp[active_id] == None
+                            and self._participant.requires_writing_checkpoint()
+                        ):
                             sim_states_cp[active_id] = self._micro_sims[
                                 active_id
                             ].get_state()
@@ -270,11 +273,7 @@ class MicroManagerCoupling(MicroManager):
                             if sim:
                                 sim.output()
 
-                if (
-                    self._is_adaptivity_on
-                    and n % self._adaptivity_output_n == 0
-                    and self._rank == 0
-                ):
+                if self._is_adaptivity_on and n % self._adaptivity_output_n == 0:
                     self._adaptivity_controller.log_metrics(n)
 
                 self._logger.log_info_rank_zero("Time window {} converged.".format(n))


### PR DESCRIPTION
The function `log_metrics` causes a deadlock at the moment, due to an incorrect implementation of a MPI Gather command. This PR fixes and also improves the metric logging. Bug reported by @steffenger

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
