### PR TITLE
Add config options for adaptivity metrics and memory usage output to allow for different levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Add config options for adaptivity metrics and memory usage output to allow for different levels https://github.com/precice/micro-manager/pull/172
 - Fix bug in adaptivity computation when an active simulation with associations is deactivated https://github.com/precice/micro-manager/pull/171
 - Properly handle micro simulation initialization for lazy initialization https://github.com/precice/micro-manager/pull/169
 - Delete the simulation object when the simulation is deactivated https://github.com/precice/micro-manager/pull/167

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ Parameter | Description
 `type` | Set to either `local` or `global`. The type of adaptivity matters when the Micro Manager is run in parallel. `local` means comparing micro simulations within a local partitioned domain for similarity. `global` means comparing micro simulations from all partitions, so over the entire domain.
 `data` | List of names of data which are to be used to calculate if micro-simulations are similar or not. For example `["temperature", "porosity"]`.
 `adaptivity_every_n_time_windows` | Frequency of adaptivity computation (integer which is number of time windows).
+`output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise adaptivity metrics. `global` outputs global averaged metrics. `all` outputs both local and global metrics.
 `output_n` | Frequency of output of adaptivity metrics (integer which is number of time windows).
 `history_param` | History parameter $$ \Lambda $$, set as $$ \Lambda >= 0 $$.
 `coarsening_constant` | Coarsening constant $$ C_c $$, set as $$ 0 =< C_c < 1 $$.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,13 +30,16 @@ The Micro Manager is configured with a JSON file. An example configuration file 
 
 This example configuration file is in [`examples/micro-manager-config.json`](https://github.com/precice/micro-manager/tree/develop/examples/micro-manager-config.json).
 
-The path to the file containing the Python importable micro simulation class is specified in the `micro_file_name` parameter. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.
+## Micro Manager Configuration
 
-Set the output [log](tooling-micro-manager-logging.html) directory using the parameter `output_dir`.
+Parameter | Description
+--- | ---
+`micro_file_name` | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.
+`output_directory` | Output [log](tooling-micro-manager-logging.html) directory.
+`memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels. All output is to a CSV file with the peak memory usage (RSS) in every time window, in MBs.
+`memory_usage_output_n` | Frequency of output of memory usage (integer which is number of time windows).
 
-To output the runtime memory usage, set `output_memory_usage` to `True`. This will output a CSV file with the peak memory usage (RSS) in every time window, in MBs.
-
-There are three main sections in the configuration file, the `coupling_params`, the `simulation_params` and the optional `diagnostics`.
+Apart from the base settings, there are three main sections in the configuration file, the `coupling_params`, the `simulation_params` and the optional `diagnostics`.
 
 ## Coupling Parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ This example configuration file is in [`examples/micro-manager-config.json`](htt
 Parameter | Description
 --- | ---
 `micro_file_name` | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.
