### PR TITLE
Added Model Instancing for reduced memory consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Added option to use compute instances to reduce memory consumption [#226](https://github.com/precice/micro-manager/pull/226)
 - Added support to run micro simulations in separate processes with workers [#219](https://github.com/precice/micro-manager/pull/219)
 - Added abstraction layers to micro simulations to support more features [#218](https://github.com/precice/micro-manager/pull/218)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,12 +11,13 @@ The Micro Manager is configured with a JSON file. Several parameters can be set.
 
 ## Micro Manager Configuration
 
-Parameter | Description | Default
---- | ---
-`micro_file_name` | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed. | -
-`output_directory` | Path to output directory for logging and performance metrics. Directory is created if not existing already. | `.`
-`memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels. | Empty string.
-`memory_usage_output_n` | Interval of output. | 1
+| Parameter                  | Description                                                                                                                                                                                           | Default       |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `micro_file_name`          | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed. | -             |
+| `micro_stateless`          | Boolean if micro simulation is stateless allowing model instancing.                                                                                                                                   | False         |
+| `output_directory`         | Path to output directory for logging and performance metrics. Directory is created if not existing already.                                                                                           | `.`           |
+| `memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels.               | Empty string. |
+| `memory_usage_output_n`    | Interval of output.                                                                                                                                                                                   | 1             |
 
 All output is to a CSV file with the peak memory usage (RSS) in every time window, in MBs.
 
@@ -24,31 +25,31 @@ Apart from the base settings, there are three main sections in the configuration
 
 ## Coupling Parameters
 
-Parameter | Description
---- | ---
-`precice_config_file_name` | Path to the preCICE XML configuration file from the current working directory.
-`macro_mesh_name` | Name of the macro mesh as stated in the preCICE configuration.
-`read_data_names` | List with the names of the data to be read from preCICE.
-`write_data_names` | List with the names of the data to be written to preCICE.
+| Parameter                  | Description                                                                    |
+|----------------------------|--------------------------------------------------------------------------------|
+| `precice_config_file_name` | Path to the preCICE XML configuration file from the current working directory. |
+| `macro_mesh_name`          | Name of the macro mesh as stated in the preCICE configuration.                 |
+| `read_data_names`          | List with the names of the data to be read from preCICE.                       |
+| `write_data_names`         | List with the names of the data to be written to preCICE.                      |
 
 ## Simulation Parameters
 
-Parameter | Description | Default
---- | --- | ---
-`macro_domain_bounds` | Minimum and maximum bounds of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]` in 3D and `[xmin, xmax, ymin, ymax]` in 2D. | -
-`decomposition` | List of number of ranks in each axis with format `[xranks, yranks, zranks]` in 3D and `[xranks, yranks]` in 2D. | `[1, 1, 1]` or `[1, 1]`
-`micro_dt` | Initial time window size (dt) of the micro simulation. | -
-`adaptivity` | Set `true` for simulations with adaptivity. See section on [adaptivity](#adaptivity). | `false`
-`load_balancing` | Set `true` for load balancing. See section on [load balancing](#load-balancing). | `false`
+| Parameter             | Description                                                                                                                                          | Default                 |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
+| `macro_domain_bounds` | Minimum and maximum bounds of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]` in 3D and `[xmin, xmax, ymin, ymax]` in 2D. | -                       |
+| `decomposition`       | List of number of ranks in each axis with format `[xranks, yranks, zranks]` in 3D and `[xranks, yranks]` in 2D.                                      | `[1, 1, 1]` or `[1, 1]` |
+| `micro_dt`            | Initial time window size (dt) of the micro simulation.                                                                                               | -                       |
+| `adaptivity`          | Set `true` for simulations with adaptivity. See section on [adaptivity](#adaptivity).                                                                | `false`                 |
+| `load_balancing`      | Set `true` for load balancing. See section on [load balancing](#load-balancing).                                                                     | `false`                 |
 
 The total number of partitions ranks in the `decomposition` list should be the same as the number of ranks in the `mpirun` or `mpiexec` command.
 
 ## Diagnostics
 
-Parameter | Description | Default
---- | --- | ---
-`data_from_micro_sims` | Dictionary with the names of the data from the micro simulation to be written to VTK files as keys and `"scalar"` or `"vector"` as values. | -
-`micro_output_n` | Frequency of calling the optional output functionality of the micro simulation in terms of number of time steps. | 1
+| Parameter              | Description                                                                                                                                | Default |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `data_from_micro_sims` | Dictionary with the names of the data from the micro simulation to be written to VTK files as keys and `"scalar"` or `"vector"` as values. | -       |
+| `micro_output_n`       | Frequency of calling the optional output functionality of the micro simulation in terms of number of time steps.                           | 1       |
 
 ### Adding diagnostics in the preCICE XML configuration
 
@@ -70,20 +71,20 @@ See the [adaptivity](tooling-micro-manager-adaptivity.html) documentation for a 
 
 To turn on adaptivity, set `"adaptivity": true` in `simulation_params`. Then under `adaptivity_settings` set the following variables:
 
-Parameter | Description | Default
---- | --- | ---
-`type` | Set to either `local` or `global`. The type of adaptivity matters when the Micro Manager is run in parallel. `local` means comparing micro simulations within a local partitioned domain for similarity. `global` means comparing micro simulations from all partitions, so over the entire domain. | None
-`data` | List of names of data which are to be used to calculate if micro-simulations are similar or not. For example `["temperature", "porosity"]`. | -
-`adaptivity_every_n_time_windows` | Interval of adaptivity computation. | 1
-`output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise adaptivity metrics. `global` outputs global averaged metrics. `all` outputs both local and global metrics. | Empty string.
-`output_n` | Frequency of output of adaptivity metrics. | 1
-`history_param` | History parameter $$ \Lambda $$, set as $$ \Lambda >= 0 $$. | 0.5
-`coarsening_constant` | Coarsening constant $$ C_c $$, set as $$ 0 =< C_c < 1 $$. | 0.5
-`refining_constant` | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$. | 0.5
-`every_implicit_iteration` | If `true`, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration. | `false`
-`similarity_measure` | Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*. | `L2rel`
-`lazy_initialization` | Set to `true` to lazily create and initialize micro simulations. If selected, micro simulation objects are created only when the micro simulation is activated for the first time. | `false`
-`load_balancing` | Set to `true` to dynamically balance simulations for parallel runs. See [load balancing settings](#load-balancing) below. | `false`
+| Parameter                         | Description                                                                                                                                                                                                                                                                                         | Default       |
+|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `type`                            | Set to either `local` or `global`. The type of adaptivity matters when the Micro Manager is run in parallel. `local` means comparing micro simulations within a local partitioned domain for similarity. `global` means comparing micro simulations from all partitions, so over the entire domain. | None          |
+| `data`                            | List of names of data which are to be used to calculate if micro-simulations are similar or not. For example `["temperature", "porosity"]`.                                                                                                                                                         | -             |
+| `adaptivity_every_n_time_windows` | Interval of adaptivity computation.                                                                                                                                                                                                                                                                 | 1             |
+| `output_type`                     | Set to either `local`, `global`, or `all`. `local` outputs rank-wise adaptivity metrics. `global` outputs global averaged metrics. `all` outputs both local and global metrics.                                                                                                                     | Empty string. |
+| `output_n`                        | Frequency of output of adaptivity metrics.                                                                                                                                                                                                                                                          | 1             |
+| `history_param`                   | History parameter $$ \Lambda $$, set as $$ \Lambda >= 0 $$.                                                                                                                                                                                                                                         | 0.5           |
+| `coarsening_constant`             | Coarsening constant $$ C_c $$, set as $$ 0 =< C_c < 1 $$.                                                                                                                                                                                                                                           | 0.5           |
+| `refining_constant`               | Refining constant $$ C_r $$, set as $$ 0 =< C_r < 1 $$.                                                                                                                                                                                                                                             | 0.5           |
+| `every_implicit_iteration`        | If `true`, adaptivity is calculated in every implicit iteration. <br> If False, adaptivity is calculated once at the start of the time window and then reused in every implicit time iteration.                                                                                                     | `false`       |
+| `similarity_measure`              | Similarity measure to be used for adaptivity. Can be either `L1`, `L2`, `L1rel` or `L2rel`. By default, `L1` is used. The `rel` variants calculate the respective relative norms. This parameter is *optional*.                                                                                     | `L2rel`       |
+| `lazy_initialization`             | Set to `true` to lazily create and initialize micro simulations. If selected, micro simulation objects are created only when the micro simulation is activated for the first time.                                                                                                                  | `false`       |
+| `load_balancing`                  | Set to `true` to dynamically balance simulations for parallel runs. See [load balancing settings](#load-balancing) below.                                                                                                                                                                           | `false`       |
 
 Example of adaptivity configuration is
 
@@ -110,10 +111,11 @@ See the [model adaptivity](tooling-micro-manager-model-adaptivity.html) document
 
 To turn on model adaptivity, set `"model_adaptivity": true` in `simulation_params`. Then under `model_adaptivity_settings` set the following variables:
 
-Parameter | Description
---- | ---
-`micro_file_names` | List of paths to the files containing the Python importable micro simulation classes. If the files are not in the working directory, give the relative path from the directory where the Micro Manager is executed. Requires a minimum of 2 files.
-`switching_function` | Path to the file containing the Python importable switching function. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.
+| Parameter            | Description                                                                                                                                                                                                                                        |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `micro_file_names`   | List of paths to the files containing the Python importable micro simulation classes. If the files are not in the working directory, give the relative path from the directory where the Micro Manager is executed. Requires a minimum of 2 files. |
+| `switching_function` | Path to the file containing the Python importable switching function. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.                                                  |
+| `micro_stateless`    | List of boolean values, whether the respective micro simulation model is stateless and can use model instancing.                                                                                                                                   |
 
 Example of model adaptivity configuration is
 
@@ -122,7 +124,8 @@ Example of model adaptivity configuration is
     "model_adaptivity": true,
     "model_adaptivity_settings": {
         "micro_file_names": ["python-dummy/micro_dummy", "python-dummy/micro_dummy", "python-dummy/micro_dummy"],
-        "switching_function": "mada_switcher"
+        "switching_function": "mada_switcher",
+        "micro_stateless": [False, True, True]
     }
 }
 ```
@@ -155,11 +158,11 @@ The Micro Manager uses the output functionality of preCICE, hence these data set
 
 Under `load_balancing_settings`, the following parameters can be set
 
-Parameter | Description | Default
---- | --- | ---
-`every_n_time_windows` | Frequency of balancing the simulations. | `1`
-`balancing_threshold` | Integer threshold value. | `0`
-`balance_inactive_sims` | If `true`, inactive simulations associated to redistributed active simulations are moved to the new ranks of the active simulations. See [balance inactive simulations](tooling-micro-manager-adaptivity.html#balance-inactive-simulations). | `false`
+| Parameter               | Description                                                                                                                                                                                                                                  | Default |
+|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `every_n_time_windows`  | Frequency of balancing the simulations.                                                                                                                                                                                                      | `1`     |
+| `balancing_threshold`   | Integer threshold value.                                                                                                                                                                                                                     | `0`     |
+| `balance_inactive_sims` | If `true`, inactive simulations associated to redistributed active simulations are moved to the new ranks of the active simulations. See [balance inactive simulations](tooling-micro-manager-adaptivity.html#balance-inactive-simulations). | `false` |
 
 ## Interpolate a crashed micro simulation
 

--- a/docs/model-adaptivity.md
+++ b/docs/model-adaptivity.md
@@ -115,6 +115,11 @@ class MicroSimulation: # Name is fixed
         It will be called with frequency set by configuration option `simulation_params: micro_output_n`
         This function is *optional*.
         """
+
+    def get_global_id(self):
+        """
+        Return the assigned global id.
+        """
 ```
 
 For this the default MicroSimulation still serves as the model interface, while the `(set)|(get)_state()` methods
@@ -124,40 +129,43 @@ is likely to be the full order model, while subsequent ones are ROMs.
 
 ```python
 def switching_function(
-    resolutions: np.ndarray,
-    locations: np.ndarray,
+    resolution: int,
+    location: np.ndarray,
     t: float,
-    inputs: list[dict],
+    input: dict,
     prev_output: dict,
-    active: np.ndarray,
-) -> np.ndarray:
+) -> int:
     """
     Switching interface function, use as reference
 
     Parameters
     ----------
-    resolutions : np.array - shape(N,)
-        Array with resolution information as get_sim_class_resolution would return for a sim obj.
-    locations : np.array - shape(N,D)
-        Array with gaussian points for all sims. D is the mesh dimension.
+    resolution : int
+        Current resolution as get_sim_class_resolution would return for the respective sim obj.
+    location : np.array - shape(D,)
+        Array with gaussian points.
     t : float
         Current time in simulation.
-    inputs : list[dict]
-        List of input objects.
-    prev_output : [None, dict-like]
+    input : dict
+        Input object.
+    prev_output : [None, dict]
         Contains the outputs of the previous model evaluation.
-    active : np.array - shape(N,)
-        Bool array indicating whether the model is active or not.
 
+    Returns
+    -------
+    switch_direction: int
+        0 if resolution should not change
+        -1 if resolution should increase
+        1 if resolution should decrease
     """
-    return np.zeros_like(resolutions)
+    return 0
 ```
 
-The switching of models is governed by the `switching_function`.
-The output is expected to be a np.ndarray of shape (N,) and is interpreted in the following manner:
+The switching of models is governed by the `switching_function`, which is evaluated for each micro simulation.
+The output is expected to be an integer and is interpreted in the following manner:
 
-Value | Action
---- | ---
-0 | No resolution change
--1 | Increase model fidelity by one (go back one in list)
-1 | Decrease model fidelity by one (go one ahead in list)
+| Value | Action                                                |
+|-------|-------------------------------------------------------|
+| 0     | No resolution change                                  |
+| -1    | Increase model fidelity by one (go back one in list)  |
+| 1     | Decrease model fidelity by one (go one ahead in list) |

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -7,6 +7,7 @@ import importlib
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.config import Config
 from micro_manager.micro_simulation import MicroSimulationClass
+from micro_manager.model_manager import ModelManager
 
 import numpy as np
 
@@ -17,6 +18,7 @@ class AdaptivityCalculator:
         configurator: Config,
         nsims: int,
         micro_problem_cls: MicroSimulationClass,
+        model_manager: ModelManager,
         base_logger: Logger,
         rank: int,
     ) -> None:
@@ -31,6 +33,8 @@ class AdaptivityCalculator:
             Number of micro simulations.
         micro_problem_cls : callable
             Class of micro problem.
+        model_manager : object
+            Handles instantiation of micro simulation.
         base_logger : object of class Logger
             Logger object to log messages.
         rank : int
@@ -44,6 +48,7 @@ class AdaptivityCalculator:
         self._adaptivity_output_type = configurator.get_adaptivity_output_type()
 
         self._micro_problem_cls = micro_problem_cls
+        self._model_manager = model_manager
 
         self._coarse_tol = 0.0
         self._ref_tol = 0.0

--- a/micro_manager/adaptivity/adaptivity_selection.py
+++ b/micro_manager/adaptivity/adaptivity_selection.py
@@ -1,0 +1,50 @@
+from .global_adaptivity import GlobalAdaptivityCalculator
+from .global_adaptivity_lb import GlobalAdaptivityLBCalculator
+from .local_adaptivity import LocalAdaptivityCalculator
+from .adaptivity import AdaptivityCalculator
+
+
+def create_adaptivity_calculator(
+    config,
+    local_number_of_sims,
+    global_number_of_sims,
+    global_ids_of_local_sims,
+    participant,
+    logger,
+    rank,
+    comm,
+    micro_problem_cls,
+    model_manager,
+    use_lb,
+) -> AdaptivityCalculator:
+    adaptivity_type = config.get_adaptivity_type()
+
+    if adaptivity_type == "local":
+        return LocalAdaptivityCalculator(
+            config,
+            local_number_of_sims,
+            logger,
+            rank,
+            comm,
+            micro_problem_cls,
+            model_manager,
+        )
+
+    if adaptivity_type == "global":
+        cls = GlobalAdaptivityCalculator
+        if use_lb:
+            cls = GlobalAdaptivityLBCalculator
+
+        return cls(
+            config,
+            global_number_of_sims,
+            global_ids_of_local_sims,
+            participant,
+            logger,
+            rank,
+            comm,
+            micro_problem_cls,
+            model_manager,
+        )
+
+    raise ValueError("Unknown adaptivity type")

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -16,6 +16,7 @@ from .adaptivity import AdaptivityCalculator
 from micro_manager.config import Config
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.micro_simulation import MicroSimulationClass
+from micro_manager.model_manager import ModelManager
 
 
 class GlobalAdaptivityCalculator(AdaptivityCalculator):
@@ -29,6 +30,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         rank: int,
         comm: MPI.Comm,
         micro_problem_cls: MicroSimulationClass,
+        model_manager: ModelManager,
     ) -> None:
         """
         Class constructor.
@@ -51,9 +53,16 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             Communicator for MPI.
         micro_problem_cls : callable
             Class of micro problem.
+        model_manager : object of class ModelManager
+            Handles instantiation of the micro simulation.
         """
         super().__init__(
-            configurator, global_number_of_sims, micro_problem_cls, base_logger, rank
+            configurator,
+            global_number_of_sims,
+            micro_problem_cls,
+            model_manager,
+            base_logger,
+            rank,
         )
         self._global_number_of_sims = global_number_of_sims
         self._global_ids = global_ids
@@ -462,7 +471,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         # Only handle activation of simulations on this rank
         for gid in to_be_activated_gids:
             to_be_activated_lid = self._global_ids.index(gid)
-            micro_sims[to_be_activated_lid] = self._micro_problem_cls(gid)
+            micro_sims[to_be_activated_lid] = self._model_manager.get_instance(
+                gid, self._micro_problem_cls
+            )
             assoc_active_gid = self._sim_is_associated_to[gid]
 
             if self._is_sim_on_this_rank[
@@ -499,7 +510,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             local_ids = to_be_activated_map[gid]
             for lid in local_ids:
                 # Create the micro simulation object and set its state
-                micro_sims[lid] = self._micro_problem_cls(self._global_ids[lid])
+                micro_sims[lid] = self._model_manager.get_instance(
+                    self._global_ids[lid], self._micro_problem_cls
+                )
                 micro_sims[lid].set_state(state)
 
         # Delete the micro simulation object if it is inactive

--- a/micro_manager/adaptivity/global_adaptivity_lb.py
+++ b/micro_manager/adaptivity/global_adaptivity_lb.py
@@ -13,6 +13,7 @@ from .global_adaptivity import GlobalAdaptivityCalculator
 from micro_manager.config import Config
 from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.tools.logging_wrapper import Logger
+from micro_manager.model_manager import ModelManager
 
 
 class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
@@ -26,6 +27,7 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
         rank: int,
         comm: MPI.Comm,
         micro_problem_cls: MicroSimulationClass,
+        model_manager: ModelManager,
     ) -> None:
         """
         Class constructor.
@@ -48,6 +50,8 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
             Communicator for MPI.
         micro_problem_cls : callable
             Class of micro problem.
+        model_manager : object of class ModelManager
+            Handles instantiation of the micro simulation.
         """
         super().__init__(
             configurator,
@@ -58,6 +62,7 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
             rank,
             comm,
             micro_problem_cls,
+            model_manager,
         )
 
         self._base_logger = base_logger
@@ -370,7 +375,9 @@ class GlobalAdaptivityLBCalculator(GlobalAdaptivityCalculator):
         # Create simulations and set them to the received states
         for req in recv_reqs:
             output, gid = req.wait()
-            micro_sims.append(self._micro_problem_cls(gid))
+            micro_sims.append(
+                self._model_manager.get_instance(gid, self._micro_problem_cls)
+            )
             micro_sims[-1].set_state(output)
             self._global_ids.append(gid)
             self._is_sim_on_this_rank[gid] = True

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -12,6 +12,7 @@ from .adaptivity import AdaptivityCalculator
 from micro_manager.config import Config
 from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.tools.logging_wrapper import Logger
+from micro_manager.model_manager import ModelManager
 
 
 class LocalAdaptivityCalculator(AdaptivityCalculator):
@@ -23,6 +24,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         rank: int,
         comm: MPI.Comm,
         micro_problem_cls: MicroSimulationClass,
+        model_manager: ModelManager,
     ) -> None:
         """
         Class constructor.
@@ -41,8 +43,12 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             Communicator for MPI.
         micro_problem_cls : callable
             Class of micro problem.
+        model_manager : object of class ModelManager
+            Handles instantiation of micro simulation.
         """
-        super().__init__(configurator, num_sims, micro_problem_cls, base_logger, rank)
+        super().__init__(
+            configurator, num_sims, micro_problem_cls, model_manager, base_logger, rank
+        )
         self._comm = comm
 
         # similarity_dists: 2D array having similarity distances between each micro simulation pair
@@ -295,7 +301,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         # Update the set of inactive micro sims
         for i in to_be_activated_ids:
             associated_active_id = self._sim_is_associated_to[i]
-            micro_sims[i] = self._micro_problem_cls(i)
+            micro_sims[i] = self._model_manager.get_instance(i, self._micro_problem_cls)
             micro_sims[i].set_state(micro_sims[associated_active_id].get_state())
             self._sim_is_associated_to[
                 i

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -11,6 +11,7 @@ from micro_manager.micro_simulation import (
 )
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.misc import clamp_in_range
+from micro_manager.model_manager import ModelManager
 from micro_manager.tasking.connection import Connection
 
 import numpy as np
@@ -20,6 +21,7 @@ import importlib
 class ModelAdaptivity:
     def __init__(
         self,
+        model_manager: ModelManager,
         configurator: Config,
         rank: int,
         log_file: str,
@@ -40,12 +42,15 @@ class ModelAdaptivity:
         """
         self._logger = Logger(__name__, log_file, rank)
 
+        self._model_manager = model_manager
         self._model_files = configurator.get_model_adaptivity_file_names()
         self._switching_func_name = (
             configurator.get_model_adaptivity_switching_function()
         )
 
+        stateless_flags = configurator.get_model_adaptivity_micro_stateless()
         self._model_classes = []
+        pos = 0
         for model_file in self._model_files:
             try:
                 model = load_backend_class(model_file)
@@ -54,6 +59,10 @@ class ModelAdaptivity:
                         self._logger, model, model_file, num_ranks, conn
                     )
                 )
+                self._model_manager.register(
+                    self._model_classes[pos], stateless_flags[pos]
+                )
+                pos += 1
             except Exception as e:
                 self._logger.log_info_rank_zero(
                     f"Failed to load model class with error: {e}"
@@ -177,7 +186,9 @@ class ModelAdaptivity:
             sim.attachments[key] = sim.get_state()
 
             # construct new sim and delay initialization if possible
-            sim_new = target_class(gid, late_init=new_state_exists)
+            sim_new = self._model_manager.get_instance(
+                gid, target_class, late_init=new_state_exists
+            )
             # need to copy over the multi-state buffer to new sim object
             sim_new.attachments = sim.attachments
             sim_new.attachments[key_new] = sim_new.get_state()

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -131,7 +131,7 @@ class Config:
         except:
             self._micro_stateless = False
             self._logger.log_info_rank_zero(
-                "Creating full instance of Micro Model per mesh vertex."
+                "Creating an instance of MicroSimulation for each mesh vertex."
             )
 
         self._logger.log_info_rank_zero(

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -25,6 +25,7 @@ class Config:
         self._config_file_name = config_file_name
         self._logger = None
         self._micro_file_name = None
+        self._micro_stateless = False
 
         self._precice_config_file_name = None
         self._macro_mesh_name = None
@@ -72,6 +73,7 @@ class Config:
         # Model Adaptivity information
         self._m_adap = False
         self._m_adap_micro_file_names = None
+        self._m_adap_micro_stateless = None
         self._m_adap_switching_function = None
 
         # Tasking
@@ -120,6 +122,17 @@ class Config:
             .replace("\\", ".")
             .replace(".py", "")
         )
+
+        try:
+            self._micro_stateless = self._data["micro_stateless"]
+            self._logger.log_info_rank_zero(
+                "Only creating one full instance of Micro Model."
+            )
+        except:
+            self._micro_stateless = False
+            self._logger.log_info_rank_zero(
+                "Creating full instance of Micro Model per mesh vertex."
+            )
 
         self._logger.log_info_rank_zero(
             "Micro simulation file name: " + self._data["micro_file_name"]
@@ -511,6 +524,28 @@ class Config:
                 "model_adaptivity_settings"
             ]["switching_function"]
 
+            if (
+                "micro_stateless"
+                in self._data["simulation_params"]["model_adaptivity_settings"]
+            ):
+                self._m_adap_micro_stateless = self._data["simulation_params"][
+                    "model_adaptivity_settings"
+                ]["micro_stateless"]
+            else:
+                self._m_adap_micro_stateless = [False] * len(
+                    self._m_adap_micro_file_names
+                )
+
+            for i in range(len(self._m_adap_micro_file_names)):
+                if self._m_adap_micro_stateless[i]:
+                    self._logger.log_info_rank_zero(
+                        f"Only creating one full instance of Micro Model {i}."
+                    )
+                else:
+                    self._logger.log_info_rank_zero(
+                        f"Creating full instance of Micro Model {i} per mesh vertex."
+                    )
+
         if "interpolate_crash" in self._data["simulation_params"]:
             if self._data["simulation_params"]["interpolate_crash"]:
                 self._interpolate_crash = True
@@ -686,6 +721,17 @@ class Config:
             String carrying the path to the Python script of the micro-simulation.
         """
         return self._micro_file_name
+
+    def turn_on_micro_stateless(self):
+        """
+        Boolean stating whether micro model is stateless or not.
+
+        Returns
+        -------
+        stateless : bool
+            True if micro model is stateless, False otherwise.
+        """
+        return self._micro_stateless
 
     def get_micro_output_n(self):
         """
@@ -1003,6 +1049,17 @@ class Config:
             String carrying the path to the Python script of the micro-simulation.
         """
         return self._m_adap_micro_file_names
+
+    def get_model_adaptivity_micro_stateless(self):
+        """
+        List of boolean stating whether the respective micro model is stateless or not.
+
+        Returns
+        -------
+        stateless : list
+            True if micro model is stateless, False otherwise.
+        """
+        return self._m_adap_micro_stateless
 
     def get_model_adaptivity_switching_function(self):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -126,7 +126,7 @@ class Config:
         try:
             self._micro_stateless = self._data["micro_stateless"]
             self._logger.log_info_rank_zero(
-                "Only creating one full instance of Micro Model."
+                "Only creating one full instance of MicroSimulation."
             )
         except:
             self._micro_stateless = False

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -25,12 +25,11 @@ from functools import partial
 
 import precice
 
+from .model_manager import ModelManager
 from .micro_manager_base import MicroManager
 
-from .adaptivity.global_adaptivity import GlobalAdaptivityCalculator
-from .adaptivity.local_adaptivity import LocalAdaptivityCalculator
-from .adaptivity.global_adaptivity_lb import GlobalAdaptivityLBCalculator
 from .adaptivity.model_adaptivity import ModelAdaptivity
+from .adaptivity.adaptivity_selection import create_adaptivity_calculator
 
 from .domain_decomposition import DomainDecomposer
 from .tasking.connection import spawn_local_workers
@@ -156,6 +155,7 @@ class MicroManagerCoupling(MicroManager):
         self._t = 0  # global time
         self._n = 0  # sim-step
 
+        self._model_manager = ModelManager()
         self._conn = None
 
     # **************
@@ -585,6 +585,7 @@ class MicroManagerCoupling(MicroManager):
         micro_problem_cls = None
         if self._is_model_adaptivity_on:
             self._model_adaptivity_controller: ModelAdaptivity = ModelAdaptivity(
+                self._model_manager,
                 self._config,
                 self._rank,
                 self._log_file,
@@ -604,54 +605,32 @@ class MicroManagerCoupling(MicroManager):
                 self._conn,
                 "MicroSimulationDefault",
             )
+            self._model_manager.register(
+                micro_problem_cls, self._config.turn_on_micro_stateless()
+            )
 
         # Create micro simulation objects
         self._micro_sims = [0] * self._local_number_of_sims
         if not self._lazy_init:
             for i in range(self._local_number_of_sims):
-                self._micro_sims[i] = micro_problem_cls(
-                    self._global_ids_of_local_sims[i]
+                self._micro_sims[i] = self._model_manager.get_instance(
+                    self._global_ids_of_local_sims[i], micro_problem_cls
                 )
 
         if self._is_adaptivity_on:
-            if self._config.get_adaptivity_type() == "local":
-                self._adaptivity_controller: LocalAdaptivityCalculator = (
-                    LocalAdaptivityCalculator(
-                        self._config,
-                        self._local_number_of_sims,
-                        self._logger,
-                        self._rank,
-                        self._comm,
-                        micro_problem_cls,
-                    )
-                )
-            elif self._config.get_adaptivity_type() == "global":
-                if self._is_adaptivity_with_load_balancing:
-                    self._adaptivity_controller: GlobalAdaptivityLBCalculator = (
-                        GlobalAdaptivityLBCalculator(
-                            self._config,
-                            self._global_number_of_sims,
-                            self._global_ids_of_local_sims,
-                            self._participant,
-                            self._logger,
-                            self._rank,
-                            self._comm,
-                            micro_problem_cls,
-                        )
-                    )
-                else:
-                    self._adaptivity_controller: GlobalAdaptivityCalculator = (
-                        GlobalAdaptivityCalculator(
-                            self._config,
-                            self._global_number_of_sims,
-                            self._global_ids_of_local_sims,
-                            self._participant,
-                            self._logger,
-                            self._rank,
-                            self._comm,
-                            micro_problem_cls,
-                        )
-                    )
+            self._adaptivity_controller = create_adaptivity_calculator(
+                self._config,
+                self._local_number_of_sims,
+                self._global_number_of_sims,
+                self._global_ids_of_local_sims,
+                self._participant,
+                self._logger,
+                self._rank,
+                self._comm,
+                micro_problem_cls,
+                self._model_manager,
+                self._is_adaptivity_with_load_balancing,
+            )
 
             self._micro_sims_active_steps = np.zeros(
                 self._global_number_of_sims
@@ -690,8 +669,8 @@ class MicroManagerCoupling(MicroManager):
                     return
 
                 for i in active_sim_lids:
-                    self._micro_sims[i] = micro_problem_cls(
-                        self._global_ids_of_local_sims[i]
+                    self._micro_sims[i] = self._model_manager.get_instance(
+                        self._global_ids_of_local_sims[i], micro_problem_cls
                     )
 
                 first_id = active_sim_lids[0]  # First active simulation ID

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -1,4 +1,4 @@
-from micro_simulation import MicroSimulationClass, MicroSimulationWrapper, MicroSimulationInterface
+from micro_manager.micro_simulation import MicroSimulationClass, MicroSimulationWrapper, MicroSimulationInterface
 
 class ModelWrapper(MicroSimulationInterface):
     """

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -1,16 +1,17 @@
-class ModelWrapper:
+from micro_simulation import MicroSimulationClass, MicroSimulationWrapper, MicroSimulationInterface
+
+class ModelWrapper(MicroSimulationInterface):
     """
-    Stateless Model Wrapper
+    Stateless Model Wrapper, will delegate any method call to the main compute instance.
+    This is used to replace instances in the main simulation container.
     """
 
-    def __init__(self, global_id, backend, attach_init, attach_output):
+    def __init__(self, global_id, backend):
         self._global_id = global_id
         self._backend = backend
 
-        if attach_init:
-            self.initialize = backend.initialize
-        if attach_output:
-            self.output = backend.output
+    def set_global_id(self, global_id):
+        self._global_id = global_id
 
     def get_global_id(self) -> int:
         return self._global_id
@@ -23,6 +24,12 @@ class ModelWrapper:
 
     def set_state(self, state):
         self._backend.set_state(state)
+
+    def initialize(self, *args, **kwargs):
+        return self._backend.initialize(*args, **kwargs)
+
+    def output(self):
+        return self._backend.output()
 
     @property
     def __class__(self):
@@ -42,14 +49,27 @@ class ModelWrapper:
 
 
 class ModelManager:
+    """
+    Manages all used micro simulation models. Stores their classes and checks whether they may
+    use model instancing. To generate instances use the get_instance method regardless of model instancing,
+    as the ModelManager handles either case.
+    """
     def __init__(self):
-        self._registered_classes = []
-        self._stateless_map = dict()
-        self._backend_map = dict()
-        self._has_init_map = dict()
-        self._has_output_map = dict()
+        self._registered_classes: list[MicroSimulationClass] = []
+        self._stateless_map     : dict[MicroSimulationClass, bool] = dict()
+        self._backend_map       : dict[MicroSimulationClass, MicroSimulationWrapper] = dict()
 
-    def register(self, micro_sim_cls, stateless):
+    def register(self, micro_sim_cls: MicroSimulationClass, stateless: bool):
+        """
+        Register a micro simulation class to create an instance of later.
+
+        Parameters
+        ----------
+        micro_sim_cls : MicroSimulationClass
+            Micro simulation class to register.
+        stateless: bool
+            Is the simulation class stateless.
+        """
         if micro_sim_cls in self._registered_classes:
             return
 
@@ -61,19 +81,25 @@ class ModelManager:
                 len(self._registered_classes) - 1
             )
 
-        self._has_init_map[micro_sim_cls] = False
-        if hasattr(micro_sim_cls, "initialize") and callable(
-            getattr(micro_sim_cls, "initialize")
-        ):
-            self._has_init_map[micro_sim_cls] = True
+    def get_instance(self, gid: int, micro_sim_cls: MicroSimulationClass, *, late_init: bool=False) -> MicroSimulationInterface:
+        """
+        Creates an instance of the requested class. If the class should be initialized later,
+        the request will be delegated to the micro simulation object (in case it supports it).
 
-        self._has_output_map[micro_sim_cls] = False
-        if hasattr(micro_sim_cls, "output") and callable(
-            getattr(micro_sim_cls, "output")
-        ):
-            self._has_output_map[micro_sim_cls] = True
+        Parameters
+        ----------
+        gid: int
+            Global Simulation ID
+        micro_sim_cls: MicroSimulationClass
+            Requested micro simulation class
+        late_init: bool
+            Should the simulation be initialized later?
 
-    def get_instance(self, gid, micro_sim_cls, *, late_init=False):
+        Returns
+        -------
+        micro_sim : MicroSimulationInterface
+            Instance of the requested micro simulation class, either delegator or compute instance
+        """
         if micro_sim_cls not in self._registered_classes:
             raise RuntimeError("Trying to create instance of unknown class!")
 
@@ -81,8 +107,6 @@ class ModelManager:
             return ModelWrapper(
                 gid,
                 self._backend_map[micro_sim_cls],
-                self._has_init_map[micro_sim_cls],
-                self._has_output_map[micro_sim_cls],
             )
         else:
             return micro_sim_cls(gid, late_init=late_init)

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -67,7 +67,7 @@ class ModelManager:
 
     def register(self, micro_sim_cls: MicroSimulationClass, stateless: bool):
         """
-        Register a micro simulation class to create an instance of later.
+        Register a micro simulation class to create an instance of it later.
 
         Parameters
         ----------

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -1,4 +1,9 @@
-from micro_manager.micro_simulation import MicroSimulationClass, MicroSimulationWrapper, MicroSimulationInterface
+from micro_manager.micro_simulation import (
+    MicroSimulationClass,
+    MicroSimulationWrapper,
+    MicroSimulationInterface,
+)
+
 
 class ModelWrapper(MicroSimulationInterface):
     """
@@ -54,10 +59,11 @@ class ModelManager:
     use model instancing. To generate instances use the get_instance method regardless of model instancing,
     as the ModelManager handles either case.
     """
+
     def __init__(self):
         self._registered_classes: list[MicroSimulationClass] = []
-        self._stateless_map     : dict[MicroSimulationClass, bool] = dict()
-        self._backend_map       : dict[MicroSimulationClass, MicroSimulationWrapper] = dict()
+        self._stateless_map: dict[MicroSimulationClass, bool] = dict()
+        self._backend_map: dict[MicroSimulationClass, MicroSimulationWrapper] = dict()
 
     def register(self, micro_sim_cls: MicroSimulationClass, stateless: bool):
         """
@@ -81,7 +87,9 @@ class ModelManager:
                 len(self._registered_classes) - 1
             )
 
-    def get_instance(self, gid: int, micro_sim_cls: MicroSimulationClass, *, late_init: bool=False) -> MicroSimulationInterface:
+    def get_instance(
+        self, gid: int, micro_sim_cls: MicroSimulationClass, *, late_init: bool = False
+    ) -> MicroSimulationInterface:
         """
         Creates an instance of the requested class. If the class should be initialized later,
         the request will be delegated to the micro simulation object (in case it supports it).

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -1,0 +1,88 @@
+class ModelWrapper:
+    """
+    Stateless Model Wrapper
+    """
+
+    def __init__(self, global_id, backend, attach_init, attach_output):
+        self._global_id = global_id
+        self._backend = backend
+
+        if attach_init:
+            self.initialize = backend.initialize
+        if attach_output:
+            self.output = backend.output
+
+    def get_global_id(self) -> int:
+        return self._global_id
+
+    def solve(self, macro_data, dt):
+        return self._backend.solve(macro_data, dt)
+
+    def get_state(self):
+        return self._backend.get_state()
+
+    def set_state(self, state):
+        self._backend.set_state(state)
+
+    @property
+    def __class__(self):
+        return self._backend.__class__
+
+    @property
+    def attachments(self):
+        return self._backend.attachments
+
+    @attachments.setter
+    def attachments(self, value):
+        self._backend.attachments = value
+
+    @property
+    def name(self):
+        return self._backend.name
+
+
+class ModelManager:
+    def __init__(self):
+        self._registered_classes = []
+        self._stateless_map = dict()
+        self._backend_map = dict()
+        self._has_init_map = dict()
+        self._has_output_map = dict()
+
+    def register(self, micro_sim_cls, stateless):
+        if micro_sim_cls in self._registered_classes:
+            return
+
+        self._registered_classes.append(micro_sim_cls)
+        self._stateless_map[micro_sim_cls] = stateless
+
+        if stateless:
+            self._backend_map[micro_sim_cls] = micro_sim_cls(
+                len(self._registered_classes) - 1
+            )
+
+        self._has_init_map[micro_sim_cls] = False
+        if hasattr(micro_sim_cls, "initialize") and callable(
+            getattr(micro_sim_cls, "initialize")
+        ):
+            self._has_init_map[micro_sim_cls] = True
+
+        self._has_output_map[micro_sim_cls] = False
+        if hasattr(micro_sim_cls, "output") and callable(
+            getattr(micro_sim_cls, "output")
+        ):
+            self._has_output_map[micro_sim_cls] = True
+
+    def get_instance(self, gid, micro_sim_cls, *, late_init=False):
+        if micro_sim_cls not in self._registered_classes:
+            raise RuntimeError("Trying to create instance of unknown class!")
+
+        if self._stateless_map[micro_sim_cls]:
+            return ModelWrapper(
+                gid,
+                self._backend_map[micro_sim_cls],
+                self._has_init_map[micro_sim_cls],
+                self._has_output_map[micro_sim_cls],
+            )
+        else:
+            return micro_sim_cls(gid, late_init=late_init)

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -25,6 +25,11 @@ class MicroSimulation:
         pass
 
 
+class ModelManager:
+    def get_instance(self, gid, micro_problem_cls):
+        return micro_problem_cls(gid)
+
+
 class TestGlobalAdaptivity(TestCase):
     def setUp(self):
         self._comm = MPI.COMM_WORLD
@@ -63,6 +68,7 @@ class TestGlobalAdaptivity(TestCase):
             rank=self._rank,
             comm=self._comm,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         adaptivity_controller._is_sim_active = np.array(
@@ -137,6 +143,7 @@ class TestGlobalAdaptivity(TestCase):
             rank=self._rank,
             comm=self._comm,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         adaptivity_controller._adaptivity_data_names = ["data1", "data2"]
@@ -192,6 +199,7 @@ class TestGlobalAdaptivity(TestCase):
             rank=self._rank,
             comm=self._comm,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         adaptivity_controller._is_sim_active = np.array(
@@ -231,6 +239,7 @@ class TestGlobalAdaptivity(TestCase):
             rank=self._rank,
             comm=self._comm,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         actual_ranks_of_sims = adaptivity_controller._get_ranks_of_sims()

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -29,6 +29,11 @@ class MicroSimulation:
         pass
 
 
+class ModelManager:
+    def get_instance(self, gid, micro_problem_cls):
+        return micro_problem_cls(gid)
+
+
 class TestLocalAdaptivity(TestCase):
     def setUp(self):
         self._number_of_sims = 5
@@ -97,6 +102,7 @@ class TestLocalAdaptivity(TestCase):
             configurator,
             nsims=self._number_of_sims,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
             base_logger=MagicMock(),
             rank=0,
         )
@@ -149,6 +155,7 @@ class TestLocalAdaptivity(TestCase):
             rank=0,
             comm=MagicMock(),
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
@@ -185,6 +192,7 @@ class TestLocalAdaptivity(TestCase):
             base_logger=MagicMock(),
             rank=0,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         fake_data = np.array([[1], [2], [3]])
@@ -283,6 +291,7 @@ class TestLocalAdaptivity(TestCase):
             base_logger=MagicMock(),
             rank=0,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const
@@ -326,6 +335,7 @@ class TestLocalAdaptivity(TestCase):
             rank=0,
             comm=MPI.COMM_WORLD,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
         adaptivity_controller._refine_const = self._refine_const
         adaptivity_controller._coarse_const = self._coarse_const

--- a/tests/unit/test_global_adaptivity_lb.py
+++ b/tests/unit/test_global_adaptivity_lb.py
@@ -26,6 +26,11 @@ class MicroSimulation:
         pass
 
 
+class ModelManager:
+    def get_instance(self, gid, micro_problem_cls):
+        return micro_problem_cls(gid)
+
+
 class TestGlobalAdaptivityLB(TestCase):
     def setUp(self):
         self._comm = MPI.COMM_WORLD
@@ -71,6 +76,7 @@ class TestGlobalAdaptivityLB(TestCase):
             rank=self._rank,
             comm=self._comm,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         adaptivity_controller._is_sim_active = np.array(
@@ -121,6 +127,7 @@ class TestGlobalAdaptivityLB(TestCase):
             rank=self._rank,
             comm=self._comm,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         adaptivity_controller._is_sim_active = np.array(
@@ -174,6 +181,7 @@ class TestGlobalAdaptivityLB(TestCase):
             rank=self._rank,
             comm=self._comm,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         adaptivity_controller._is_sim_active = np.array(
@@ -246,6 +254,7 @@ class TestGlobalAdaptivityLB(TestCase):
             rank=self._rank,
             comm=self._comm,
             micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         adaptivity_controller._is_sim_active = np.array(


### PR DESCRIPTION
Model instancing allows reusing the same micro simulation object as a compute backend to compute the results of different GIDs. This is only applicable for simulation types that are marked as stateless, thus not depending on the previous local compute history.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
