### PR TITLE
Fix ordering of global IDs of micro simulation for load balancing to ensure consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed ordering of global IDs of micro simulation for load balancing to ensure consistency [#210](https://github.com/precice/micro-manager/pull/210)
 - Initiated triggering of load balancing at the start of the simulation when adaptivity is triggered [#207](https://github.com/precice/micro-manager/pull/207)
 - Added functionality to adaptively switch micro-scale models [#198](https://github.com/precice/micro-manager/pull/198)
 - Changed locations of profiling sections in the code base to reflect operations being profiled correctly [#205](https://github.com/precice/micro-manager/pull/205)

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -362,6 +362,10 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                     # Remove the picked global id from the rank list
                     gid_list.pop(0)
 
+        # for gid_list in active_gids_all_ranks:
+        #     for gid in gid_list:
+        #         active_gids_to_iterate.append(gid)
+
         # Update the set of active micro sims
         active_gids_to_check = active_gids_to_iterate.copy()
         for gid in active_gids_to_iterate:

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -362,10 +362,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                     # Remove the picked global id from the rank list
                     gid_list.pop(0)
 
-        # for gid_list in active_gids_all_ranks:
-        #     for gid in gid_list:
-        #         active_gids_to_iterate.append(gid)
-
         # Update the set of active micro sims
         active_gids_to_check = active_gids_to_iterate.copy()
         for gid in active_gids_to_iterate:

--- a/micro_manager/adaptivity/global_adaptivity_lb.py
+++ b/micro_manager/adaptivity/global_adaptivity_lb.py
@@ -114,7 +114,7 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
             if n_active_sims_local < avg_active_sims:
                 recv_sims = int(avg_active_sims) - n_active_sims_local
             elif n_active_sims_local > avg_active_sims:
-                send_sims = int(n_active_sims_local) - avg_active_sims
+                send_sims = n_active_sims_local - int(avg_active_sims)
         else:
             if n_active_sims_local < f_avg_active_sims:
                 recv_sims = f_avg_active_sims - n_active_sims_local
@@ -257,7 +257,7 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
                     # Get the global IDs to move
                     global_ids_of_sims_to_move = rank_wise_global_ids_of_active_sims[
                         send_rank
-                    ][0 : global_recv_sims[recv_rank]]
+                    ][0 : int(global_recv_sims[recv_rank])]
 
                     global_send_map[send_rank].append(
                         (global_ids_of_sims_to_move, recv_rank)
@@ -271,7 +271,7 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
 
                     # Remove the global IDs which are already mapped for moving
                     del rank_wise_global_ids_of_active_sims[send_rank][
-                        0 : global_recv_sims[recv_rank]
+                        0 : int(global_recv_sims[recv_rank])
                     ]
 
                     if count < len(recv_ranks) - 1:
@@ -282,16 +282,20 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
                     # Get the global IDs to move
                     global_ids_of_sims_to_move = rank_wise_global_ids_of_active_sims[
                         send_rank
-                    ][0:sims]
+                    ][0 : int(sims)]
 
-                    global_send_map[send_rank].append((sims, recv_rank))
+                    global_send_map[send_rank].append(
+                        (global_ids_of_sims_to_move, recv_rank)
+                    )
 
-                    global_recv_map[recv_rank].append((sims, send_rank))
+                    global_recv_map[recv_rank].append(
+                        (global_ids_of_sims_to_move, send_rank)
+                    )
 
                     global_recv_sims[recv_rank] -= sims
 
                     # Remove the global IDs which are already mapped for moving
-                    del rank_wise_global_ids_of_active_sims[send_rank][0:sims]
+                    del rank_wise_global_ids_of_active_sims[send_rank][0 : int(sims)]
 
                     sims = 0
 

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -48,23 +48,41 @@ class DomainDecomposer:
 
         dims = len(ranks_per_axis)
 
+        rank_in_axis = None
         if dims == 3:
-            for z in range(ranks_per_axis[2]):
+            for x in range(ranks_per_axis[0]):
                 for y in range(ranks_per_axis[1]):
-                    for x in range(ranks_per_axis[0]):
+                    for z in range(ranks_per_axis[2]):
                         n = (
-                            x
-                            + y * ranks_per_axis[0]
-                            + z * ranks_per_axis[0] * ranks_per_axis[1]
+                            y
+                            + z * ranks_per_axis[1]
+                            + x * ranks_per_axis[1] * ranks_per_axis[2]
                         )
                         if n == self._rank:
                             rank_in_axis = [x, y, z]
+                            break
+                    if rank_in_axis is not None:
+                        break
+                if rank_in_axis is not None:
+                    break
         elif dims == 2:
-            for y in range(ranks_per_axis[1]):
-                for x in range(ranks_per_axis[0]):
+            for x in range(ranks_per_axis[0]):
+                for y in range(ranks_per_axis[1]):
                     n = x + y * ranks_per_axis[0]
                     if n == self._rank:
                         rank_in_axis = [x, y]
+                        break
+                if rank_in_axis is not None:
+                    break
+        else:
+            raise ValueError(
+                f"Unsupported number of dimensions: {dims}. Only 2D and 3D domains are supported."
+            )
+
+        if rank_in_axis is None:
+            raise RuntimeError(
+                f"Could not determine rank position in domain decomposition for rank {self._rank}"
+            )
 
         dx = []
         for d in range(dims):
@@ -74,15 +92,57 @@ class DomainDecomposer:
 
         mesh_bounds = []
         for d in range(dims):
-            if rank_in_axis[d] > 0:
-                mesh_bounds.append(macro_bounds[d * 2] + rank_in_axis[d] * dx[d])
-                mesh_bounds.append(macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx[d])
-            elif rank_in_axis[d] == 0:
-                mesh_bounds.append(macro_bounds[d * 2])
-                mesh_bounds.append(macro_bounds[d * 2] + dx[d])
+            mesh_bounds.append(macro_bounds[d * 2] + rank_in_axis[d] * dx[d])
+            mesh_bounds.append(macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx[d])
 
             # Adjust the maximum bound to be exactly the domain size
             if rank_in_axis[d] + 1 == ranks_per_axis[d]:
                 mesh_bounds[d * 2 + 1] = macro_bounds[d * 2 + 1]
 
         return mesh_bounds
+
+    def decompose_micro_simulations(
+        self, macro_bounds: list, ranks_per_axis: list, macro_coords: np.ndarray
+    ) -> tuple[int, list]:
+        """
+        Decompose the micro simulations among all ranks based on their positions in the macro domain.
+
+        Parameters
+        ----------
+        macro_bounds : list
+            List containing upper and lower bounds of the macro domain.
+            Format in 2D is [x_min, x_max, y_min, y_max]
+            Format in 3D is [x_min, x_max, y_min, y_max, z_min, z_max]
+        ranks_per_axis : list
+            List containing axis wise ranks for a parallel run
+            Format in 2D is [ranks_x, ranks_y]
+            Format in 3D is [ranks_x, ranks_y, ranks_z]
+        macro_coords : numpy.ndarray
+            The coordinates associated to the IDs and corresponding data values (dim * size)
+
+        Returns
+        -------
+        micro_sims_on_rank : int
+            Number of micro simulations assigned to this rank.
+        macro_coords_on_this_rank : list
+            List of macro coordinates assigned to this rank.
+        """
+        local_mesh_bounds = self.decompose_macro_domain(macro_bounds, ranks_per_axis)
+
+        macro_coords_on_this_rank = []
+
+        micro_sims_on_rank = 0
+        for position in macro_coords:
+            inside = True
+            for d in range(len(ranks_per_axis)):
+                if not (
+                    position[d] >= local_mesh_bounds[d * 2]
+                    and position[d] <= local_mesh_bounds[d * 2 + 1]
+                ):
+                    inside = False
+                    break
+            if inside:
+                macro_coords_on_this_rank.append(position)
+                micro_sims_on_rank += 1
+
+        return micro_sims_on_rank, macro_coords_on_this_rank

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -48,41 +48,25 @@ class DomainDecomposer:
 
         dims = len(ranks_per_axis)
 
-        rank_in_axis = None
         if dims == 3:
-            for x in range(ranks_per_axis[0]):
+            for z in range(ranks_per_axis[2]):
                 for y in range(ranks_per_axis[1]):
-                    for z in range(ranks_per_axis[2]):
+                    for x in range(ranks_per_axis[0]):
                         n = (
-                            y
-                            + z * ranks_per_axis[1]
-                            + x * ranks_per_axis[1] * ranks_per_axis[2]
+                            x
+                            + y * ranks_per_axis[0]
+                            + z * ranks_per_axis[0] * ranks_per_axis[1]
                         )
                         if n == self._rank:
                             rank_in_axis = [x, y, z]
-                            break
-                    if rank_in_axis is not None:
-                        break
-                if rank_in_axis is not None:
-                    break
         elif dims == 2:
-            for x in range(ranks_per_axis[0]):
-                for y in range(ranks_per_axis[1]):
+            for y in range(ranks_per_axis[1]):
+                for x in range(ranks_per_axis[0]):
                     n = x + y * ranks_per_axis[0]
                     if n == self._rank:
                         rank_in_axis = [x, y]
-                        break
-                if rank_in_axis is not None:
-                    break
         else:
-            raise ValueError(
-                f"Unsupported number of dimensions: {dims}. Only 2D and 3D domains are supported."
-            )
-
-        if rank_in_axis is None:
-            raise RuntimeError(
-                f"Could not determine rank position in domain decomposition for rank {self._rank}"
-            )
+            raise ValueError("Domain decomposition only supports 2D and 3D cases.")
 
         dx = []
         for d in range(dims):
@@ -92,8 +76,12 @@ class DomainDecomposer:
 
         mesh_bounds = []
         for d in range(dims):
-            mesh_bounds.append(macro_bounds[d * 2] + rank_in_axis[d] * dx[d])
-            mesh_bounds.append(macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx[d])
+            if rank_in_axis[d] > 0:
+                mesh_bounds.append(macro_bounds[d * 2] + rank_in_axis[d] * dx[d])
+                mesh_bounds.append(macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx[d])
+            elif rank_in_axis[d] == 0:
+                mesh_bounds.append(macro_bounds[d * 2])
+                mesh_bounds.append(macro_bounds[d * 2] + dx[d])
 
             # Adjust the maximum bound to be exactly the domain size
             if rank_in_axis[d] + 1 == ranks_per_axis[d]:

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -20,7 +20,7 @@ class DomainDecomposer:
         self._rank = rank
         self._size = size
 
-    def decompose_macro_domain(self, macro_bounds: list, ranks_per_axis: list) -> list:
+    def get_local_mesh_bounds(self, macro_bounds: list, ranks_per_axis: list) -> list:
         """
         Decompose the macro domain equally among all ranks, if the Micro Manager is run in parallel.
 
@@ -101,7 +101,7 @@ class DomainDecomposer:
 
         return mesh_bounds
 
-    def decompose_micro_simulations(
+    def get_local_sims_and_macro_coords(
         self, macro_bounds: list, ranks_per_axis: list, macro_coords: np.ndarray
     ) -> tuple[int, list]:
         """
@@ -127,7 +127,7 @@ class DomainDecomposer:
         macro_coords_on_this_rank : list
             List of macro coordinates assigned to this rank.
         """
-        local_mesh_bounds = self.decompose_macro_domain(macro_bounds, ranks_per_axis)
+        local_mesh_bounds = self.get_local_mesh_bounds(macro_bounds, ranks_per_axis)
 
         macro_coords_on_this_rank = []
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -36,7 +36,6 @@ from .domain_decomposition import DomainDecomposer
 
 from .micro_simulation import create_simulation_class
 from .tools.logging_wrapper import Logger
-from .tools.misc import divide_in_parts
 
 
 try:
@@ -210,12 +209,6 @@ class MicroManagerCoupling(MicroManager):
 
                     active_sim_gids = (
                         self._adaptivity_controller.get_active_sim_global_ids()
-                    )
-
-                    self._logger.log_info(
-                        "time-window {} - Active simulations IDs: {}".format(
-                            self._n, active_sim_gids
-                        )
                     )
 
                     for gid in active_sim_gids:
@@ -424,7 +417,7 @@ class MicroManagerCoupling(MicroManager):
             )
 
         if self._is_parallel and not self._is_adaptivity_with_load_balancing:
-            coupling_mesh_bounds = domain_decomposer.decompose_macro_domain(
+            coupling_mesh_bounds = domain_decomposer.get_local_mesh_bounds(
                 self._macro_bounds, self._ranks_per_axis
             )
         else:  # When serial or load balancing, the whole macro domain is assigned to one/each rank
@@ -448,25 +441,14 @@ class MicroManagerCoupling(MicroManager):
             self._mesh_vertex_coords,
         ) = self._participant.get_mesh_vertex_ids_and_coordinates(self._macro_mesh_name)
 
-        self._logger.log_info(
-            "preCICE returned the vertex IDs: {}".format(self._mesh_vertex_ids)
-        )
-        self._logger.log_info(
-            "preCICE returned the vertex coordinates: {}".format(
-                self._mesh_vertex_coords
-            )
-        )
-
         if self._mesh_vertex_coords.size == 0:
             raise Exception("Macro mesh has no vertices.")
 
         if self._is_adaptivity_with_load_balancing:
-            # total_number_of_sims, _ = self._mesh_vertex_coords.shape
-            # cpu_wise_number_of_sims = divide_in_parts(total_number_of_sims, self._size)
             (
                 self._local_number_of_sims,
                 local_macro_coords,
-            ) = domain_decomposer.decompose_micro_simulations(
+            ) = domain_decomposer.get_local_sims_and_macro_coords(
                 self._macro_bounds, self._ranks_per_axis, self._mesh_vertex_coords
             )
         else:
@@ -527,17 +509,21 @@ class MicroManagerCoupling(MicroManager):
         self._global_ids_of_local_sims = []  # DECLARATION
 
         if self._is_adaptivity_with_load_balancing:
+            # Create a set of global coordinate indices for faster lookup
+            coord_to_index = {
+                tuple(coord): i for i, coord in enumerate(self._mesh_vertex_coords)
+            }
+
+            # Set global IDs based on the coordinate ordering in preCICE to be consistent with the scenario without load balancing
             for coords in local_macro_coords:
-                # Find the index of coords in the global mesh vertex coords
-                for i, global_coord in enumerate(self._mesh_vertex_coords):
-                    if np.allclose(coords, global_coord):
-                        self._global_ids_of_local_sims.append(i)
-                        break
+                coord_tuple = tuple(coords)
+                self._global_ids_of_local_sims.append(coord_to_index[coord_tuple])
         else:
             sim_id = np.sum(nms_all_ranks[: self._rank])
             for i in range(self._local_number_of_sims):
                 self._global_ids_of_local_sims.append(sim_id)
                 sim_id += 1
+
         # Setup for simulation crashes
         self._has_sim_crashed = [False] * self._local_number_of_sims
         if self._interpolate_crashed_sims:
@@ -826,10 +812,6 @@ class MicroManagerCoupling(MicroManager):
         else:
             read_vertex_ids = self._mesh_vertex_ids
 
-        self._logger.log_info(
-            "Reading data from preCICE for vertex IDs: {}".format(read_vertex_ids)
-        )
-
         for name in self._read_data_names:
             read_data[name] = []
 
@@ -845,8 +827,6 @@ class MicroManagerCoupling(MicroManager):
             if self._is_adaptivity_on:
                 if name in self._adaptivity_macro_data_names:
                     self._data_for_adaptivity[name] = read_data[name]
-
-        self._logger.log_info("Data read from preCICE: {}".format(read_data))
 
         return [dict(zip(read_data, t)) for t in zip(*read_data.values())]
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -212,6 +212,12 @@ class MicroManagerCoupling(MicroManager):
                         self._adaptivity_controller.get_active_sim_global_ids()
                     )
 
+                    self._logger.log_info(
+                        "time-window {} - Active simulations IDs: {}".format(
+                            self._n, active_sim_gids
+                        )
+                    )
+
                     for gid in active_sim_gids:
                         self._micro_sims_active_steps[gid] += 1
 
@@ -416,20 +422,17 @@ class MicroManagerCoupling(MicroManager):
                 self._rank,
                 self._size,
             )
+
+        if self._is_parallel and not self._is_adaptivity_with_load_balancing:
             coupling_mesh_bounds = domain_decomposer.decompose_macro_domain(
                 self._macro_bounds, self._ranks_per_axis
             )
-        else:
+        else:  # When serial or load balancing, the whole macro domain is assigned to one/each rank
             coupling_mesh_bounds = self._macro_bounds
 
-        if not self._is_adaptivity_with_load_balancing:
-            self._participant.set_mesh_access_region(
-                self._macro_mesh_name, coupling_mesh_bounds
-            )
-        else:  # When load balancing is on, each rank accesses the complete macro mesh
-            self._participant.set_mesh_access_region(
-                self._macro_mesh_name, self._macro_bounds
-            )
+        self._participant.set_mesh_access_region(
+            self._macro_mesh_name, coupling_mesh_bounds
+        )
 
         self._participant.stop_last_profiling_section()
 
@@ -445,15 +448,29 @@ class MicroManagerCoupling(MicroManager):
             self._mesh_vertex_coords,
         ) = self._participant.get_mesh_vertex_ids_and_coordinates(self._macro_mesh_name)
 
+        self._logger.log_info(
+            "preCICE returned the vertex IDs: {}".format(self._mesh_vertex_ids)
+        )
+        self._logger.log_info(
+            "preCICE returned the vertex coordinates: {}".format(
+                self._mesh_vertex_coords
+            )
+        )
+
         if self._mesh_vertex_coords.size == 0:
             raise Exception("Macro mesh has no vertices.")
 
-        if not self._is_adaptivity_with_load_balancing:
+        if self._is_adaptivity_with_load_balancing:
+            # total_number_of_sims, _ = self._mesh_vertex_coords.shape
+            # cpu_wise_number_of_sims = divide_in_parts(total_number_of_sims, self._size)
+            (
+                self._local_number_of_sims,
+                local_macro_coords,
+            ) = domain_decomposer.decompose_micro_simulations(
+                self._macro_bounds, self._ranks_per_axis, self._mesh_vertex_coords
+            )
+        else:
             self._local_number_of_sims, _ = self._mesh_vertex_coords.shape
-        else:  # When load balancing, each rank needs to manually determine how many micro simulations it starts with
-            total_number_of_sims, _ = self._mesh_vertex_coords.shape
-            cpu_wise_number_of_sims = divide_in_parts(total_number_of_sims, self._size)
-            self._local_number_of_sims = cpu_wise_number_of_sims[self._rank]
 
         if self._local_number_of_sims == 0:
             if self._is_parallel:
@@ -506,13 +523,21 @@ class MicroManagerCoupling(MicroManager):
             for name in self._adaptivity_data_names:
                 self._data_for_adaptivity[name] = [0] * self._local_number_of_sims
 
-        # Create lists of local and global IDs
-        sim_id = np.sum(nms_all_ranks[: self._rank])
+        # Create lists of global IDs
         self._global_ids_of_local_sims = []  # DECLARATION
-        for i in range(self._local_number_of_sims):
-            self._global_ids_of_local_sims.append(sim_id)
-            sim_id += 1
 
+        if self._is_adaptivity_with_load_balancing:
+            for coords in local_macro_coords:
+                # Find the index of coords in the global mesh vertex coords
+                for i, global_coord in enumerate(self._mesh_vertex_coords):
+                    if np.allclose(coords, global_coord):
+                        self._global_ids_of_local_sims.append(i)
+                        break
+        else:
+            sim_id = np.sum(nms_all_ranks[: self._rank])
+            for i in range(self._local_number_of_sims):
+                self._global_ids_of_local_sims.append(sim_id)
+                sim_id += 1
         # Setup for simulation crashes
         self._has_sim_crashed = [False] * self._local_number_of_sims
         if self._interpolate_crashed_sims:
@@ -801,6 +826,10 @@ class MicroManagerCoupling(MicroManager):
         else:
             read_vertex_ids = self._mesh_vertex_ids
 
+        self._logger.log_info(
+            "Reading data from preCICE for vertex IDs: {}".format(read_vertex_ids)
+        )
+
         for name in self._read_data_names:
             read_data[name] = []
 
@@ -816,6 +845,8 @@ class MicroManagerCoupling(MicroManager):
             if self._is_adaptivity_on:
                 if name in self._adaptivity_macro_data_names:
                     self._data_for_adaptivity[name] = read_data[name]
+
+        self._logger.log_info("Data read from preCICE: {}".format(read_data))
 
         return [dict(zip(read_data, t)) for t in zip(*read_data.values())]
 

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -30,7 +30,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [2, 2]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 2
-        mesh_bounds = domain_decomposer.decompose_macro_domain(
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_2d, ranks_per_axis
         )
 
@@ -45,7 +45,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [2, 2, 1]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.decompose_macro_domain(
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
 
@@ -60,7 +60,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [1, 2, 5]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.decompose_macro_domain(
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
 
@@ -75,7 +75,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [4, 1, 8]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.decompose_macro_domain(
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
 
@@ -90,7 +90,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [8, 2, 1]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.decompose_macro_domain(
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
 


### PR DESCRIPTION
The ordering of global IDs for micro simulations was done serially, from the lowest to the highest rank. While this does not cause any problems in scenarios with global adaptivity, it is a problem when load balancing is used. When load balancing is used, each rank directly accesses the full macro mesh coordinates but defines micro simulations for only a subset of the total coordinates. The macro coordinates are divided amongst all ranks as equally as possible. This results in different coordinates across ranks, compared to when load balancing is not used. This is because when load balancing is not used, the Micro Manager decomposes the macro domain into as many boxes as there are ranks. Each rank then directly accesses the macro coordinates within its box. This discrepancy leads to different sets of active and inactive problems when load balancing is used, significantly increasing the numerical error compared to the case without load balancing.

Now the Micro Manager decomposes the macro domain into boxes even when load balancing is used, and each rank assigns global IDs according to the ordering of coordinates in preCICE. This makes the initial set of active and inactive problems nearly consistent across scenarios with and without load balancing, thereby reducing numerical error.

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
