### PR TITLE
Share similarity distance matrix between ranks on a compute node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Share similarity distance matrix between ranks on a compute node https://github.com/precice/micro-manager/pull/176
 - Use booleans instead of strings `"True"` and `"False"` in the configuration https://github.com/precice/micro-manager/pull/175
 - Renaming and using a newer workflow for publishing according to the trusted publishing in PyPI https://github.com/precice/micro-manager/pull/173
 - Add config options for adaptivity metrics and memory usage output to allow for different levels https://github.com/precice/micro-manager/pull/172

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -66,7 +66,8 @@ class AdaptivityCalculator:
         # Get the buffer on the local rank 0
         buffer, itemsize = win.Shared_query(0)
 
-        assert itemsize == MPI.FLOAT.Get_size(), "Item size mismatch in shared memory."
+        if itemsize != MPI.FLOAT.Get_size():
+            raise RuntimeError("Item size mismatch in shared memory.")
 
         # Create a numpy array from the buffer
         array_buffer = np.array(buffer, dtype="B", copy=False)
@@ -77,8 +78,9 @@ class AdaptivityCalculator:
             buffer=array_buffer, dtype="f", shape=(nsims, nsims)
         )
 
-        # Initialize the similarity distances to zero
-        self._similarity_dists.fill(0.0)
+        if self._MPI_local_rank == 0:
+            # Initialize the similarity distances to zero
+            self._similarity_dists.fill(0.0)
 
         self._max_similarity_dist = 0.0
 

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -142,6 +142,7 @@ class AdaptivityCalculator:
         data : dict
             Data to be used in similarity distance calculation
         """
+        # Update similarity distances without copying
         self._similarity_dists *= exp(-self._hist_param * dt)
 
         for name in data.keys():

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -6,14 +6,13 @@ from math import exp
 from typing import Callable
 from warnings import warn
 import importlib
-from mpi4py import MPI
 from micro_manager.tools.logging_wrapper import Logger
 
 import numpy as np
 
 
 class AdaptivityCalculator:
-    def __init__(self, configurator, comm_world, rank, nsims) -> None:
+    def __init__(self, configurator, rank, nsims) -> None:
         """
         Class constructor.
 
@@ -21,8 +20,6 @@ class AdaptivityCalculator:
         ----------
         configurator : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
-        comm_world : MPI communicator
-            MPI communicator COMM_WORLD.
         rank : int
             Rank of the MPI communicator.
         nsims : int
@@ -46,41 +43,6 @@ class AdaptivityCalculator:
         self._ref_tol = 0.0
 
         self._rank = rank
-
-        comm_node = comm_world.Split_type(MPI.COMM_TYPE_SHARED)
-
-        self._MPI_local_rank = comm_node.Get_rank()
-
-        # Size of data type
-        itemsize = MPI.FLOAT.Get_size()
-
-        if (
-            self._MPI_local_rank == 0
-        ):  # Only the first rank in the node allocates the shared memory
-            nbytes = nsims * nsims * itemsize
-        else:
-            nbytes = 0
-
-        win = MPI.Win.Allocate_shared(nbytes, itemsize, comm=comm_node)
-
-        # Get the buffer on the local rank 0
-        buffer, itemsize = win.Shared_query(0)
-
-        if itemsize != MPI.FLOAT.Get_size():
-            raise RuntimeError("Item size mismatch in shared memory.")
-
-        # Create a numpy array from the buffer
-        array_buffer = np.array(buffer, dtype="B", copy=False)
-
-        # similarity_dists: 2D array having similarity distances between each micro simulation pair
-        # This matrix is modified in place via the function update_similarity_dists
-        self._similarity_dists: np.ndarray = np.ndarray(
-            buffer=array_buffer, dtype="f", shape=(nsims, nsims)
-        )
-
-        if self._MPI_local_rank == 0:
-            # Initialize the similarity distances to zero
-            self._similarity_dists.fill(0.0)
 
         self._max_similarity_dist = 0.0
 

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -114,6 +114,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         self._comm_world.Barrier()  # Wait for the similarity distances to be updated
 
+        self._max_similarity_dist = np.amax(self._similarity_dists)
+
         self._update_active_sims()
 
         self._update_inactive_sims(micro_sims)

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -24,7 +24,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         global_ids: list,
         participant,
         rank: int,
-        comm,
+        comm_world,
     ) -> None:
         """
         Class constructor.
@@ -41,13 +41,13 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             Object of the class Participant using which the preCICE API is called.
         rank : int
             MPI rank.
-        comm : MPI.COMM_WORLD
-            Global communicator of MPI.
+        comm_world : MPI.COMM_WORLD
+            Base global communicator of MPI.
         """
