### PR TITLE
Move creation of output directory into main coupling class

### DIFF
--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -5,7 +5,6 @@ import sys
 from math import exp
 from typing import Callable
 from warnings import warn
-import subprocess
 import importlib
 from micro_manager.tools.logging_wrapper import Logger
 
@@ -70,7 +69,6 @@ class AdaptivityCalculator:
         output_dir = configurator.get_output_dir()
 
         if output_dir is not None:
-            subprocess.run(["mkdir", "-p", output_dir])  # Create output directory
             metrics_output_dir = output_dir + "/adaptivity-metrics"
         else:
             metrics_output_dir = "adaptivity-metrics"

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -4,7 +4,6 @@ in a local way. If the Micro Manager is run in parallel, simulations on one rank
 each other. A global comparison is not done.
 """
 import numpy as np
-import importlib
 from copy import deepcopy
 
 from .adaptivity import AdaptivityCalculator

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -23,6 +23,7 @@ import numpy as np
 import time
 from psutil import Process
 import csv
+import subprocess
 
 import precice
 
@@ -69,6 +70,7 @@ class MicroManagerCoupling(MicroManager):
 
         if self._output_dir is not None:
             self._output_dir = os.path.abspath(self._output_dir) + "/"
+            subprocess.run(["mkdir", "-p", self._output_dir])  # Create output directory
         else:
             self._output_dir = os.path.abspath(os.getcwd()) + "/"
 
@@ -308,6 +310,7 @@ class MicroManagerCoupling(MicroManager):
                 mem_usage_output_file = (
                     self._output_dir + "global_avg_peak_mem_usage.csv"
                 )
+                print("MEM USAGE OUTPUT FILE: ", mem_usage_output_file)
                 with open(mem_usage_output_file, mode="w", newline="") as file:
                     writer = csv.writer(file)
                     writer.writerow(["Time window", "RSS (MB)"])

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -310,7 +310,6 @@ class MicroManagerCoupling(MicroManager):
                 mem_usage_output_file = (
                     self._output_dir + "global_avg_peak_mem_usage.csv"
                 )
-                print("MEM USAGE OUTPUT FILE: ", mem_usage_output_file)
                 with open(mem_usage_output_file, mode="w", newline="") as file:
                     writer = csv.writer(file)
                     writer.writerow(["Time window", "RSS (MB)"])


### PR DESCRIPTION
The subprocess command for the creation of the output directory is moved from the adaptivity base class to the main `MicroManagerCoupling` class, because the directory needs to be created for simulations without adaptivity too.
