### PR TITLE
Trigger adaptivity when all the adaptivity data is the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Trigger adaptivity when all the adaptivity data is the same https://github.com/precice/micro-manager/pull/170
 - Add configuration option to control frequency of adaptivity computation https://github.com/precice/micro-manager/pull/168
 - Remove checkpointing of adaptivity and fix output of memory usage https://github.com/precice/micro-manager/pull/166
 - Performance improvements: restricting data types, in-place modifications https://github.com/precice/micro-manager/pull/162

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -144,7 +144,7 @@ class AdaptivityCalculator:
 
         # Start with a large distance to trigger the search for the most similar active sim
         # Add the +1 for the case when the similarity distance matrix is zeros
-        dist_min_start_value = 2 * (self._max_similarity_dist + 1)
+        dist_min_start_value = self._max_similarity_dist + 1
 
         # Associate inactive micro sims to active micro sims
         for inactive_id in inactive_ids:

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -143,7 +143,8 @@ class AdaptivityCalculator:
         inactive_ids = np.where(self._is_sim_active == False)[0]
 
         # Start with a large distance to trigger the search for the most similar active sim
-        dist_min_start_value = 2 * self._max_similarity_dist
+        # Add the +1 for the case when the similarity distance matrix is zeros
+        dist_min_start_value = 2 * (self._max_similarity_dist + 1)
 
         # Associate inactive micro sims to active micro sims
         for inactive_id in inactive_ids:


### PR DESCRIPTION
When the data of all the micro simulations used for adaptivity is the same, the similarity distance matrix has zeros. Such a situation should lead to exactly one active simulation, with all the rest inactive. The starting value of the minimum distance in the association step needs to be greater than zero to ensure the correct adaptivity states.

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