-        super().__init__(configurator, rank, global_number_of_sims)
+        super().__init__(configurator, comm_world, rank, global_number_of_sims)
         self._global_number_of_sims = global_number_of_sims
         self._global_ids = global_ids
-        self._comm = comm
+        self._comm_world = comm_world
 
         local_number_of_sims = len(global_ids)
 
@@ -104,10 +104,15 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         # Gather adaptivity data from all ranks
         global_data_for_adaptivity = dict()
         for name in data_for_adaptivity.keys():
-            data_as_list = self._comm.allgather(data_for_adaptivity[name])
+            data_as_list = self._comm_world.allgather(data_for_adaptivity[name])
             global_data_for_adaptivity[name] = np.concatenate((data_as_list[:]), axis=0)
 
-        self._update_similarity_dists(dt, global_data_for_adaptivity)
+        if (
+            self._MPI_local_rank == 0
+        ):  # Only the first rank in the node updates the similarity distances
+            self._update_similarity_dists(dt, global_data_for_adaptivity)
+
+        self._comm_world.Barrier()  # Wait for the similarity distances to be updated
 
         self._update_active_sims()
 
@@ -226,13 +231,15 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             self._adaptivity_output_type == "all"
             or self._adaptivity_output_type == "global"
         ):
-            active_sims_rankwise = self._comm.gather(active_sims_on_this_rank, root=0)
-            inactive_sims_rankwise = self._comm.gather(
+            active_sims_rankwise = self._comm_world.gather(
+                active_sims_on_this_rank, root=0
+            )
+            inactive_sims_rankwise = self._comm_world.gather(
                 inactive_sims_on_this_rank, root=0
             )
 
             if self._rank == 0:
-                size = self._comm.Get_size()
+                size = self._comm_world.Get_size()
 
                 self._global_metrics_logger.log_info(
                     "{},{},{},{},{}".format(
@@ -449,7 +456,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             send_map_local[i] = self._rank
 
         # Gather information about which sims to send where, from the sending perspective
-        send_map_list = self._comm.allgather(send_map_local)
+        send_map_list = self._comm_world.allgather(send_map_local)
 
         for d in send_map_list:
             for i, rank in d.items():
@@ -465,7 +472,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             local_id = self._global_ids.index(global_id)
             for send_rank in send_ranks:
                 tag = self._create_tag(global_id, self._rank, send_rank)
-                req = self._comm.isend(data[local_id], dest=send_rank, tag=tag)
+                req = self._comm_world.isend(data[local_id], dest=send_rank, tag=tag)
                 send_reqs.append(req)
 
         # Asynchronous receive operations
@@ -475,7 +482,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             bufsize = (
                 1 << 30
             )  # allocate and use a temporary 1 MiB buffer size https://github.com/mpi4py/mpi4py/issues/389
-            req = self._comm.irecv(bufsize, source=recv_rank, tag=tag)
+            req = self._comm_world.irecv(bufsize, source=recv_rank, tag=tag)
             recv_reqs.append(req)
 
         # Wait for all non-blocking communication to complete
@@ -495,7 +502,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         for gid in self._global_ids:
             local_gids_to_rank[gid] = self._rank
 
-        ranks_maps_as_list = self._comm.allgather(local_gids_to_rank)
+        ranks_maps_as_list = self._comm_world.allgather(local_gids_to_rank)
 
         ranks_of_sims = np.zeros(self._global_number_of_sims, dtype=np.intc)
         for ranks_map in ranks_maps_as_list:

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -71,9 +71,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ):
             self._metrics_logger.log_info("n,n active,n inactive,assoc ranks")
 
-        comm_node = comm_world.Split_type(MPI.COMM_TYPE_SHARED)
+        self._comm_node = comm_world.Split_type(MPI.COMM_TYPE_SHARED)
 
-        self._MPI_local_rank = comm_node.Get_rank()
+        self._MPI_local_rank = self._comm_node.Get_rank()
 
         # Size of data type
         itemsize = MPI.FLOAT.Get_size()
@@ -87,7 +87,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         else:
             nbytes = 0
 
-        win = MPI.Win.Allocate_shared(nbytes, itemsize, comm=comm_node)
+        win = MPI.Win.Allocate_shared(nbytes, itemsize, comm=self._comm_node)
 
         # Get the buffer on the local rank 0
         buffer, itemsize = win.Shared_query(0)
@@ -151,7 +151,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ):  # Only the first rank in the node updates the similarity distances
             self._update_similarity_dists(dt, global_data_for_adaptivity)
 
-        self._comm_world.Barrier()  # Wait for the similarity distances to be updated
+        self._comm_node.Barrier()  # Wait for the similarity distances to be updated on all ranks of the node
 
         self._max_similarity_dist = np.amax(self._similarity_dists)
 

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -78,6 +78,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         self._comm_world.Barrier()  # Wait for the similarity distances to be updated
 
+        self._max_similarity_dist = np.amax(self._similarity_dists)
+
         self._update_active_sims()
 
         self._update_inactive_sims(micro_sims)

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -11,7 +11,7 @@ from ..micro_simulation import create_simulation_class
 
 
 class LocalAdaptivityCalculator(AdaptivityCalculator):
-    def __init__(self, configurator, num_sims, participant, rank, comm) -> None:
+    def __init__(self, configurator, num_sims, participant, rank, comm_world) -> None:
         """
         Class constructor.
 
@@ -25,11 +25,11 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             Object of the class Participant using which the preCICE API is called.
         rank : int
             Rank of the current MPI process.
-        comm : MPI.COMM_WORLD
+        comm_world : MPI.COMM_WORLD
             Global communicator of MPI.
         """
-        super().__init__(configurator, rank, num_sims)
-        self._comm = comm
+        super().__init__(configurator, comm_world, rank, num_sims)
+        self._comm_world = comm_world
 
         if (
             self._adaptivity_output_type == "all"
@@ -71,7 +71,12 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
                     )
                 )
 