-`output_directory` | Output [log](tooling-micro-manager-logging.html) directory.
+`output_directory` | Path to output directory for logging and performance metrics. Directory is created if not existing already.
 `memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels. All output is to a CSV file with the peak memory usage (RSS) in every time window, in MBs.
 `memory_usage_output_n` | Frequency of output of memory usage (integer which is number of time windows).
 

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -31,6 +31,7 @@ class AdaptivityCalculator:
         self._hist_param = configurator.get_adaptivity_hist_param()
         self._adaptivity_data_names = configurator.get_data_for_adaptivity()
         self._adaptivity_type = configurator.get_adaptivity_type()
+        self._adaptivity_output_type = configurator.get_adaptivity_output_type()
 
         self._micro_problem = getattr(
             importlib.import_module(
@@ -74,7 +75,10 @@ class AdaptivityCalculator:
         else:
             metrics_output_dir = "adaptivity-metrics"
 
-        if self._rank == 0:
+        if self._rank == 0 and (
+            self._adaptivity_output_type == "global"
+            or self._adaptivity_output_type == "all"
+        ):
             self._global_metrics_logger = Logger(
                 "global-metrics-logger",
                 metrics_output_dir + "-global.csv",
@@ -86,12 +90,16 @@ class AdaptivityCalculator:
                 "n,avg active,avg inactive,max active,max inactive"
             )
 
-        self._metrics_logger = Logger(
-            "metrics-logger",
-            metrics_output_dir + "-" + str(rank) + ".csv",
-            rank,
-            csv_logger=True,
-        )
+        if (
+            self._adaptivity_output_type == "local"
+            or self._adaptivity_output_type == "all"
+        ):
+            self._metrics_logger = Logger(
+                "metrics-logger",
+                metrics_output_dir + "-" + str(rank) + ".csv",
+                rank,
+                csv_logger=True,
+            )
 
     def _update_similarity_dists(self, dt: float, data: dict) -> None:
         """

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -65,7 +65,11 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         self._precice_participant = participant
 
-        self._metrics_logger.log_info("n,n active,n inactive,assoc ranks")
+        if (
+            self._adaptivity_output_type == "all"
+            or self._adaptivity_output_type == "local"
+        ):
+            self._metrics_logger.log_info("n,n active,n inactive,assoc ranks")
 
     def compute_adaptivity(
         self,
@@ -168,7 +172,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         """
         Log the following metrics:
 
-        Metrics on this rank:
+        Local metrics:
         - Time window at which the metrics are logged
         - Number of active simulations
         - Number of inactive simulations
@@ -194,39 +198,51 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             else:
                 inactive_sims_on_this_rank += 1
 
-        ranks_of_sims = self._get_ranks_of_sims()
+        if (
+            self._adaptivity_output_type == "all"
+            or self._adaptivity_output_type == "local"
+        ):
+            ranks_of_sims = self._get_ranks_of_sims()
 
-        assoc_ranks = []  # Ranks to which inactive sims on this rank are associated
-        for global_id in self._global_ids:
-            if not self._is_sim_active[global_id]:
-                assoc_rank = int(ranks_of_sims[self._sim_is_associated_to[global_id]])
-                if not assoc_rank in assoc_ranks:
-                    assoc_ranks.append(assoc_rank)
+            assoc_ranks = []  # Ranks to which inactive sims on this rank are associated
+            for global_id in self._global_ids:
+                if not self._is_sim_active[global_id]:
+                    assoc_rank = int(
+                        ranks_of_sims[self._sim_is_associated_to[global_id]]
+                    )
+                    if not assoc_rank in assoc_ranks:
+                        assoc_ranks.append(assoc_rank)
 
-        self._metrics_logger.log_info(
-            "{},{},{},{}".format(
-                n,
-                active_sims_on_this_rank,
-                inactive_sims_on_this_rank,
-                assoc_ranks,
-            )
-        )
-
-        active_sims_rankwise = self._comm.gather(active_sims_on_this_rank, root=0)
-        inactive_sims_rankwise = self._comm.gather(inactive_sims_on_this_rank, root=0)
-
-        if self._rank == 0:
-            size = self._comm.Get_size()
-
-            self._global_metrics_logger.log_info(
-                "{},{},{},{},{}".format(
+            self._metrics_logger.log_info(
+                "{},{},{},{}".format(
                     n,
-                    sum(active_sims_rankwise) / size,
-                    sum(inactive_sims_rankwise) / size,
-                    max(active_sims_rankwise),
-                    max(inactive_sims_rankwise),
+                    active_sims_on_this_rank,
+                    inactive_sims_on_this_rank,
+                    assoc_ranks,
                 )
             )
+
+        if (
+            self._adaptivity_output_type == "all"
+            or self._adaptivity_output_type == "global"
+        ):
+            active_sims_rankwise = self._comm.gather(active_sims_on_this_rank, root=0)
+            inactive_sims_rankwise = self._comm.gather(
+                inactive_sims_on_this_rank, root=0
+            )
+
+            if self._rank == 0:
+                size = self._comm.Get_size()
+
+                self._global_metrics_logger.log_info(
+                    "{},{},{},{},{}".format(
+                        n,
+                        sum(active_sims_rankwise) / size,
+                        sum(inactive_sims_rankwise) / size,
+                        max(active_sims_rankwise),
+                        max(inactive_sims_rankwise),
+                    )
+                )
 
     def _communicate_micro_output(
         self,

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -133,7 +133,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         """
         Log the following metrics:
 
-        Metrics on this rank:
+        Local metrics:
         - Time window at which the metrics are logged
         - Number of active simulations
         - Number of inactive simulations

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -32,7 +32,11 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         super().__init__(configurator, rank, num_sims)
         self._comm = comm
 
-        self._metrics_logger.log_info("n,n active,n inactive")
+        if (
+            self._adaptivity_output_type == "all"
+            or self._adaptivity_output_type == "local"
+        ):
+            self._metrics_logger.log_info("n,n active,n inactive")
 
         self._precice_participant = participant
 
@@ -153,29 +157,39 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             else:
                 inactive_sims_on_this_rank += 1
 
-        self._metrics_logger.log_info(
-            "{},{},{}".format(
-                n,
-                active_sims_on_this_rank,
-                inactive_sims_on_this_rank,
-            )
-        )
-
-        active_sims_rankwise = self._comm.gather(active_sims_on_this_rank, root=0)
-        inactive_sims_rankwise = self._comm.gather(inactive_sims_on_this_rank, root=0)
-
-        if self._rank == 0:
-            size = self._comm.Get_size()
-
-            self._global_metrics_logger.log_info_rank_zero(
-                "{},{},{},{},{}".format(
+        if (
+            self._adaptivity_output_type == "all"
+            or self._adaptivity_output_type == "local"
+        ):
+            self._metrics_logger.log_info(
+                "{},{},{}".format(
                     n,
-                    sum(active_sims_rankwise) / size,
-                    sum(inactive_sims_rankwise) / size,
-                    max(active_sims_rankwise),
-                    max(inactive_sims_rankwise),
+                    active_sims_on_this_rank,
+                    inactive_sims_on_this_rank,
                 )
             )
+
+        if (
+            self._adaptivity_output_type == "global"
+            or self._adaptivity_output_type == "all"
+        ):
+            active_sims_rankwise = self._comm.gather(active_sims_on_this_rank, root=0)
+            inactive_sims_rankwise = self._comm.gather(
+                inactive_sims_on_this_rank, root=0
+            )
+
+            if self._rank == 0:
+                size = self._comm.Get_size()
+
+                self._global_metrics_logger.log_info_rank_zero(
+                    "{},{},{},{},{}".format(
+                        n,
+                        sum(active_sims_rankwise) / size,
+                        sum(inactive_sims_rankwise) / size,
+                        max(active_sims_rankwise),
+                        max(inactive_sims_rankwise),
+                    )
+                )
 
     def _update_inactive_sims(self, micro_sims: list) -> None:
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -43,7 +43,7 @@ class Config:
         self._interpolate_crash = False
 
         self._adaptivity = False
-        self._adaptivity_type = "local"
+        self._adaptivity_type = ""
         self._data_for_adaptivity = dict()
         self._adaptivity_n = 1
         self._adaptivity_history_param = 0.5
@@ -51,6 +51,7 @@ class Config:
         self._adaptivity_refining_constant = 0.5
         self._adaptivity_every_implicit_iteration = False
         self._adaptivity_similarity_measure = "L1"
+        self._adaptivity_output_type = ""
         self._adaptivity_output_n = 1
 
         # Snapshot information
@@ -269,13 +270,30 @@ class Config:
                 ]["adaptivity_every_n_time_windows"]
                 self._logger.log_info_rank_zero(
                     "Adaptivity will be computed every "
-                    + str(self._adaptivity_output_n)
+                    + str(self._adaptivity_n)
                     + " time windows."
                 )
             except BaseException:
                 self._logger.log_info_rank_zero(
                     "No interval for adaptivity computation provided. Adaptivity will be computed in every time window."
                 )
+
+            try:
+                self._adaptivity_output_type = self._data["simulation_params"][
+                    "adaptivity_settings"
+                ]["output_type"]
+                if self._adaptivity_output_type not in ["all", "local", "global"]:
+                    raise Exception(
+                        "Adaptivity output type can be either 'all', 'local' or 'global'."
+                    )
+                self._logger.log_info_rank_zero(
+                    "Adaptivity output type: " + self._adaptivity_output_type
+                )
+            except BaseException:
+                self._logger.log_info_rank_zero(
+                    "No adaptivity output type provided. Defaulting to 'local'."
+                )
+                self._adaptivity_output_type = "local"
 
             try:
                 self._adaptivity_output_n = self._data["simulation_params"][
@@ -588,6 +606,17 @@ class Config:
             Frequency of adaptivity computation, as a multiple of time windows.
         """
         return self._adaptivity_n
+
+    def get_adaptivity_output_type(self):
+        """
+        Get the type of adaptivity output.
+
+        Returns
+        -------
+        adaptivity_output_type : str
+            Type of adaptivity output, can be "all", "local" or "global".
+        """
+        return self._adaptivity_output_type
 
     def get_adaptivity_output_n(self):
         """


### PR DESCRIPTION
This PR ...

- ... adds a configuration option `adaptivity_output_type`, which can either be `local`, `global`, or `all`.
- ... changes the existing configuration option `output_memory_usage` is also now to be set to either `local`, `global`, or `all`.
- ... adds the configuration option `memory_usage_output_n` to be set to control the output frequency of the peak memory usage.

**Breaking change**: The existing configuration option `output_dir` is renamed to `output_directory` for consistency.

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
