### PR TITLE
Fix URL in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ The Micro Manager package on PyPI is [micro-manager-precice](https://pypi.org/pr
 pip install micro-manager-precice
 ```
 
-To enable [crash handling by interpolation](tooling-micro-manager-running.html/#what-happens-when-a-micro-simulation-crashes), the optional dependency sklearn is required. To install with sklearn, run
+To enable [crash handling by interpolation](tooling-micro-manager-running.html#what-happens-when-a-micro-simulation-crashes), the optional dependency sklearn is required. To install with sklearn, run
 
 ```bash
 pip install micro-manager-precice[sklearn]


### PR DESCRIPTION
In https://precice.org/tooling-micro-manager-installation.html

there is a link to https://precice.org/tooling-micro-manager-running.html/

which should be https://precice.org/tooling-micro-manager-running.html

I would even argue that these URLs should be absolute, not relative, since they can be clicked from this repository.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`. -> N/A
- If necessary, I made changes to the documentation and/or added new content. -> N/A
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
