### PR TITLE
Use `|` delimiter in CSV files with adaptivity metrics data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Use `|` delimiter in CSV files of adaptivity metrics data [#193](https://github.com/precice/micro-manager/pull/193)
 - Add profiling sections for solving the micro simulations [commit](https://github.com/precice/micro-manager/commit/fa81f6a7e8f494a3e441fee7f70de5271ae8d83b)
 - Fix bug in load balancing when more than one rank has as many simulations as the balancing bound [#192](https://github.com/precice/micro-manager/pull/192)
 - Remove two-step balancing from load balancing [#191](https://github.com/precice/micro-manager/pull/191)

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -61,7 +61,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             self._adaptivity_output_type == "all"
             or self._adaptivity_output_type == "local"
         ):
-            self._metrics_logger.log_info("n,n active,n inactive,assoc ranks")
+            self._metrics_logger.log_info("n|n active|n inactive|n assoc ranks")
 
         self._comm_node = comm_world.Split_type(MPI.COMM_TYPE_SHARED)
 
@@ -301,7 +301,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                         assoc_ranks.append(assoc_rank)
 
             self._metrics_logger.log_info(
-                "{},{},{},{}".format(
+                "{}|{}|{}|{}".format(
                     n,
                     active_sims_on_this_rank,
                     inactive_sims_on_this_rank,
@@ -324,7 +324,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 size = self._comm_world.Get_size()
 
                 self._global_metrics_logger.log_info(
-                    "{},{},{},{},{}".format(
+                    "{}|{}|{}|{}|{}".format(
                         n,
                         sum(active_sims_rankwise) / size,
                         sum(inactive_sims_rankwise) / size,

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -61,7 +61,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             self._adaptivity_output_type == "all"
             or self._adaptivity_output_type == "local"
         ):
-            self._metrics_logger.log_info("n|n active|n inactive|n assoc ranks")
+            self._metrics_logger.log_info("n|n active|n inactive|assoc ranks")
 
         self._comm_node = comm_world.Split_type(MPI.COMM_TYPE_SHARED)
 

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -35,7 +35,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             self._adaptivity_output_type == "all"
             or self._adaptivity_output_type == "local"
         ):
-            self._metrics_logger.log_info("n,n active,n inactive")
+            self._metrics_logger.log_info("n|n active|n inactive")
 
         self._precice_participant = participant
 
@@ -194,7 +194,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             or self._adaptivity_output_type == "local"
         ):
             self._metrics_logger.log_info(
-                "{},{},{}".format(
+                "{}|{}|{}".format(
                     n,
                     active_sims_on_this_rank,
                     inactive_sims_on_this_rank,
@@ -216,7 +216,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
                 size = self._comm_world.Get_size()
 
                 self._global_metrics_logger.log_info_rank_zero(
-                    "{},{},{},{},{}".format(
+                    "{}|{}|{}|{}|{}".format(
                         n,
                         sum(active_sims_rankwise) / size,
                         sum(inactive_sims_rankwise) / size,


### PR DESCRIPTION
Change the delimiter in the CSV files of adaptivity metrics from `,` to `|` so that lists can be read properly. Suggested by @fsimonis and works very nicely.

Checklist:

- [ ] ~~I made sure that the CI passed before I ask for a review.~~
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
