### PR TITLE
Checkpoint lazily created simulation only if a checkpoint is necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Micro Manager changelog
 
+## latest
+
+- Checkpoint lazily created simulation only if a checkpoint is necessary https://github.com/precice/micro-manager/pull/161
+
 ## v0.6.0
 
 - Add functionality for lazy creation and initialization of micro simulations https://github.com/precice/micro-manager/pull/117

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -208,7 +208,10 @@ class MicroManagerCoupling(MicroManager):
                     for active_id in active_sim_ids:
                         self._micro_sims_active_steps[active_id] += 1
 
-                        if sim_states_cp[active_id] == None:
+                        if (
+                            sim_states_cp[active_id] == None
+                            and self._participant.requires_writing_checkpoint()
+                        ):
                             sim_states_cp[active_id] = self._micro_sims[
                                 active_id
                             ].get_state()


### PR DESCRIPTION
If a simulation is created lazily, that is after the adaptivity computation is done, it needs to be checkpointed, only if preCICE requires writing a checkpoint. Right now a checkpoint is always stored, which is incorrect.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
