### PR TITLE
Fix duplicate micro simulations for macro-points on rank boundaries #102

### DIFF
--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -121,17 +121,17 @@ class DomainDecomposer:
 
         micro_sims_on_rank = 0
         for position in macro_coords:
-    inside = True
-    for d in range(len(ranks_per_axis)):
-        is_upper_boundary = np.isclose(local_mesh_bounds[d * 2 + 1], macro_bounds[d * 2 + 1])
-        if not (
-            position[d] >= local_mesh_bounds[d * 2]
-            and (position[d] <= local_mesh_bounds[d * 2 + 1] if is_upper_boundary else position[d] < local_mesh_bounds[d * 2 + 1])
-        ):
-            inside = False
-            break
-    if inside:
-        macro_coords_on_this_rank.append(position)
-        micro_sims_on_rank += 1
+            inside = True
+            for d in range(len(ranks_per_axis)):
+                is_upper_boundary = np.isclose(local_mesh_bounds[d * 2 + 1], macro_bounds[d * 2 + 1])
+                if not (
+                    position[d] >= local_mesh_bounds[d * 2]
+                    and (position[d] <= local_mesh_bounds[d * 2 + 1] if is_upper_boundary else position[d] < local_mesh_bounds[d * 2 + 1])
+                ):
+                    inside = False
+                    break
+            if inside:
+                macro_coords_on_this_rank.append(position)
+                micro_sims_on_rank += 1
 
         return micro_sims_on_rank, macro_coords_on_this_rank

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -121,16 +121,17 @@ class DomainDecomposer:
 
         micro_sims_on_rank = 0
         for position in macro_coords:
-            inside = True
-            for d in range(len(ranks_per_axis)):
-                if not (
-                    position[d] >= local_mesh_bounds[d * 2]
-                    and position[d] <= local_mesh_bounds[d * 2 + 1]
-                ):
-                    inside = False
-                    break
-            if inside:
-                macro_coords_on_this_rank.append(position)
-                micro_sims_on_rank += 1
+    inside = True
+    for d in range(len(ranks_per_axis)):
+        is_upper_boundary = np.isclose(local_mesh_bounds[d * 2 + 1], macro_bounds[d * 2 + 1])
+        if not (
+            position[d] >= local_mesh_bounds[d * 2]
+            and (position[d] <= local_mesh_bounds[d * 2 + 1] if is_upper_boundary else position[d] < local_mesh_bounds[d * 2 + 1])
+        ):
+            inside = False
+            break
+    if inside:
+        macro_coords_on_this_rank.append(position)
+        micro_sims_on_rank += 1
 
         return micro_sims_on_rank, macro_coords_on_this_rank

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 import numpy as np
 from micro_manager.domain_decomposition import DomainDecomposer
 
-
 class TestDomainDecomposition(TestCase):
     def setUp(self) -> None:
         self._macro_bounds_3d = [
@@ -13,7 +12,6 @@ class TestDomainDecomposition(TestCase):
             -2,
             8,
         ]  # Cuboid which is not symmetric around origin
-
         self._macro_bounds_2d = [
             0,
             1,
@@ -33,7 +31,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_2d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, 1, 2]))
 
     def test_rank1_out_of_4_3d(self):
@@ -48,7 +45,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [0.0, 1, -2, 0.0, -2, 8]))
 
     def test_rank5_outof_10_3d(self):
@@ -63,7 +59,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [-1, 1, 0, 2, 2, 4]))
 
     def test_rank10_out_of_32_3d(self):
@@ -78,7 +73,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, -2, 2, 0.5, 1.75]))
 
     def test_rank7_out_of_16_3d(self):
@@ -93,5 +87,24 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [0.75, 1, -2, 0, -2, 8]))
+
+    def test_no_duplicate_coords_on_boundary_2d(self):
+        """
+        Check that a point on the boundary between two ranks is only assigned to one rank.
+        """
+        ranks_per_axis = [2, 1]
+        size = 2
+        macro_coords = np.array([[0.5, 0.5], [0.25, 0.5], [0.75, 0.5]])
+
+        decomposer_rank0 = DomainDecomposer(0, size)
+        decomposer_rank1 = DomainDecomposer(1, size)
+
+        n0, _ = decomposer_rank0.get_local_sims_and_macro_coords(
+            self._macro_bounds_2d, ranks_per_axis, macro_coords
+        )
+        n1, _ = decomposer_rank1.get_local_sims_and_macro_coords(
+            self._macro_bounds_2d, ranks_per_axis, macro_coords
+        )
+
+        self.assertEqual(n0 + n1, len(macro_coords))


### PR DESCRIPTION
Closes #102
Problem:
When running the Micro Manager in parallel, each MPI rank is assigned a bounding box. Macro-points lying exactly on the boundary between two ranks were being included in both, causing the Micro Manager to create duplicate micro simulations for the same point. This led to:

Incorrect results in preCICE, which accumulates both outputs
Wasted computation from running identical micro simulations
Potentially different outputs with local adaptivity

Fix:
In get_local_sims_and_macro_coords, added an is_upper_boundary check per axis. A rank now uses <= for its upper bound only if that bound coincides with the global domain boundary — otherwise < is used. This ensures every boundary point is assigned to exactly one rank.
Changes:

micro_manager/domain_decomposition.py: Fixed boundary condition logic in get_local_sims_and_macro_coords
tests/unit/test_domain_decomposition.py: Added test_no_duplicate_coords_on_boundary_2d to verify no point is double-counted across ranks
