### PR TITLE
Revert to using (default) mpich as error is fixed in setup-mpi action

### DIFF
--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Use mpi4py
         uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: openmpi
 
       - name: Install dependencies
         working-directory: micro-manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Revert to using (default) mpich as error is fixed in setup-mpi action https://github.com/precice/micro-manager/pull/187
 - Refactor adaptivity: simplify logic and shorten iterator variable names https://github.com/precice/micro-manager/pull/186
 - Use boolean parameter values in JSON config files of unit cube integration test https://github.com/precice/micro-manager/pull/185
 - Use OpenMPI in mpi4py setup action in parallel tests action https://github.com/precice/micro-manager/pull/184


### PR DESCRIPTION
Fix in the setup action: https://github.com/mpi4py/setup-mpi/pull/19

Checklist:

- [ ] ~~I made sure that the CI passed before I ask for a review.~~
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
