### PR TITLE
Use booleans in JSON config files of integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Use boolean parameter values in JSON config files of unit cube integration test https://github.com/precice/micro-manager/pull/185
 - Use OpenMPI in mpi4py setup action in parallel tests action https://github.com/precice/micro-manager/pull/184
 - Software improvements to the snapshot computation functionality https://github.com/precice/micro-manager/pull/178
 

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -11,18 +11,18 @@
         "micro_dt": 1.0,
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
         "decomposition": [2, 1, 1],
-        "adaptivity": "True",
+        "adaptivity": true,
         "adaptivity_settings": {
             "type": "global",
             "data": ["micro-data-1", "micro-data-2"],
             "history_param": 1.0,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "False",
-	        "output_cpu_time": "True"
+            "every_implicit_iteration": false,
+            "output_cpu_time": true
         }
     },
     "diagnostics": {
-        "output_micro_sim_solve_time": "True"
+        "output_micro_sim_solve_time": true
     }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -9,14 +9,14 @@
     "simulation_params": {
         "micro_dt": 1.0,
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-        "adaptivity": "True",
+        "adaptivity": true,
         "adaptivity_settings": {
             "type": "global",
             "data": ["micro-data-1", "micro-data-2"],
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "True"
+            "every_implicit_iteration": true
         }
     }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -9,14 +9,14 @@
     "simulation_params": {
         "micro_dt": 1.0,
         "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-        "adaptivity": "True",
+        "adaptivity": true,
         "adaptivity_settings": {
             "type": "local",
             "data": ["micro-data-1", "micro-data-2"],
             "history_param": 0.5,
             "coarsening_constant": 0.3,
             "refining_constant": 0.4,
-            "every_implicit_iteration": "True"
+            "every_implicit_iteration": true
         }
     }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -12,6 +12,6 @@
 	    "decomposition": [1, 1, 2]
     },
     "diagnostics": {
-        "output_micro_sim_solve_time": "True"
+        "output_micro_sim_solve_time": true
     }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -12,6 +12,6 @@
 	    "decomposition": [1, 2, 3]
     },
     "diagnostics": {
-        "output_micro_sim_solve_time": "True"
+        "output_micro_sim_solve_time": true
     }
 }


### PR DESCRIPTION
Use boolean parameter values in the JSON configuration files of the unit cube integration test. Left over from https://github.com/precice/micro-manager/pull/175

Checklist:

- [ ] ~~I made sure that the CI passed before I ask for a review.~~
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
