### PR TITLE
 Expose MicroSimulationInterface as public abstract base class for user subclassing #65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Exposed `MicroSimulationInterface` as a public abstract base class for user subclassing [#224](https://github.com/precice/micro-manager/pull/224)
 - Added option to use compute instances to reduce memory consumption [#226](https://github.com/precice/micro-manager/pull/226)
 - Added support to run micro simulations in separate processes with workers [#219](https://github.com/precice/micro-manager/pull/219)
 - Added abstraction layers to micro simulations to support more features [#218](https://github.com/precice/micro-manager/pull/218)

--- a/examples/python-dummy/micro_dummy.py
+++ b/examples/python-dummy/micro_dummy.py
@@ -1,10 +1,13 @@
 """
 Micro simulation
-In this script we solve a dummy micro problem to just show the working of the macro-micro coupling
+In this script we solve a dummy micro problem to just show the working of the macro-micro coupling.
+This example shows how to inherit from MicroSimulationInterface provided by the Micro Manager.
 """
 
+from micro_manager import MicroSimulationInterface
 
-class MicroSimulation:
+
+class MicroSimulation(MicroSimulationInterface):
     def __init__(self, sim_id):
         """
         Constructor of MicroSimulation class.
@@ -14,6 +17,9 @@ class MicroSimulation:
         self._micro_scalar_data = None
         self._micro_vector_data = None
         self._state = None
+
+    def initialize(self, initial_data=None):
+        pass
 
     def solve(self, macro_data, dt):
         assert dt != 0
@@ -35,3 +41,9 @@ class MicroSimulation:
 
     def get_global_id(self):
         return self._sim_id
+
+    def set_global_id(self, global_id):
+        self._sim_id = global_id
+
+    def output(self):
+        pass

--- a/micro_manager/__init__.py
+++ b/micro_manager/__init__.py
@@ -2,6 +2,7 @@ import argparse
 import os
 
 from .config import Config
+from .micro_simulation import MicroSimulationInterface
 from .micro_manager import MicroManagerCoupling
 
 try:

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -211,11 +211,12 @@ class MicroSimulationLocal(MicroSimulationInterface):
 
 
 class MicroSimulationRemote(MicroSimulationInterface):
-    def __init__(self, gid, late_init, num_ranks, conn, cls_path):
+    def __init__(self, gid, late_init, num_ranks, conn, cls_path, sim_cls):
         self._cls_path = cls_path
         self._gid = gid
         self._num_ranks = num_ranks
         self._conn = conn
+        self._sim_cls = sim_cls
 
         construct_cls = ConstructLateTask if late_init else ConstructTask
         for worker_id in range(self._num_ranks):
@@ -291,6 +292,12 @@ class MicroSimulationRemote(MicroSimulationInterface):
 
         return result
 
+    def requires_initialize(self) -> bool:
+        return self._sim_cls.initialize is not MicroSimulationInterface.initialize
+
+    def requires_output(self) -> bool:
+        return self._sim_cls.output is not MicroSimulationInterface.output
+
 
 class MicroSimulationWrapper(MicroSimulationInterface):
     """
@@ -303,7 +310,7 @@ class MicroSimulationWrapper(MicroSimulationInterface):
 
         if num_ranks > 1 and conn is not None:
             self._impl = MicroSimulationRemote(
-                global_id, late_init, num_ranks, conn, cls_path
+                global_id, late_init, num_ranks, conn, cls_path, sim_cls
             )
         else:
             self._impl = MicroSimulationLocal(global_id, late_init, sim_cls)

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -396,7 +396,8 @@ class MicroSimulationClass:
         # If the class inherits from MicroSimulationInterface, use requires_initialize()
         try:
             if issubclass(self._sim_cls, MicroSimulationInterface):
-                if not test_instance.requires_initialize():
+                # Check at class level without relying on instance state
+                if self._sim_cls.initialize is MicroSimulationInterface.initialize:
                     return False, False
         except TypeError:
             pass  # pybind11 classes may not support issubclass
@@ -462,11 +463,8 @@ class MicroSimulationClass:
         # If the class inherits from MicroSimulationInterface, use requires_output()
         try:
             if issubclass(self._sim_cls, MicroSimulationInterface):
-                instance = self._sim_cls.__new__(self._sim_cls)
-                try:
-                    return instance.requires_output()
-                except Exception:
-                    pass
+                # Check at class level without instantiating
+                return self._sim_cls.output is not MicroSimulationInterface.output
         except TypeError:
             pass  # pybind11 classes may not support issubclass
 

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -376,10 +376,9 @@ class MicroSimulationClass:
         """
         Check whether the micro simulation class implements ``initialize``.
 
-        If the class inherits from ``MicroSimulationInterface``, use
-        ``requires_initialize()`` to determine whether the method is overridden.
-        Otherwise, fall back to ``hasattr`` for backwards compatibility with
-        classes that do not inherit from the interface (e.g. pybind11 classes).
+        Since ``load_backend_class`` guarantees that ``self._sim_cls`` always
+        inherits from ``MicroSimulationInterface``, we can rely on
+        ``requires_initialize()`` directly. No ``issubclass`` guard is needed.
 
         Parameters
         ----------
@@ -393,20 +392,7 @@ class MicroSimulationClass:
         tuple[bool, bool]
             (has_initialize, requires_initial_data)
         """
-        # If the class inherits from MicroSimulationInterface, use requires_initialize()
-        try:
-            if issubclass(self._sim_cls, MicroSimulationInterface):
-                # Check at class level without relying on instance state
-                if self._sim_cls.initialize is MicroSimulationInterface.initialize:
-                    return False, False
-        except TypeError:
-            pass  # pybind11 classes may not support issubclass
-
-        has_init = hasattr(self._sim_cls, "initialize")
-        if not has_init:
-            return False, False
-        callable_init = callable(getattr(self._sim_cls, "initialize"))
-        if not callable_init:
+        if not test_instance.requires_initialize():
             return False, False
 
         has_args = False
@@ -445,55 +431,146 @@ class MicroSimulationClass:
                         "The initialize() method of the Micro simulation has an incorrect number of arguments."
                     )
 
-        return has_init and callable_init, has_args
+        return True, has_args
 
     def check_output(self) -> bool:
         """
         Check whether the micro simulation class implements ``output``.
 
-        If the class inherits from ``MicroSimulationInterface``, use
-        ``requires_output()`` to determine whether the method is overridden.
-        Otherwise, fall back to ``hasattr`` for backwards compatibility.
+        Since ``load_backend_class`` guarantees that ``self._sim_cls`` always
+        inherits from ``MicroSimulationInterface``, we can rely on
+        ``requires_output()`` directly at the class level.
 
         Returns
         -------
         bool
-            True if the micro simulation class has a callable ``output`` method.
+            True if the micro simulation class overrides the ``output`` method.
         """
-        # If the class inherits from MicroSimulationInterface, use requires_output()
-        try:
-            if issubclass(self._sim_cls, MicroSimulationInterface):
-                # Check at class level without instantiating
-                return self._sim_cls.output is not MicroSimulationInterface.output
-        except TypeError:
-            pass  # pybind11 classes may not support issubclass
-
-        has_output = hasattr(self._sim_cls, "output")
-        if not has_output:
-            return False
-        return callable(getattr(self._sim_cls, "output"))
+        return self._sim_cls.output is not MicroSimulationInterface.output
 
 
-def load_backend_class(path_to_micro_file):
+def _wrap_non_interface_class(cls: type, path_to_micro_file: str) -> type:
+    """
+    Dynamically create a class that inherits from MicroSimulationInterface
+    and delegates all method calls to the provided class.
+
+    This ensures that load_backend_class always returns a class that adheres
+    to MicroSimulationInterface, even for pybind11 classes or legacy classes
+    that do not explicitly inherit from it.
+
+    Parameters
+    ----------
+    cls : type
+        The original micro simulation class (e.g. loaded via pybind11).
+    path_to_micro_file : str
+        Path string used for the deprecation warning message.
+
+    Returns
+    -------
+    type
+        A new class inheriting from MicroSimulationInterface that wraps cls.
+    """
+    import warnings
+
+    warnings.warn(
+        "The MicroSimulation class in '{}' does not inherit from MicroSimulationInterface. "
+        "Please update your class definition to: "
+        "class MicroSimulation(MicroSimulationInterface). "
+        "In a future version this will become an error.".format(path_to_micro_file),
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+    # Determine whether the original class provides initialize / output
+    has_initialize = callable(getattr(cls, "initialize", None))
+    has_output = callable(getattr(cls, "output", None))
+
+    # Build the class body: __init__ and mandatory interface methods
+    class_body = """
+def __init__(self, global_id):
+    self._wrapped = wrapped_cls(global_id)
+    self._global_id = global_id
+
+def solve(self, micro_sim_input, dt):
+    return self._wrapped.solve(micro_sim_input, dt)
+
+def get_state(self):
+    return self._wrapped.get_state()
+
+def set_state(self, state):
+    return self._wrapped.set_state(state)
+
+def get_global_id(self):
+    return self._global_id
+
+def set_global_id(self, global_id):
+    self._global_id = global_id
+    if hasattr(self._wrapped, "set_global_id"):
+        self._wrapped.set_global_id(global_id)
+
+def __getattr__(self, name):
+    return getattr(self._wrapped, name)
+"""
+
+    # Only add initialize override if the wrapped class actually has it,
+    # so that requires_initialize() returns True for those classes.
+    if has_initialize:
+        class_body += """
+def initialize(self, *args, **kwargs):
+    return self._wrapped.initialize(*args, **kwargs)
+"""
+
+    # Only add output override if the wrapped class actually has it,
+    # so that requires_output() returns True for those classes.
+    if has_output:
+        class_body += """
+def output(self):
+    return self._wrapped.output()
+"""
+
+    class_dict = {}
+    exec(class_body, {"wrapped_cls": cls, "__builtins__": __builtins__}, class_dict)
+
+    wrapper_cls = type(
+        "MicroSimulationWrapper_{}".format(cls.__name__),
+        (MicroSimulationInterface,),
+        class_dict,
+    )
+    return wrapper_cls
+
+
+def load_backend_class(path_to_micro_file: str) -> type:
+    """
+    Load the MicroSimulation class from the given module path.
+
+    Always returns a class that inherits from MicroSimulationInterface.
+    If the loaded class does not inherit from it (e.g. pybind11 classes or
+    legacy classes), it is wrapped in a dynamically created adapter class
+    that delegates all calls to the original and correctly implements
+    requires_initialize() and requires_output().
+
+    Parameters
+    ----------
+    path_to_micro_file : str
+        Dotted module path to the micro simulation file.
+
+    Returns
+    -------
+    type
+        A class inheriting from MicroSimulationInterface.
+    """
     CLS_NAME = "MicroSimulation"
     cls = getattr(ipl.import_module(path_to_micro_file, CLS_NAME), CLS_NAME)
+
     try:
         inherits = issubclass(cls, MicroSimulationInterface)
     except TypeError:
-        # pybind11 classes may not support issubclass checks
+        # pybind11 extension types may not support issubclass — wrap them
         inherits = False
 
     if not inherits:
-        import warnings
+        cls = _wrap_non_interface_class(cls, path_to_micro_file)
 
-        warnings.warn(
-            "The MicroSimulation class in '{}' does not inherit from MicroSimulationInterface. "
-            "Please update your class definition to: "
-            "class MicroSimulation(MicroSimulationInterface). "
-            "In a future version this will become an error.".format(path_to_micro_file),
-            DeprecationWarning,
-            stacklevel=2,
-        )
     return cls
 
 

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -20,32 +20,124 @@ from .tasking.task import (
 
 
 class MicroSimulationInterface(ABC):
+    """
+    Abstract base class for micro simulations. Users should inherit from this class
+    when creating their micro simulation and implement all abstract methods.
+
+    Example usage:
+
+        from micro_manager import MicroSimulationInterface
+
+        class MicroSimulation(MicroSimulationInterface):
+            def __init__(self, sim_id):
+                self._sim_id = sim_id
+
+            def initialize(self, initial_data=None):
+                pass
+
+            def solve(self, macro_data, dt):
+                return {}
+
+            def get_state(self):
+                return None
+
+            def set_state(self, state):
+                pass
+
+            def get_global_id(self):
+                return self._sim_id
+
+            def set_global_id(self, global_id):
+                self._sim_id = global_id
+
+            def output(self):
+                pass
+    """
+
+    @abstractmethod
+    def initialize(self, *args, **kwargs):
+        """
+        Initialize the micro simulation. Called once before the coupling loop starts.
+
+        Parameters
+        ----------
+        initial_data : dict, optional
+            Initial data passed from the Micro Manager.
+        """
+        pass
+
     @abstractmethod
     def solve(self, micro_sim_input, dt):
+        """
+        Solve the micro simulation for one time step.
+
+        Parameters
+        ----------
+        micro_sim_input : dict
+            Input data from the macro simulation.
+        dt : float
+            Time step size.
+
+        Returns
+        -------
+        dict
+            Output data to be passed to the macro simulation.
+        """
         pass
 
     @abstractmethod
     def get_state(self):
+        """
+        Return the current state of the micro simulation for checkpointing.
+
+        Returns
+        -------
+        object
+            The current state of the micro simulation.
+        """
         pass
 
     @abstractmethod
     def set_state(self, state):
+        """
+        Set the state of the micro simulation from a checkpoint.
+
+        Parameters
+        ----------
+        state : object
+            The state to restore.
+        """
         pass
 
     @abstractmethod
     def get_global_id(self):
+        """
+        Return the global ID of this micro simulation instance.
+
+        Returns
+        -------
+        int
+            Global ID of the micro simulation.
+        """
         pass
 
     @abstractmethod
     def set_global_id(self, global_id):
-        pass
+        """
+        Set the global ID of this micro simulation instance.
 
-    @abstractmethod
-    def initialize(self, *args, **kwargs):
+        Parameters
+        ----------
+        global_id : int
+            Global ID to assign.
+        """
         pass
 
     @abstractmethod
     def output(self):
+        """
+        Optional output method called after each solve step.
+        """
         pass
 
 
@@ -302,7 +394,14 @@ class MicroSimulationClass:
 
 def load_backend_class(path_to_micro_file):
     CLS_NAME = "MicroSimulation"
-    return getattr(ipl.import_module(path_to_micro_file, CLS_NAME), CLS_NAME)
+    cls = getattr(ipl.import_module(path_to_micro_file, CLS_NAME), CLS_NAME)
+    if not issubclass(cls, MicroSimulationInterface):
+        raise TypeError(
+            "The MicroSimulation class in '{}' must inherit from MicroSimulationInterface. "
+            "Please update your class definition to: "
+            "class MicroSimulation(MicroSimulationInterface)".format(path_to_micro_file)
+        )
+    return cls
 
 
 def create_simulation_class(

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -396,10 +396,14 @@ def load_backend_class(path_to_micro_file):
     CLS_NAME = "MicroSimulation"
     cls = getattr(ipl.import_module(path_to_micro_file, CLS_NAME), CLS_NAME)
     if not issubclass(cls, MicroSimulationInterface):
-        raise TypeError(
-            "The MicroSimulation class in '{}' must inherit from MicroSimulationInterface. "
+        import warnings
+        warnings.warn(
+            "The MicroSimulation class in '{}' does not inherit from MicroSimulationInterface. "
             "Please update your class definition to: "
-            "class MicroSimulation(MicroSimulationInterface)".format(path_to_micro_file)
+            "class MicroSimulation(MicroSimulationInterface). "
+            "In a future version this will become an error.".format(path_to_micro_file),
+            DeprecationWarning,
+            stacklevel=2,
         )
     return cls
 

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -89,7 +89,7 @@ class MicroSimulationInterface(ABC):
 
         Returns
         -------
-        dict
+        micro_sim_output : dict
             Output data to be passed to the macro simulation.
         """
         pass
@@ -101,7 +101,7 @@ class MicroSimulationInterface(ABC):
 
         Returns
         -------
-        object
+        state : object
             The current state of the micro simulation.
         """
         pass
@@ -125,7 +125,7 @@ class MicroSimulationInterface(ABC):
 
         Returns
         -------
-        int
+        global_id : int
             Global ID of the micro simulation.
         """
         pass
@@ -156,7 +156,7 @@ class MicroSimulationInterface(ABC):
 
         Returns
         -------
-        bool
+        requires_initialize : bool
             True if ``initialize`` is overridden, False otherwise.
         """
         return type(self).initialize is not MicroSimulationInterface.initialize
@@ -168,7 +168,7 @@ class MicroSimulationInterface(ABC):
 
         Returns
         -------
-        bool
+        requires_output : bool
             True if ``output`` is overridden, False otherwise.
         """
         return type(self).output is not MicroSimulationInterface.output
@@ -390,7 +390,7 @@ class MicroSimulationClass:
         return self._sim_cls
 
     def check_initialize(
-        self, test_instance: object, test_input: dict
+        self, test_instance: MicroSimulationInterface, test_input: dict
     ) -> tuple[bool, bool]:
         """
         Check whether the micro simulation class implements ``initialize``.
@@ -408,7 +408,7 @@ class MicroSimulationClass:
 
         Returns
         -------
-        tuple[bool, bool]
+        check_result : tuple[bool, bool]
             (has_initialize, requires_initial_data)
         """
         if not test_instance.requires_initialize():
@@ -462,7 +462,7 @@ class MicroSimulationClass:
 
         Returns
         -------
-        bool
+        check_result : bool
             True if the micro simulation class overrides the ``output`` method.
         """
         return self._sim_cls.output is not MicroSimulationInterface.output
@@ -551,7 +551,7 @@ def output(self):
     exec(class_body, {"wrapped_cls": cls, "__builtins__": __builtins__}, class_dict)
 
     wrapper_cls = type(
-        "MicroSimulationWrapper_{}".format(cls.__name__),
+        "CompatibilityWrapper_{}".format(cls.__name__),
         (MicroSimulationInterface,),
         class_dict,
     )

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -203,6 +203,12 @@ class MicroSimulationLocal(MicroSimulationInterface):
     def output(self):
         return self._instance.output()
 
+    def requires_initialize(self) -> bool:
+        return self._instance.requires_initialize()
+
+    def requires_output(self) -> bool:
+        return self._instance.requires_output()
+
 
 class MicroSimulationRemote(MicroSimulationInterface):
     def __init__(self, gid, late_init, num_ranks, conn, cls_path):
@@ -325,6 +331,12 @@ class MicroSimulationWrapper(MicroSimulationInterface):
 
     def output(self):
         return self._impl.output()
+
+    def requires_initialize(self) -> bool:
+        return self._impl.requires_initialize()
+
+    def requires_output(self) -> bool:
+        return self._impl.requires_output()
 
     def __getattr__(self, name):
         return getattr(self._impl, name)

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -508,7 +508,6 @@ def _wrap_non_interface_class(cls: type, path_to_micro_file: str) -> type:
     class_body = """
 def __init__(self, global_id):
     self._wrapped = wrapped_cls(global_id)
-    self._global_id = global_id
 
 def solve(self, micro_sim_input, dt):
     return self._wrapped.solve(micro_sim_input, dt)
@@ -520,12 +519,10 @@ def set_state(self, state):
     return self._wrapped.set_state(state)
 
 def get_global_id(self):
-    return self._global_id
+    return self._wrapped.get_global_id()
 
 def set_global_id(self, global_id):
-    self._global_id = global_id
-    if hasattr(self._wrapped, "set_global_id"):
-        self._wrapped.set_global_id(global_id)
+    self._wrapped.set_global_id(global_id)
 
 def __getattr__(self, name):
     return getattr(self._wrapped, name)

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -24,50 +24,59 @@ class MicroSimulationInterface(ABC):
     Abstract base class for micro simulations. Users should inherit from this class
     when creating their micro simulation and implement all abstract methods.
 
-    Example usage:
+    The methods ``initialize`` and ``output`` are optional — override them only if
+    your simulation needs them. The Micro Manager checks ``requires_initialize()``
+    and ``requires_output()`` to decide whether to call them.
+
+    Example usage::
 
         from micro_manager import MicroSimulationInterface
 
         class MicroSimulation(MicroSimulationInterface):
-            def __init__(self, sim_id):
+            def __init__(self, sim_id: int) -> None:
                 self._sim_id = sim_id
 
-            def initialize(self, initial_data=None):
+            def initialize(self, initial_data: dict | None = None) -> dict | None:
                 pass
 
-            def solve(self, macro_data, dt):
+            def solve(self, macro_data: dict, dt: float) -> dict:
                 return {}
 
-            def get_state(self):
+            def get_state(self) -> object:
                 return None
 
-            def set_state(self, state):
+            def set_state(self, state: object) -> None:
                 pass
 
-            def get_global_id(self):
+            def get_global_id(self) -> int:
                 return self._sim_id
 
-            def set_global_id(self, global_id):
+            def set_global_id(self, global_id: int) -> None:
                 self._sim_id = global_id
 
-            def output(self):
+            def output(self) -> None:
                 pass
     """
 
-    @abstractmethod
-    def initialize(self, *args, **kwargs):
+    def initialize(self, *args, **kwargs) -> dict | None:
         """
         Initialize the micro simulation. Called once before the coupling loop starts.
+        This method is optional. Override it if your simulation requires initialization.
 
         Parameters
         ----------
         initial_data : dict, optional
             Initial data passed from the Micro Manager.
+
+        Returns
+        -------
+        dict or None
+            Optional initial output data to be used in the adaptivity calculation.
         """
         pass
 
     @abstractmethod
-    def solve(self, micro_sim_input, dt):
+    def solve(self, micro_sim_input: dict, dt: float) -> dict:
         """
         Solve the micro simulation for one time step.
 
@@ -86,7 +95,7 @@ class MicroSimulationInterface(ABC):
         pass
 
     @abstractmethod
-    def get_state(self):
+    def get_state(self) -> object:
         """
         Return the current state of the micro simulation for checkpointing.
 
@@ -98,7 +107,7 @@ class MicroSimulationInterface(ABC):
         pass
 
     @abstractmethod
-    def set_state(self, state):
+    def set_state(self, state: object) -> None:
         """
         Set the state of the micro simulation from a checkpoint.
 
@@ -110,7 +119,7 @@ class MicroSimulationInterface(ABC):
         pass
 
     @abstractmethod
-    def get_global_id(self):
+    def get_global_id(self) -> int:
         """
         Return the global ID of this micro simulation instance.
 
@@ -122,7 +131,7 @@ class MicroSimulationInterface(ABC):
         pass
 
     @abstractmethod
-    def set_global_id(self, global_id):
+    def set_global_id(self, global_id: int) -> None:
         """
         Set the global ID of this micro simulation instance.
 
@@ -133,12 +142,36 @@ class MicroSimulationInterface(ABC):
         """
         pass
 
-    @abstractmethod
-    def output(self):
+    def output(self) -> None:
         """
         Optional output method called after each solve step.
+        Override this method if your simulation needs to write output at each step.
         """
         pass
+
+    def requires_initialize(self) -> bool:
+        """
+        Return True if this simulation class overrides the ``initialize`` method.
+        The Micro Manager calls this to determine whether initialization is needed.
+
+        Returns
+        -------
+        bool
+            True if ``initialize`` is overridden, False otherwise.
+        """
+        return type(self).initialize is not MicroSimulationInterface.initialize
+
+    def requires_output(self) -> bool:
+        """
+        Return True if this simulation class overrides the ``output`` method.
+        The Micro Manager calls this to determine whether output is needed.
+
+        Returns
+        -------
+        bool
+            True if ``output`` is overridden, False otherwise.
+        """
+        return type(self).output is not MicroSimulationInterface.output
 
 
 class MicroSimulationLocal(MicroSimulationInterface):
@@ -337,7 +370,37 @@ class MicroSimulationClass:
     def backend_cls(self):
         return self._sim_cls
 
-    def check_initialize(self, test_instance, test_input):
+    def check_initialize(
+        self, test_instance: object, test_input: dict
+    ) -> tuple[bool, bool]:
+        """
+        Check whether the micro simulation class implements ``initialize``.
+
+        If the class inherits from ``MicroSimulationInterface``, use
+        ``requires_initialize()`` to determine whether the method is overridden.
+        Otherwise, fall back to ``hasattr`` for backwards compatibility with
+        classes that do not inherit from the interface (e.g. pybind11 classes).
+
+        Parameters
+        ----------
+        test_instance : object
+            An instance of the micro simulation class used for signature probing.
+        test_input : dict
+            Sample input data used to probe whether ``initialize`` accepts arguments.
+
+        Returns
+        -------
+        tuple[bool, bool]
+            (has_initialize, requires_initial_data)
+        """
+        # If the class inherits from MicroSimulationInterface, use requires_initialize()
+        try:
+            if issubclass(self._sim_cls, MicroSimulationInterface):
+                if not test_instance.requires_initialize():
+                    return False, False
+        except TypeError:
+            pass  # pybind11 classes may not support issubclass
+
         has_init = hasattr(self._sim_cls, "initialize")
         if not has_init:
             return False, False
@@ -383,20 +446,48 @@ class MicroSimulationClass:
 
         return has_init and callable_init, has_args
 
-    def check_output(self):
-        has_init = hasattr(self._sim_cls, "output")
-        if not has_init:
-            return False
-        callable_init = callable(getattr(self._sim_cls, "output"))
+    def check_output(self) -> bool:
+        """
+        Check whether the micro simulation class implements ``output``.
 
-        return has_init and callable_init
+        If the class inherits from ``MicroSimulationInterface``, use
+        ``requires_output()`` to determine whether the method is overridden.
+        Otherwise, fall back to ``hasattr`` for backwards compatibility.
+
+        Returns
+        -------
+        bool
+            True if the micro simulation class has a callable ``output`` method.
+        """
+        # If the class inherits from MicroSimulationInterface, use requires_output()
+        try:
+            if issubclass(self._sim_cls, MicroSimulationInterface):
+                instance = self._sim_cls.__new__(self._sim_cls)
+                try:
+                    return instance.requires_output()
+                except Exception:
+                    pass
+        except TypeError:
+            pass  # pybind11 classes may not support issubclass
+
+        has_output = hasattr(self._sim_cls, "output")
+        if not has_output:
+            return False
+        return callable(getattr(self._sim_cls, "output"))
 
 
 def load_backend_class(path_to_micro_file):
     CLS_NAME = "MicroSimulation"
     cls = getattr(ipl.import_module(path_to_micro_file, CLS_NAME), CLS_NAME)
-    if not issubclass(cls, MicroSimulationInterface):
+    try:
+        inherits = issubclass(cls, MicroSimulationInterface)
+    except TypeError:
+        # pybind11 classes may not support issubclass checks
+        inherits = False
+
+    if not inherits:
         import warnings
+
         warnings.warn(
             "The MicroSimulation class in '{}' does not inherit from MicroSimulationInterface. "
             "Please update your class definition to: "


### PR DESCRIPTION
Closes #65

Exposes MicroSimulationInterface as a public abstract base class that users can inherit from when writing their micro simulations. This ensures users stick to the required API and get clear errors if they miss a method.

Changes:
- Added full docstrings with examples to all abstract methods in MicroSimulationInterface
- Exported MicroSimulationInterface from __init__.py so users can do `from micro_manager import MicroSimulationInterface`
- Updated load_backend_class() to warn users with a DeprecationWarning if their class does not inherit from MicroSimulationInterface (will become a hard error in a future version)
- Updated examples/python-dummy/micro_dummy.py to demonstrate the new inheritance pattern