### PR TITLE
Use global maximum similarity distance in local adaptivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Use global maximum similarity distance in local adaptivity [#197](https://github.com/precice/micro-manager/pull/197)
 - Log adaptivity metrics at t=0 [#194](https://github.com/precice/micro-manager/pull/194)
 - Use `|` delimiter in CSV files of adaptivity metrics data [#193](https://github.com/precice/micro-manager/pull/193)
 - Add profiling sections for solving the micro simulations [commit](https://github.com/precice/micro-manager/commit/fa81f6a7e8f494a3e441fee7f70de5271ae8d83b)

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -5,6 +5,7 @@ each other. A global comparison is not done.
 """
 import numpy as np
 from copy import deepcopy
+from mpi4py import MPI
 
 from .adaptivity import AdaptivityCalculator
 from ..micro_simulation import create_simulation_class
@@ -76,7 +77,12 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         self._update_similarity_dists(dt, data_for_adaptivity)
 
-        self._max_similarity_dist = np.amax(self._similarity_dists)
+        self._local_max_similarity_dist = np.amax(self._similarity_dists)
+
+        # Gather maximum similarity distance from every rank, and use the global maximum distance
+        self._max_similarity_dist = self._comm_world.allreduce(
+            self._local_max_similarity_dist, op=MPI.MAX
+        )
 
         self._update_active_sims()
 


### PR DESCRIPTION
In local adaptivity, each rank computes its own similarity distance matrix by comparing simulations on the rank, and takes the maximum similarity distance from this matrix. This PR adds a global operation so that each rank uses the globally maximum similarity distance.

Checklist:

- [ ] ~~I made sure that the CI passed before I ask for a review.~~
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