-        self._update_similarity_dists(dt, data_for_adaptivity)
+        if (
+            self._MPI_local_rank == 0
+        ):  # Only the first rank in the node updates the similarity distances
+            self._update_similarity_dists(dt, data_for_adaptivity)
+
+        self._comm_world.Barrier()  # Wait for the similarity distances to be updated
 
         self._update_active_sims()
 
@@ -172,13 +177,15 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             self._adaptivity_output_type == "global"
             or self._adaptivity_output_type == "all"
         ):
-            active_sims_rankwise = self._comm.gather(active_sims_on_this_rank, root=0)
-            inactive_sims_rankwise = self._comm.gather(
+            active_sims_rankwise = self._comm_world.gather(
+                active_sims_on_this_rank, root=0
+            )
+            inactive_sims_rankwise = self._comm_world.gather(
                 inactive_sims_on_this_rank, root=0
             )
 
             if self._rank == 0:
-                size = self._comm.Get_size()
+                size = self._comm_world.Get_size()
 
                 self._global_metrics_logger.log_info_rank_zero(
                     "{},{},{},{},{}".format(

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -158,6 +158,7 @@ class TestGlobalAdaptivity(TestCase):
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)
         )
+
         self.assertTrue(
             np.array_equal(
                 expected_sim_is_associated_to,

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -24,9 +24,9 @@ class MicroSimulation:
 
 class TestGlobalAdaptivity(TestCase):
     def setUp(self):
-        self._comm = MPI.COMM_WORLD
-        self._rank = self._comm.Get_rank()
-        self._size = self._comm.Get_size()
+        comm_world = MPI.COMM_WORLD
+        self._rank = comm_world.Get_rank()
+        self._size = comm_world.Get_size()
 
     def test_update_inactive_sims_global_adaptivity(self):
         """
@@ -54,7 +54,7 @@ class TestGlobalAdaptivity(TestCase):
             global_ids,
             participant=MagicMock(),
             rank=self._rank,
-            comm=self._comm,
+            comm_world=MPI.COMM_WORLD,
         )
 
         adaptivity_controller._is_sim_active = np.array(
@@ -126,7 +126,7 @@ class TestGlobalAdaptivity(TestCase):
             global_ids,
             participant=MagicMock(),
             rank=self._rank,
-            comm=self._comm,
+            comm_world=MPI.COMM_WORLD,
         )
 
         adaptivity_controller._adaptivity_data_names = ["data1", "data2"]
@@ -195,7 +195,7 @@ class TestGlobalAdaptivity(TestCase):
             global_ids,
             participant=MagicMock(),
             rank=self._rank,
-            comm=self._comm,
+            comm_world=MPI.COMM_WORLD,
         )
 
         adaptivity_controller._is_sim_active = np.array(

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 import numpy as np
+from mpi4py import MPI
 
 from micro_manager.adaptivity.adaptivity import AdaptivityCalculator
 from micro_manager.adaptivity.local_adaptivity import LocalAdaptivityCalculator
@@ -91,7 +92,7 @@ class TestLocalAdaptivity(TestCase):
         )
 
         adaptivity_controller = AdaptivityCalculator(
-            configurator, 0, self._number_of_sims
+            configurator, comm_world=MPI.COMM_WORLD, rank=0, nsims=self._number_of_sims
         )
         adaptivity_controller._hist_param = 0.5
         adaptivity_controller._adaptivity_data_names = [
@@ -134,7 +135,7 @@ class TestLocalAdaptivity(TestCase):
         )
 
         adaptivity_controller = AdaptivityCalculator(
-            configurator, 0, self._number_of_sims
+            configurator, comm_world=MPI.COMM_WORLD, rank=0, nsims=self._number_of_sims
         )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
@@ -166,7 +167,7 @@ class TestLocalAdaptivity(TestCase):
         )
 
         adaptivity_controller = AdaptivityCalculator(
-            configurator, 0, self._number_of_sims
+            configurator, comm_world=MPI.COMM_WORLD, rank=0, nsims=self._number_of_sims
         )
 
         fake_data = np.array([[1], [2], [3]])
@@ -260,7 +261,7 @@ class TestLocalAdaptivity(TestCase):
         )
 
         adaptivity_controller = AdaptivityCalculator(
-            configurator, 0, self._number_of_sims
+            configurator, comm_world=MPI.COMM_WORLD, rank=0, nsims=self._number_of_sims
         )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
@@ -302,7 +303,7 @@ class TestLocalAdaptivity(TestCase):
             self._number_of_sims,
             MagicMock(),
             0,
-            MagicMock(),
+            comm_world=MPI.COMM_WORLD,
         )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -109,12 +109,17 @@ class TestLocalAdaptivity(TestCase):
 
         adaptivity_controller._similarity_dists = self._similarity_dists
 
+        old_similarity_dists = adaptivity_controller._similarity_dists.copy()
+
         adaptivity_controller._update_similarity_dists(self._dt, adaptivity_data)
 
         expected_similarity_dists = (
-            exp(-adaptivity_controller._hist_param * self._dt) * self._similarity_dists
+            exp(-adaptivity_controller._hist_param * self._dt) * old_similarity_dists
             + self._dt * self._data_diff
         )
+
+        print("Expected similarity distances:\n", expected_similarity_dists)
+        print("Actual similarity distances:\n", adaptivity_controller._similarity_dists)
 
         self.assertTrue(
             np.array_equal(

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -7,7 +7,6 @@ from mpi4py import MPI
 
 from micro_manager.adaptivity.adaptivity import AdaptivityCalculator
 from micro_manager.adaptivity.local_adaptivity import LocalAdaptivityCalculator
-from micro_manager.config import Config
 
 
 class MicroSimulation:

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -91,7 +91,7 @@ class TestLocalAdaptivity(TestCase):
         )
 
         adaptivity_controller = AdaptivityCalculator(
-            configurator, comm_world=MPI.COMM_WORLD, rank=0, nsims=self._number_of_sims
+            configurator, rank=0, nsims=self._number_of_sims
         )
         adaptivity_controller._hist_param = 0.5
         adaptivity_controller._adaptivity_data_names = [
@@ -139,7 +139,7 @@ class TestLocalAdaptivity(TestCase):
         )
 
         adaptivity_controller = AdaptivityCalculator(
-            configurator, comm_world=MPI.COMM_WORLD, rank=0, nsims=self._number_of_sims
+            configurator, rank=0, nsims=self._number_of_sims
         )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
@@ -171,7 +171,7 @@ class TestLocalAdaptivity(TestCase):
         )
 
         adaptivity_controller = AdaptivityCalculator(
-            configurator, comm_world=MPI.COMM_WORLD, rank=0, nsims=self._number_of_sims
+            configurator, rank=0, nsims=self._number_of_sims
         )
 
         fake_data = np.array([[1], [2], [3]])
@@ -265,7 +265,7 @@ class TestLocalAdaptivity(TestCase):
         )
 
         adaptivity_controller = AdaptivityCalculator(
-            configurator, comm_world=MPI.COMM_WORLD, rank=0, nsims=self._number_of_sims
+            configurator, rank=0, nsims=self._number_of_sims
         )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const


### PR DESCRIPTION
In the adaptivity computation, the similarity distance matrix is the most memory heavy data structure. Currently it is stored on every rank, which leads to a memory bottleneck for large problems. This PR implements sharing of the similarity distance matrix between ranks on a compute node. This will lead to a memory benefit of as many times as the number of ranks per node. Shared access is implemented using MPI, by following the strategy from [this example](https://groups.google.com/g/mpi4py/c/Fme1n9niNwQ/m/lk3VJ54WAQAJ).

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
