### PR TITLE
Change default values in the configuration and simplify configuration documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Changed default values of adaptivity metrics output and similarity distance calculation norm [#213](https://github.com/precice/micro-manager/pull/213)
 - Fixed ordering of global IDs of micro simulation for load balancing to ensure consistency [#210](https://github.com/precice/micro-manager/pull/210)
 - Initiated triggering of load balancing at the start of the simulation when adaptivity is triggered [#207](https://github.com/precice/micro-manager/pull/207)
 - Added functionality to adaptively switch micro-scale models [#198](https://github.com/precice/micro-manager/pull/198)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,8 +33,10 @@ Parameter | Description
 --- | ---
 `micro_file_name` | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.
 `output_directory` | Path to output directory for logging and performance metrics. Directory is created if not existing already.
-`memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels. All output is to a CSV file with the peak memory usage (RSS) in every time window, in MBs.
-`memory_usage_output_n` | Frequency of output of memory usage (integer which is number of time windows).
+`memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels.
+`memory_usage_output_n` | Interval of output.
+
+All output is to a CSV file with the peak memory usage (RSS) in every time window, in MBs.
 
 Apart from the base settings, there are three main sections in the configuration file, [coupling parameters](#coupling-parameters), [simulation parameters](#simulation-parameters), and [diagnostics](#diagnostics).
 
@@ -42,16 +44,16 @@ Apart from the base settings, there are three main sections in the configuration
 
 Parameter | Description
 --- | ---
-`precice_config_file_name` |  Path to the preCICE XML configuration file from the current working directory.
-`macro_mesh_name` |  Name of the macro mesh as stated in the preCICE configuration.
-`read_data_names` |  A list with the names of the data to be read from preCICE.
-`write_data_names` |  A list with the names of the data to be written to preCICE.
+`precice_config_file_name` | Path to the preCICE XML configuration file from the current working directory.
+`macro_mesh_name` | Name of the macro mesh as stated in the preCICE configuration.
+`read_data_names` | List with the names of the data to be read from preCICE.
+`write_data_names` | List with the names of the data to be written to preCICE.
 
 ## Simulation Parameters
 
 Parameter | Description
 --- | ---
-`macro_domain_bounds`| Minimum and maximum bounds of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]` in 3D and `[xmin, xmax, ymin, ymax]` in 2D.
+`macro_domain_bounds` | Minimum and maximum bounds of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]` in 3D and `[xmin, xmax, ymin, ymax]` in 2D.
 Domain decomposition parameters | See section on [domain decomposition](#domain-decomposition). But default, the Micro Manager assumes serial execution.
 Adaptivity parameters | See section on [adaptivity](#adaptivity). By default, adaptivity is disabled.
 Load balancing parameters | See section on [load balancing](#load-balancing). By default, load balancing is disabled.
@@ -59,10 +61,10 @@ Load balancing parameters | See section on [load balancing](#load-balancing). By
 
 ## Diagnostics
 
-Parameter | Description
---- | ---
-`data_from_micro_sims` | A Python dictionary with the names of the data from the micro simulation to be written to VTK files as keys and `"scalar"` or `"vector"` as values.
-`micro_output_n`|  Frequency of calling the optional output functionality of the micro simulation in terms of number of time steps. If not given, `micro_sim.output()` is called every time step.
+Parameter | Description | Default
+--- | --- | ---
+`data_from_micro_sims` | Dictionary with the names of the data from the micro simulation to be written to VTK files as keys and `"scalar"` or `"vector"` as values. | -
+`micro_output_n` |  Frequency of calling the optional output functionality of the micro simulation in terms of number of time steps. | 1
 
 ### Adding diagnostics in the preCICE XML configuration
 
@@ -97,20 +99,20 @@ See the [adaptivity](tooling-micro-manager-adaptivity.html) documentation for a 
 
 To turn on adaptivity, set `"adaptivity": true` in `simulation_params`. Then under `adaptivity_settings` set the following variables:
 
-Parameter | Description
---- | ---
-`type` | Set to either `local` or `global`. The type of adaptivity matters when the Micro Manager is run in parallel. `local` means comparing micro simulations within a local partitioned domain for similarity. `global` means comparing micro simulations from all partitions, so over the entire domain.
-`data` | List of names of data which are to be used to calculate if micro-simulations are similar or not. For example `["temperature", "porosity"]`.
-`adaptivity_every_n_time_windows` | Frequency of adaptivity computation (integer which is number of time windows).
-`output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise adaptivity metrics. `global` outputs global averaged metrics. `all` outputs both local and global metrics.
-`output_n` | Frequency of output of adaptivity metrics (integer which is number of time windows).
-`history_param` | History parameter $$ \Lambda $$, set as $$ \Lambda >= 0 $$.
-`coarsening_constant` | Coarsening constant $$ C_c $$, set as $$ 0 =< C_c < 1 $$.
-`refining_constant` | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$.
-`every_implicit_iteration` | If `true`, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration. Default `false`.
-`similarity_measure`| Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*. Default `L1`.
-`lazy_initialization` | Set to `true` to lazily create and initialize micro simulations. If selected, micro simulation objects are created only when the micro simulation is activated for the first time. Default: `false`.
-`load_balancing` | Set to `true` to dynamically balance simulations for parallel runs. Default `false`. See [load balancing settings](#load-balancing) below.
+Parameter | Description | Default
+--- | --- | ---
+`type` | Set to either `local` or `global`. The type of adaptivity matters when the Micro Manager is run in parallel. `local` means comparing micro simulations within a local partitioned domain for similarity. `global` means comparing micro simulations from all partitions, so over the entire domain. | None
+`data` | List of names of data which are to be used to calculate if micro-simulations are similar or not. For example `["temperature", "porosity"]`. | -
+`adaptivity_every_n_time_windows` | Interval of adaptivity computation. | 1
+`output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise adaptivity metrics. `global` outputs global averaged metrics. `all` outputs both local and global metrics. | Empty string.
+`output_n` | Frequency of output of adaptivity metrics. | 1
+`history_param` | History parameter $$ \Lambda $$, set as $$ \Lambda >= 0 $$. | 0.5
+`coarsening_constant` | Coarsening constant $$ C_c $$, set as $$ 0 =< C_c < 1 $$. | 0.5
+`refining_constant` | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$. | 0.5
+`every_implicit_iteration` | If `true`, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration. | `false`
+`similarity_measure` | Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*. | `L2rel`
+`lazy_initialization` | Set to `true` to lazily create and initialize micro simulations. If selected, micro simulation objects are created only when the micro simulation is activated for the first time. | `false`
+`load_balancing` | Set to `true` to dynamically balance simulations for parallel runs. See [load balancing settings](#load-balancing) below. | `false`
 
 Example of adaptivity configuration is
 
@@ -159,10 +161,8 @@ Example of model adaptivity configuration is
 
 If adaptivity is used, the Micro Manager will attempt to write two scalar data per micro simulation to preCICE, called `active_state` and `active_steps`.
 
-Parameter | Description
---- | ---
-`active_state` | `1` if the micro simulation is active in the time window, and `0` if inactive.
-`active_steps` | Summation of `active_state` up to the current time window.
+- `active_state` is `1` if the micro simulation is active in the time window, and `0` if inactive.
+- `active_steps` is summation of `active_state` up to the current time window.
 
 The Micro Manager uses the output functionality of preCICE, hence these data sets need to be manually added to the preCICE configuration file. In the mesh and the participant Micro-Manager add the following lines:
 
@@ -185,11 +185,11 @@ The Micro Manager uses the output functionality of preCICE, hence these data set
 
 Under `load_balancing_settings`, the following parameters can be set
 
-Parameter | Description
---- | ---
-`every_n_time_windows` | Frequency of balancing the simulations. Default `1` (every time window).
-`balancing_threshold` | Integer threshold value. Default `0`.
-`balance_inactive_sims` | If `true`, inactive simulations associated to redistributed active simulations are moved to the new ranks of the active simulations. See [balance inactive simulations](tooling-micro-manager-adaptivity.html#balance-inactive-simulations). Default `false`.
+Parameter | Description | Default
+--- | --- | ---
+`every_n_time_windows` | Frequency of balancing the simulations. | `1`
+`balancing_threshold` | Integer threshold value. | `0`
+`balance_inactive_sims` | If `true`, inactive simulations associated to redistributed active simulations are moved to the new ranks of the active simulations. See [balance inactive simulations](tooling-micro-manager-adaptivity.html#balance-inactive-simulations). | `false`
 
 ## Interpolate a crashed micro simulation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,34 +7,16 @@ summary: Provide a JSON file to configure the Micro Manager.
 
 {% note %} In the preCICE XML configuration the Micro Manager is a participant with the name `Micro-Manager`. {% endnote %}
 
-The Micro Manager is configured with a JSON file. An example configuration file looks like
-
-```json
-{
-    "micro_file_name": "micro_solver",
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "macro-mesh",
-        "read_data_names": ["temperature", "heat-flux"],
-        "write_data_names": ["porosity", "conductivity"]
-    },
-    "simulation_params": {
-        "macro_domain_bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
-        "micro_dt": 1.0
-    }
-}
-```
-
-This example configuration file is in [`examples/micro-manager-config.json`](https://github.com/precice/micro-manager/tree/develop/examples/micro-manager-config.json).
+The Micro Manager is configured with a JSON file. Several parameters can be set.
 
 ## Micro Manager Configuration
 
-Parameter | Description
+Parameter | Description | Default
 --- | ---
-`micro_file_name` | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.
-`output_directory` | Path to output directory for logging and performance metrics. Directory is created if not existing already.
-`memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels.
-`memory_usage_output_n` | Interval of output.
+`micro_file_name` | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed. | -
+`output_directory` | Path to output directory for logging and performance metrics. Directory is created if not existing already. | `.`
+`memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels. | Empty string.
+`memory_usage_output_n` | Interval of output. | 1
 
 All output is to a CSV file with the peak memory usage (RSS) in every time window, in MBs.
 
@@ -51,20 +33,22 @@ Parameter | Description
 
 ## Simulation Parameters
 
-Parameter | Description
---- | ---
-`macro_domain_bounds` | Minimum and maximum bounds of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]` in 3D and `[xmin, xmax, ymin, ymax]` in 2D.
-Domain decomposition parameters | See section on [domain decomposition](#domain-decomposition). But default, the Micro Manager assumes serial execution.
-Adaptivity parameters | See section on [adaptivity](#adaptivity). By default, adaptivity is disabled.
-Load balancing parameters | See section on [load balancing](#load-balancing). By default, load balancing is disabled.
-`micro_dt` | Initial time window size (dt) of the micro simulation.
+Parameter | Description | Default
+--- | --- | ---
+`macro_domain_bounds` | Minimum and maximum bounds of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]` in 3D and `[xmin, xmax, ymin, ymax]` in 2D. | -
+`decomposition` | List of number of ranks in each axis with format `[xranks, yranks, zranks]` in 3D and `[xranks, yranks]` in 2D. | `[1, 1, 1]` or `[1, 1]`
+`micro_dt` | Initial time window size (dt) of the micro simulation. | -
+`adaptivity` | Set `true` for simulations with adaptivity. See section on [adaptivity](#adaptivity). | `false`
+`load_balancing` | Set `true` for load balancing. See section on [load balancing](#load-balancing). | `false`
+
+The total number of partitions ranks in the `decomposition` list should be the same as the number of ranks in the `mpirun` or `mpiexec` command.
 
 ## Diagnostics
 
 Parameter | Description | Default
 --- | --- | ---
 `data_from_micro_sims` | Dictionary with the names of the data from the micro simulation to be written to VTK files as keys and `"scalar"` or `"vector"` as values. | -
-`micro_output_n` |  Frequency of calling the optional output functionality of the micro simulation in terms of number of time steps. | 1
+`micro_output_n` | Frequency of calling the optional output functionality of the micro simulation in terms of number of time steps. | 1
 
 ### Adding diagnostics in the preCICE XML configuration
 
@@ -79,19 +63,6 @@ If the parameter `data_from_micro_sims` is set, the data to be output needs to b
   <export:vtu directory="Micro-Manager-output" every-n-time-windows="5"/>
 </participant>
 ```
-
-## Domain decomposition
-
-The Micro Manager can be run in parallel. For a parallel run, set the desired partitions in each axis by setting the `decomposition` parameter. For example, if the domain is 3D and the decomposition needs to be two partitions in x, one partition in y, and sixteen partitions in for z, the setting is
-
-```json
-"simulation_params": {
-    "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-    "decomposition": [2, 1, 16]
-}
-```
-
-For a 2D domain, only two values need to be set for `decomposition`. The total number of partitions provided in the `decomposition` should be the same as the number of processors provided in the `mpirun`/`mpiexec` command.
 
 ## Adaptivity
 
@@ -118,15 +89,16 @@ Example of adaptivity configuration is
 
 ```json
 "simulation_params": {
-    "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-    "adaptivity": true,
     "adaptivity_settings" {
         "type": "local",
         "data": ["temperature", "porosity"],
+        "adaptivity_every_n_time_windows": 5,
+        "output_type": "all",
+        "output_n": 5,
         "history_param": 0.5,
         "coarsening_constant": 0.3,
         "refining_constant": 0.4,
-        "every_implicit_iteration": true,
+        "every_implicit_iteration": false,
         "lazy_initialization": true
     }
 }
@@ -147,8 +119,6 @@ Example of model adaptivity configuration is
 
 ```json
 "simulation_params": {
-    "micro_dt": 1.0,
-    "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
     "model_adaptivity": true,
     "model_adaptivity_settings": {
         "micro_file_names": ["python-dummy/micro_dummy", "python-dummy/micro_dummy", "python-dummy/micro_dummy"],

--- a/docs/snapshot_configuration.md
+++ b/docs/snapshot_configuration.md
@@ -21,7 +21,7 @@ pip install h5py
 
 ## Preparation
 
-Prepare your micro simulation for the Micro Manager snapshot computation by following the instructions in the [preparation guide](tooling-micro-manager-preparation.html).
+Prepare your micro simulation for the Micro Manager snapshot computation by following the instructions in the [preparation guide](tooling-micro-manager-prepare-micro-simulation.html).
 
 Note: The `initialize()` method is not used for the snapshot computation.
 

--- a/docs/snapshot_configuration.md
+++ b/docs/snapshot_configuration.md
@@ -45,19 +45,16 @@ Configure the snapshot computation functionality with a JSON file. An example co
         "post_processing_file_name": "snapshot_postprocessing",
         "initialize_once": true,
         "output_file_name": "snapshot_data"
-    },
-    "diagnostics": {
-        "output_micro_sim_solve_time": true
     }
 }
 ```
 
 ## Micro Manager Configuration
 
-Parameter | Description
---- | ---
-`micro_file_name` | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.
-`output_directory` | Path to output directory for logging and performance metrics. Directory is created if not existing already.
+Parameter | Description | Default
+--- | --- | ---
+`micro_file_name` | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed. | -
+`output_directory` | Path to output directory for logging and performance metrics. Directory is created if not existing already. | `.`
 
 Apart from the base settings, there are three main sections in the configuration file, [coupling parameters](#coupling-parameters), [simulation parameters](#simulation-parameters), [snapshot parameters](#snapshot-parameters), and [diagnostics](#diagnostics).
 
@@ -89,9 +86,9 @@ Parameter | Description
 
 ## Diagnostics
 
-Parameter | Description
---- | ---
-`output_micro_sim_solve_time` | If `true`, the Micro Manager writes the wall clock time of the `solve()` function of each micro simulation to the database.
+Parameter | Description | Default
+--- | --- | ---
+`output_micro_sim_solve_time` | If `true`, the Micro Manager writes the wall clock time of the `solve()` function of each micro simulation to the database. | `false`
 
 ## Running
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -50,7 +50,7 @@ class Config:
         self._adaptivity_coarsening_constant = 0.5
         self._adaptivity_refining_constant = 0.5
         self._adaptivity_every_implicit_iteration = False
-        self._adaptivity_similarity_measure = "L1"
+        self._adaptivity_similarity_measure = "L2rel"
         self._adaptivity_output_type = ""
         self._adaptivity_output_n = 1
 
@@ -306,9 +306,8 @@ class Config:
                 )
             except BaseException:
                 self._logger.log_info_rank_zero(
-                    "No adaptivity output type provided. Defaulting to 'local'."
+                    "No adaptivity output type provided. No metrics will be output."
                 )
-                self._adaptivity_output_type = "local"
 
             try:
                 self._adaptivity_output_n = self._data["simulation_params"][

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -137,6 +137,14 @@ class MicroManagerCoupling(MicroManager):
                 self._load_balancing_n = self._config.get_load_balancing_n()
 
         self._adaptivity_n = self._config.get_adaptivity_n()
+
+        adaptivity_output_type = self._config.get_adaptivity_output_type()
+
+        if adaptivity_output_type == "":
+            self._adaptivity_output_required = False
+        else:
+            self._adaptivity_output_required = True
+
         self._adaptivity_output_n = self._config.get_adaptivity_output_n()
 
         self._is_model_adaptivity_on = self._config.turn_on_model_adaptivity()
@@ -306,8 +314,10 @@ class MicroManagerCoupling(MicroManager):
                             if sim:
                                 sim.output()
 
-                if self._is_adaptivity_on and (
-                    self._n % self._adaptivity_output_n == 0
+                if (
+                    self._is_adaptivity_on
+                    and self._adaptivity_output_required
+                    and (self._n % self._adaptivity_output_n == 0)
                 ):
                     self._adaptivity_controller.log_metrics(self._n)
 
@@ -333,7 +343,11 @@ class MicroManagerCoupling(MicroManager):
             mem_usage_n.append(self._n)
 
         # Final adaptivity metrics logging at the end of the simulation if not already logged at the end of the last time window
-        if self._is_adaptivity_on and self._n % self._adaptivity_output_n != 0:
+        if (
+            self._is_adaptivity_on
+            and self._adaptivity_output_required
+            and self._n % self._adaptivity_output_n != 0
+        ):
             self._adaptivity_controller.log_metrics(self._n)
 
         if (

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -65,6 +65,7 @@ class MicroManagerCoupling(MicroManager):
         self._config.read_json_micro_manager()
 
         self._memory_usage_output_type = self._config.get_memory_usage_output_type()
+
         self._memory_usage_output_n = self._config.get_memory_usage_output_n()
 
         self._output_dir = self._config.get_output_dir()
@@ -138,12 +139,7 @@ class MicroManagerCoupling(MicroManager):
 
         self._adaptivity_n = self._config.get_adaptivity_n()
 
-        adaptivity_output_type = self._config.get_adaptivity_output_type()
-
-        if adaptivity_output_type == "":
-            self._adaptivity_output_required = False
-        else:
-            self._adaptivity_output_required = True
+        self._adaptivity_output_type = self._config.get_adaptivity_output_type()
 
         self._adaptivity_output_n = self._config.get_adaptivity_output_n()
 
@@ -316,7 +312,7 @@ class MicroManagerCoupling(MicroManager):
 
                 if (
                     self._is_adaptivity_on
-                    and self._adaptivity_output_required
+                    and self._adaptivity_output_type
                     and (self._n % self._adaptivity_output_n == 0)
                 ):
                     self._adaptivity_controller.log_metrics(self._n)
@@ -345,7 +341,7 @@ class MicroManagerCoupling(MicroManager):
         # Final adaptivity metrics logging at the end of the simulation if not already logged at the end of the last time window
         if (
             self._is_adaptivity_on
-            and self._adaptivity_output_required
+            and self._adaptivity_output_type
             and self._n % self._adaptivity_output_n != 0
         ):
             self._adaptivity_controller.log_metrics(self._n)


### PR DESCRIPTION
The following defaults are changed:

- Adaptivity metrics output default set to having no output.
- Similarity distance calculation norm default set to L2 relative norm.

Additionally, the default values of configuration parameters are documented in the configuration documentation.

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
