### PR TITLE
Update the documentation on the website only when there is a release

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -2,7 +2,7 @@ name: Update website
 on:
   push:
     branches:
-      - 'develop'
+      - 'main'
     paths:
       - 'docs/**'
 jobs:


### PR DESCRIPTION
@uekerman @MakisH does this make sense? Right now, for every merge to develop, the website gets updated. In my opinion this is too frequent, and also misleading because oftentimes users work with the latest release and not with the latest develop state.

Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
