### PR TITLE
Handle adaptivity case when deactivation and activation happens in the same time window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Handle adaptivity case when deactivation and activation happens in the same time window https://github.com/precice/micro-manager/pull/165
 - Add command line input argument to set log file https://github.com/precice/micro-manager/pull/163
 - Fix adaptivity metrics logging and add logging documentation https://github.com/precice/micro-manager/pull/160
 - Checkpoint lazily created simulation only if a checkpoint is necessary https://github.com/precice/micro-manager/pull/161

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -36,6 +36,8 @@ class AdaptivityCalculator:
 
         self._rank = rank
 
+        self._just_deactivated: list[int] = []
+
         self._similarity_measure = self._get_similarity_measure(
             configurator.get_adaptivity_similarity_measure()
         )
@@ -142,6 +144,7 @@ class AdaptivityCalculator:
             if _is_sim_active[i]:  # if sim is active
                 if self._check_for_deactivation(i, similarity_dists, _is_sim_active):
                     _is_sim_active[i] = False
+                    self._just_deactivated.append(i)
 
         return _is_sim_active
 

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -364,8 +364,10 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                     _sim_is_associated_to_updated[
                         i
                     ] = -2  # Active sim cannot have an associated sim
-                    if self._is_sim_on_this_rank[i]:
+                    if self._is_sim_on_this_rank[i] and i not in self._just_deactivated:
                         to_be_activated_ids.append(i)
+
+        self._just_deactivated.clear()  # Clear the list of sims deactivated in this step
 
         local_sim_is_associated_to = _sim_is_associated_to[
             self._global_ids[0] : self._global_ids[-1] + 1
@@ -463,8 +465,10 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                     _sim_is_associated_to_updated[
                         i
                     ] = -2  # Active sim cannot have an associated sim
-                    if self._is_sim_on_this_rank[i]:
+                    if self._is_sim_on_this_rank[i] and i not in self._just_deactivated:
                         to_be_activated_ids.append(i)
+
+        self._just_deactivated.clear()  # Clear the list of sims deactivated in this step
 
         local_sim_is_associated_to = _sim_is_associated_to[
             self._global_ids[0] : self._global_ids[-1] + 1

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -252,14 +252,17 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         for i in range(_is_sim_active.size):
             if not _is_sim_active[i]:  # if id is inactive
                 if self._check_for_activation(i, similarity_dists, _is_sim_active):
-                    associated_active_local_id = _sim_is_associated_to[i]
-                    micro_sims[i].set_state(
-                        micro_sims[associated_active_local_id].get_state()
-                    )
                     _is_sim_active[i] = True
+                    if i not in self._just_deactivated:
+                        associated_active_local_id = _sim_is_associated_to[i]
+                        micro_sims[i].set_state(
+                            micro_sims[associated_active_local_id].get_state()
+                        )
                     _sim_is_associated_to[
                         i
                     ] = -2  # Active sim cannot have an associated sim
+
+        self._just_deactivated.clear()  # Clear the list of sims deactivated in this step
 
         return _is_sim_active, _sim_is_associated_to
 
@@ -306,24 +309,27 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         for i in range(_is_sim_active.size):
             if not _is_sim_active[i]:  # if id is inactive
                 if self._check_for_activation(i, similarity_dists, _is_sim_active):
-                    associated_active_local_id = _sim_is_associated_to[i]
-                    if (
-                        micro_sims[i] == 0
-                    ):  # 0 indicates that the micro simulation object has not been created yet
-                        micro_problem = getattr(
-                            importlib.import_module(
-                                self._micro_file_name, "MicroSimulation"
-                            ),
-                            "MicroSimulation",
-                        )
-                        micro_sims[i] = create_simulation_class(micro_problem)(i)
-                    micro_sims[i].set_state(
-                        micro_sims[associated_active_local_id].get_state()
-                    )
                     _is_sim_active[i] = True
+                    if i not in self._just_deactivated:
+                        associated_active_local_id = _sim_is_associated_to[i]
+                        if (
+                            micro_sims[i] == 0
+                        ):  # 0 indicates that the micro simulation object has not been created yet
+                            micro_problem = getattr(
+                                importlib.import_module(
+                                    self._micro_file_name, "MicroSimulation"
+                                ),
+                                "MicroSimulation",
+                            )
+                            micro_sims[i] = create_simulation_class(micro_problem)(i)
+                        micro_sims[i].set_state(
+                            micro_sims[associated_active_local_id].get_state()
+                        )
                     _sim_is_associated_to[
                         i
                     ] = -2  # Active sim cannot have an associated sim
+
+        self._just_deactivated.clear()  # Clear the list of sims deactivated in this step
 
         return _is_sim_active, _sim_is_associated_to
 


### PR DESCRIPTION
If a simulation is deactivated and then tagged for activation in the same time window, it does not have an associated active simulation to get the state from. The association is also not necessary, because the current state can simply be carried forward. This PR handles this case in the global and local adaptivity.

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
