### PR TITLE
Fix bug in load balancing when a rank has exactly as many active simulation as the global average

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fix bug in load balancing when a rank has exactly as many active simulation as the global average [#200](https://github.com/precice/micro-manager/pull/200)
 - Use global maximum similarity distance in local adaptivity [#197](https://github.com/precice/micro-manager/pull/197)
 - Log adaptivity metrics at t=0 [#194](https://github.com/precice/micro-manager/pull/194)
 - Use `|` delimiter in CSV files of adaptivity metrics data [#193](https://github.com/precice/micro-manager/pull/193)

--- a/micro_manager/adaptivity/global_adaptivity_lb.py
+++ b/micro_manager/adaptivity/global_adaptivity_lb.py
@@ -115,14 +115,20 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
         f_avg_active_sims = math.floor(avg_active_sims - self._threshold)
         c_avg_active_sims = math.ceil(avg_active_sims + self._threshold)
 
-        if n_active_sims_local < f_avg_active_sims:
-            recv_sims = f_avg_active_sims - n_active_sims_local
-        elif n_active_sims_local == f_avg_active_sims:
-            recv_sims += 1
-        elif n_active_sims_local > c_avg_active_sims:
-            send_sims = n_active_sims_local - c_avg_active_sims
-        elif n_active_sims_local == c_avg_active_sims:
-            send_sims += 1
+        if f_avg_active_sims == c_avg_active_sims:
+            if n_active_sims_local < avg_active_sims:
+                recv_sims = int(avg_active_sims) - n_active_sims_local
+            elif n_active_sims_local > avg_active_sims:
+                send_sims = int(n_active_sims_local) - avg_active_sims
+        else:
+            if n_active_sims_local < f_avg_active_sims:
+                recv_sims = f_avg_active_sims - n_active_sims_local
+            elif n_active_sims_local == f_avg_active_sims:
+                recv_sims += 1
+            elif n_active_sims_local > c_avg_active_sims:
+                send_sims = n_active_sims_local - c_avg_active_sims
+            elif n_active_sims_local == c_avg_active_sims:
+                send_sims += 1
 
         # Number of active sims that each rank wants to send and receive
         global_send_sims = self._comm_world.allgather(send_sims)


### PR DESCRIPTION
Checklist:

- [ ] ~~I made sure that the CI passed before I ask for a review.~~
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
