### PR TITLE
Remove two-step-balancing option from load balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## latest
 
-- Remove option of simulation solve time from diagnostics https://github.com/precice/micro-manager/pull/188
-- Add dynamic load balancing capability to global adaptivity https://github.com/precice/micro-manager/pull/141
-- Revert to using (default) mpich as error is fixed in setup-mpi action https://github.com/precice/micro-manager/pull/187
-- Refactor adaptivity: simplify logic and shorten iterator variable names https://github.com/precice/micro-manager/pull/186
-- Use boolean parameter values in JSON config files of unit cube integration test https://github.com/precice/micro-manager/pull/185
-- Use OpenMPI in mpi4py setup action in parallel tests action https://github.com/precice/micro-manager/pull/184
-- Software improvements to the snapshot computation functionality https://github.com/precice/micro-manager/pull/178
+- Remove two-step balancing from load balancing [#191](https://github.com/precice/micro-manager/pull/191)
+- Remove option of simulation solve time from diagnostics [#188](https://github.com/precice/micro-manager/pull/188)
+- Add dynamic load balancing capability to global adaptivity [#144](https://github.com/precice/micro-manager/pull/141)
+- Revert to using (default) mpich as error is fixed in setup-mpi action [#187](https://github.com/precice/micro-manager/pull/187)
+- Refactor adaptivity: simplify logic and shorten iterator variable names [#186](https://github.com/precice/micro-manager/pull/186)
+- Use boolean parameter values in JSON config files of unit cube integration test [#185](https://github.com/precice/micro-manager/pull/185)
+- Use OpenMPI in mpi4py setup action in parallel tests action [#184](https://github.com/precice/micro-manager/pull/184)
+- Software improvements to the snapshot computation functionality [#178](https://github.com/precice/micro-manager/pull/178)
 
 ## v0.7.0
 

--- a/docs/adaptivity.md
+++ b/docs/adaptivity.md
@@ -97,18 +97,6 @@ For a rank $$ i $$ having $$ N_A^{i} $$ active simulations, the following scenar
 4. If $$ N_A^{i} =  L $$ , rank $$ i $$  can expect to receive one active simulation, if available.
 5. If $$ N_A^{i} = U $$ , rank $$ i $$  can expect to send one active simulation, if available.
 
-### Two-step approach
-
-As mentioned in the [load balancing](#load-balancing) section scenarios 4 and 5, it is possible that the number of active simulations on a rank are exactly as many as the bounds. To get the best possible balancing, these ranks send or receive one active simulation.
-
-{% disclaimer %}
-Use this option only if the best possible balancing is desired, because this will lead to added communication effort.
-{% enddisclaimer %}
-
-{% note %}
-If the balancing threshold $$ \tau \gt 0 $$, two-step balancing does not produce a different balancing state, so it is disabled.
-{% endnote %}
-
 ### Effect of the balancing threshold
 
 Example:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,7 +162,6 @@ Under `load_balancing_settings`, the following parameters can be set
 Parameter | Description
 --- | ---
 `every_n_time_windows` | Frequency of balancing the simulations. Default `1` (every time window).
-`two_step_balancing` | If `true`, simulations are balanced in two steps. See [two-step approach](tooling-micro-manager-adaptivity.html#two-step-approach).
 `balancing_threshold` | Integer threshold value. Default `0`.
 `balance_inactive_sims` | If `true`, inactive simulations associated to redistributed active simulations are moved to the new ranks of the active simulations. See [balance inactive simulations](tooling-micro-manager-adaptivity.html#balance-inactive-simulations). Default `false`.
 

--- a/micro_manager/adaptivity/global_adaptivity_lb.py
+++ b/micro_manager/adaptivity/global_adaptivity_lb.py
@@ -66,10 +66,6 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
 
         self._threshold = configurator.get_load_balancing_threshold()
 
-        self._is_load_balancing_done_in_two_steps = (
-            configurator.is_load_balancing_two_step()
-        )
-
         self._balance_inactive_sims = configurator.balance_inactive_sims()
 
         self._nothing_to_balance = False
@@ -190,17 +186,12 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
 
         self._move_active_sims(micro_sims, send_map, recv_map)
 
-        if self._is_load_balancing_done_in_two_steps:
-            if sum(global_psend_sims) != 0 and sum(global_precv_sims) != 0:
-                send_map, recv_map = self._get_communication_maps(
-                    global_psend_sims, global_precv_sims
-                )
+        if sum(global_psend_sims) != 0 and sum(global_precv_sims) != 0:
+            send_map, recv_map = self._get_communication_maps(
+                global_psend_sims, global_precv_sims
+            )
 
-                self._move_active_sims(micro_sims, send_map, recv_map)
-            else:
-                self._base_logger.log_warning_rank_zero(
-                    "No load balancing was done in the second step because the micro simulations are already almost perfectly balanced."
-                )
+            self._move_active_sims(micro_sims, send_map, recv_map)
 
     def _redistribute_inactive_sims(self, micro_sims: list) -> None:
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -56,7 +56,6 @@ class Config:
 
         self._adaptivity_is_load_balancing = False
         self._load_balancing_n = 1
-        self._two_step_load_balancing = False
         self._load_balancing_threshold = 0
         self._balance_inactive_sims = False
 
@@ -414,19 +413,6 @@ class Config:
             )
 
             try:
-                self._two_step_load_balancing = self._data["simulation_params"][
-                    "load_balancing_settings"
-                ]["two_step_balancing"]
-                if self._two_step_load_balancing:
-                    self._logger.log_info_rank_zero(
-                        "Micro Manager will use two-step load balancing."
-                    )
-            except BaseException:
-                self._logger.log_info_rank_zero(
-                    "Two-step load balancing is not specified. Micro Manager will only try to balance the load in one sweep."  # TODO: Need a better log message here.
-                )
-
-            try:
                 self._load_balancing_threshold = self._data["simulation_params"][
                     "load_balancing_settings"
                 ]["balancing_threshold"]
@@ -436,12 +422,6 @@ class Config:
             except BaseException:
                 self._logger.log_info_rank_zero(
                     "No load balancing threshold provided. The threshold will be set to 0."
-                )
-
-            if self._load_balancing_threshold > 0 and self._two_step_load_balancing:
-                self._two_step_load_balancing = False
-                self._logger.log_warning_rank_zero(
-                    "Threshold is not zero, so two step load balancing is disabled."
                 )
 
             try:
@@ -792,17 +772,6 @@ class Config:
             Load balancing frequency
         """
         return self._load_balancing_n
-
-    def is_load_balancing_two_step(self):
-        """
-        Check if two-step load balancing is required.
-
-        Returns
-        -------
-        two_step_load_balancing : bool
-            True if two-step load balancing is required, False otherwise.
-        """
-        return self._two_step_load_balancing
 
     def get_load_balancing_threshold(self):
         """

--- a/tests/unit/test_global_adaptivity_lb.py
+++ b/tests/unit/test_global_adaptivity_lb.py
@@ -38,7 +38,6 @@ class TestGlobalAdaptivityLB(TestCase):
         )
         self._configurator.get_output_dir = MagicMock(return_value="output_dir")
 
-        self._configurator.is_load_balancing_two_step = MagicMock(return_value=False)
         self._configurator.get_load_balancing_threshold = MagicMock(return_value=0)
 
     @unittest.skipUnless(
@@ -139,78 +138,7 @@ class TestGlobalAdaptivityLB(TestCase):
     @unittest.skipUnless(
         MPI.COMM_WORLD.Get_size() == 4, "This test only works with 4 ranks."
     )
-    def test_redistribute_active_sims_four_ranks_one_step(self):
-        """
-        Test load balancing functionality to redistribute active simulations. The load balancing is done in one step.
-        Run this test in parallel using MPI with 4 ranks.
-        """
-        global_number_of_sims = 15
-
-        if self._rank == 0:
-            global_ids = [0, 1, 2, 3]
-            expected_global_ids = [0, 1, 2, 3]
-        elif self._rank == 1:
-            global_ids = [4, 5, 6, 7]
-            expected_global_ids = [4, 5, 6, 7, 12]
-        elif self._rank == 2:
-            global_ids = [8, 9, 10, 11]
-            expected_global_ids = [8, 9, 10, 11]
-        elif self._rank == 3:
-            global_ids = [12, 13, 14]
-            expected_global_ids = [13, 14]
-
-        expected_ranks_of_sims = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 1, 3, 3]
-
-        adaptivity_controller = GlobalAdaptivityLBCalculator(
-            self._configurator,
-            global_number_of_sims,
-            global_ids,
-            participant=MagicMock(),
-            logger=MagicMock(),
-            rank=self._rank,
-            comm=self._comm,
-        )
-
-        adaptivity_controller._is_sim_active = np.array(
-            [
-                True,
-                True,
-                True,
-                False,
-                False,
-                False,
-                False,
-                False,
-                True,
-                False,
-                False,
-                False,
-                True,
-                True,
-                True,
-            ]
-        )
-
-        micro_sims = []
-        for i in global_ids:
-            micro_sims.append(MicroSimulation(i))
-
-        adaptivity_controller._redistribute_active_sims(micro_sims)
-
-        actual_global_ids = []
-        for sim in micro_sims:
-            actual_global_ids.append(sim.get_global_id())
-
-        self.assertEqual(actual_global_ids, expected_global_ids)
-
-        actual_ranks_of_sims = adaptivity_controller._get_ranks_of_sims()
-
-        self.assertTrue(np.array_equal(expected_ranks_of_sims, actual_ranks_of_sims))
-
-    @unittest.skipUnless(
-        MPI.COMM_WORLD.Get_size() == 4, "This test only works with 4 ranks."
-    )
-    def test_redistribute_active_sims_four_ranks_two_steps(self):
+    def test_redistribute_active_sims_four_ranks(self):
         """
         Test load balancing functionality to redistribute active simulations. The load balancing is one in two steps.
         Run this test in parallel using MPI with 4 ranks.
@@ -231,8 +159,6 @@ class TestGlobalAdaptivityLB(TestCase):
             expected_global_ids = [13, 14]
 
         expected_ranks_of_sims = [2, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 1, 3, 3]
-
-        self._configurator.is_load_balancing_two_step = MagicMock(return_value=True)
 
         adaptivity_controller = GlobalAdaptivityLBCalculator(
             self._configurator,


### PR DESCRIPTION
The user configurable option two-step balancing is deemed unnecessary in the load balancing strategy. The balancing is always done to the best possible precision.

Checklist:

- [ ] ~~I made sure that the CI passed before I ask for a review.~~
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
