### PR TITLE
Fix duplicate micro simulations for macro-points on rank boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed duplicate micro simulations for macro-points on rank boundaries by filtering coordinates already claimed by lower-ranked ranks [#230](https://github.com/precice/micro-manager/pull/230)
 - Exposed `MicroSimulationInterface` as a public abstract base class for user subclassing [#224](https://github.com/precice/micro-manager/pull/224)
 - Added option to use compute instances to reduce memory consumption [#226](https://github.com/precice/micro-manager/pull/226)
 - Added support to run micro simulations in separate processes with workers [#219](https://github.com/precice/micro-manager/pull/219)

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -135,56 +135,50 @@ class DomainDecomposer:
 
         return micro_sims_on_rank, macro_coords_on_this_rank
 
+    def filter_duplicate_coords(
+        self,
+        all_coords: list,
+        all_ids: list,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Filter out vertex coordinates that are already owned by a lower-ranked rank.
 
-def filter_duplicate_coords(
-    my_rank: int,
-    size: int,
-    all_coords: list,
-    all_ids: list,
-) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Filter out vertex coordinates that are already owned by a lower-ranked rank.
+        When a macro-point lies exactly on the boundary between two rank bounding
+        boxes, preCICE returns it to both ranks. This function ensures every vertex
+        is processed by exactly one rank — the lowest-ranked rank that received it —
+        while preserving the preCICE ID-coord pairing.
 
-    When a macro-point lies exactly on the boundary between two rank bounding
-    boxes, preCICE returns it to both ranks. This function ensures every vertex
-    is processed by exactly one rank — the lowest-ranked rank that received it —
-    while preserving the preCICE ID-coord pairing.
+        Parameters
+        ----------
+        all_coords : list
+            List of numpy arrays, one per rank, containing vertex coordinates.
+        all_ids : list
+            List of arrays, one per rank, containing preCICE vertex IDs.
 
-    Parameters
-    ----------
-    my_rank : int
-        MPI rank of the calling process.
-    size : int
-        Total number of MPI processes.
-    all_coords : list
-        List of numpy arrays, one per rank, containing vertex coordinates.
-    all_ids : list
-        List of arrays, one per rank, containing preCICE vertex IDs.
+        Returns
+        -------
+        filtered_coords : numpy.ndarray
+            Vertex coordinates with duplicates removed.
+        filtered_ids : numpy.ndarray
+            preCICE vertex IDs corresponding to the filtered coordinates.
+        """
+        mesh_vertex_coords = np.array(all_coords[self._rank])
+        mesh_vertex_ids = np.array(all_ids[self._rank])
 
-    Returns
-    -------
-    filtered_coords : numpy.ndarray
-        Vertex coordinates with duplicates removed.
-    filtered_ids : numpy.ndarray
-        preCICE vertex IDs corresponding to the filtered coordinates.
-    """
-    mesh_vertex_coords = np.array(all_coords[my_rank])
-    mesh_vertex_ids = np.array(all_ids[my_rank])
+        seen_coords = set()
+        keep_mask = np.ones(len(mesh_vertex_coords), dtype=bool)
 
-    seen_coords = set()
-    keep_mask = np.ones(len(mesh_vertex_coords), dtype=bool)
-
-    for rank in range(size):
-        for i, coord in enumerate(all_coords[rank]):
-            coord_key = tuple(np.round(coord, decimals=10))
-            if rank < my_rank:
-                # Mark coords already claimed by earlier ranks
-                seen_coords.add(coord_key)
-            elif rank == my_rank:
-                # Only keep coords not already claimed by earlier ranks
-                if coord_key in seen_coords:
-                    keep_mask[i] = False
-                else:
+        for rank in range(self._size):
+            for i, coord in enumerate(all_coords[rank]):
+                coord_key = tuple(np.round(coord, decimals=10))
+                if rank < self._rank:
+                    # Mark coords already claimed by earlier ranks
                     seen_coords.add(coord_key)
+                elif rank == self._rank:
+                    # Only keep coords not already claimed by earlier ranks
+                    if coord_key in seen_coords:
+                        keep_mask[i] = False
+                    else:
+                        seen_coords.add(coord_key)
 
-    return mesh_vertex_coords[keep_mask], mesh_vertex_ids[keep_mask]
+        return mesh_vertex_coords[keep_mask], mesh_vertex_ids[keep_mask]

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -123,10 +123,9 @@ class DomainDecomposer:
         for position in macro_coords:
             inside = True
             for d in range(len(ranks_per_axis)):
-                is_upper_boundary = np.isclose(local_mesh_bounds[d * 2 + 1], macro_bounds[d * 2 + 1])
                 if not (
                     position[d] >= local_mesh_bounds[d * 2]
-                    and (position[d] <= local_mesh_bounds[d * 2 + 1] if is_upper_boundary else position[d] < local_mesh_bounds[d * 2 + 1])
+                    and position[d] <= local_mesh_bounds[d * 2 + 1]
                 ):
                     inside = False
                     break

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -134,3 +134,57 @@ class DomainDecomposer:
                 micro_sims_on_rank += 1
 
         return micro_sims_on_rank, macro_coords_on_this_rank
+
+
+def filter_duplicate_coords(
+    my_rank: int,
+    size: int,
+    all_coords: list,
+    all_ids: list,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Filter out vertex coordinates that are already owned by a lower-ranked rank.
+
+    When a macro-point lies exactly on the boundary between two rank bounding
+    boxes, preCICE returns it to both ranks. This function ensures every vertex
+    is processed by exactly one rank — the lowest-ranked rank that received it —
+    while preserving the preCICE ID-coord pairing.
+
+    Parameters
+    ----------
+    my_rank : int
+        MPI rank of the calling process.
+    size : int
+        Total number of MPI processes.
+    all_coords : list
+        List of numpy arrays, one per rank, containing vertex coordinates.
+    all_ids : list
+        List of arrays, one per rank, containing preCICE vertex IDs.
+
+    Returns
+    -------
+    filtered_coords : numpy.ndarray
+        Vertex coordinates with duplicates removed.
+    filtered_ids : numpy.ndarray
+        preCICE vertex IDs corresponding to the filtered coordinates.
+    """
+    mesh_vertex_coords = np.array(all_coords[my_rank])
+    mesh_vertex_ids = np.array(all_ids[my_rank])
+
+    seen_coords = set()
+    keep_mask = np.ones(len(mesh_vertex_coords), dtype=bool)
+
+    for rank in range(size):
+        for i, coord in enumerate(all_coords[rank]):
+            coord_key = tuple(np.round(coord, decimals=10))
+            if rank < my_rank:
+                # Mark coords already claimed by earlier ranks
+                seen_coords.add(coord_key)
+            elif rank == my_rank:
+                # Only keep coords not already claimed by earlier ranks
+                if coord_key in seen_coords:
+                    keep_mask[i] = False
+                else:
+                    seen_coords.add(coord_key)
+
+    return mesh_vertex_coords[keep_mask], mesh_vertex_ids[keep_mask]

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -121,17 +121,17 @@ class DomainDecomposer:
 
         micro_sims_on_rank = 0
         for position in macro_coords:
-    inside = True
-    for d in range(len(ranks_per_axis)):
-        is_upper_boundary = np.isclose(local_mesh_bounds[d * 2 + 1], macro_bounds[d * 2 + 1])
-        if not (
-            position[d] >= local_mesh_bounds[d * 2]
-            and (position[d] <= local_mesh_bounds[d * 2 + 1] if is_upper_boundary else position[d] < local_mesh_bounds[d * 2 + 1])
-        ):
-            inside = False
-            break
-    if inside:
-        macro_coords_on_this_rank.append(position)
-        micro_sims_on_rank += 1
+            inside = True
+            for d in range(len(ranks_per_axis)):
+                is_upper_boundary = np.isclose(local_mesh_bounds[d * 2 + 1], macro_bounds[d * 2 + 1])
+                if not (
+                    position[d] >= local_mesh_bounds[d * 2]
+                    and (position[d] <= local_mesh_bounds[d * 2 + 1] if is_upper_boundary else position[d] < local_mesh_bounds[d * 2 + 1])
+                ):
+                    inside = False
+                    break
+            if inside:
+                macro_coords_on_this_rank.append(position)
+                micro_sims_on_rank += 1
 
         return micro_sims_on_rank, macro_coords_on_this_rank

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -121,16 +121,17 @@ class DomainDecomposer:
 
         micro_sims_on_rank = 0
         for position in macro_coords:
-            inside = True
-            for d in range(len(ranks_per_axis)):
-                if not (
-                    position[d] >= local_mesh_bounds[d * 2]
-                    and position[d] <= local_mesh_bounds[d * 2 + 1]
-                ):
-                    inside = False
-                    break
-            if inside:
-                macro_coords_on_this_rank.append(position)
-                micro_sims_on_rank += 1
+    inside = True
+    for d in range(len(ranks_per_axis)):
+        is_upper_boundary = np.isclose(local_mesh_bounds[d * 2 + 1], macro_bounds[d * 2 + 1])
+        if not (
+            position[d] >= local_mesh_bounds[d * 2]
+            and (position[d] <= local_mesh_bounds[d * 2 + 1] if is_upper_boundary else position[d] < local_mesh_bounds[d * 2 + 1])
+        ):
+            inside = False
+            break
+    if inside:
+        macro_coords_on_this_rank.append(position)
+        micro_sims_on_rank += 1
 
         return micro_sims_on_rank, macro_coords_on_this_rank

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -738,9 +738,9 @@ class MicroManagerCoupling(MicroManager):
                     # Save initial data from first micro simulation as we anyway have it
                     for name in initial_micro_output.keys():
                         if name in self._data_for_adaptivity:
-                            self._data_for_adaptivity[name][first_id] = (
-                                initial_micro_output[name]
-                            )
+                            self._data_for_adaptivity[name][
+                                first_id
+                            ] = initial_micro_output[name]
                         else:
                             raise Exception(
                                 "The initialize() method needs to return data which is required for the adaptivity calculation."
@@ -753,17 +753,17 @@ class MicroManagerCoupling(MicroManager):
                                 initial_data[i]
                             )
                             for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][i] = (
-                                    initial_micro_output[name]
-                                )
+                                self._data_for_adaptivity[name][
+                                    i
+                                ] = initial_micro_output[name]
                                 initial_micro_data[name][i] = initial_micro_output[name]
                     else:
                         for i in micro_sims_to_init:
                             initial_micro_output = self._micro_sims[i].initialize()
                             for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][i] = (
-                                    initial_micro_output[name]
-                                )
+                                self._data_for_adaptivity[name][
+                                    i
+                                ] = initial_micro_output[name]
                                 initial_micro_data[name][i] = initial_micro_output[name]
 
                     # If lazy initialization is on, initial states of inactive simulations need to be determined
@@ -975,9 +975,9 @@ class MicroManagerCoupling(MicroManager):
                     # Mark the micro sim as active for export
                     micro_sims_output[lid]["Active-State"] = 1
                     gid = self._global_ids_of_local_sims[lid]
-                    micro_sims_output[lid]["Active-Steps"] = (
-                        self._micro_sims_active_steps[gid]
-                    )
+                    micro_sims_output[lid][
+                        "Active-Steps"
+                    ] = self._micro_sims_active_steps[gid]
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
@@ -1031,9 +1031,9 @@ class MicroManagerCoupling(MicroManager):
         for inactive_lid in inactive_sim_lids:
             micro_sims_output[inactive_lid]["Active-State"] = 0
             gid = self._global_ids_of_local_sims[inactive_lid]
-            micro_sims_output[inactive_lid]["Active-Steps"] = (
-                self._micro_sims_active_steps[gid]
-            )
+            micro_sims_output[inactive_lid][
+                "Active-Steps"
+            ] = self._micro_sims_active_steps[gid]
 
         # Collect micro sim output for adaptivity calculation
         for i in range(self._local_number_of_sims):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -476,6 +476,33 @@ class MicroManagerCoupling(MicroManager):
             self._mesh_vertex_coords,
         ) = self._participant.get_mesh_vertex_ids_and_coordinates(self._macro_mesh_name)
 
+        if self._is_parallel:
+            # Gather all vertex coords and IDs from all ranks onto all ranks,
+            # find globally duplicated coords, and remove them from this rank
+            # while preserving the preCICE ID-coord pairing.
+            all_coords = self._comm.allgather(self._mesh_vertex_coords)
+            all_ids = self._comm.allgather(self._mesh_vertex_ids)
+
+            # Build a global set of (coord, id) pairs seen by previous ranks
+            seen_coords = set()
+            keep_mask = np.ones(len(self._mesh_vertex_coords), dtype=bool)
+
+            for r in range(self._size):
+                for i, coord in enumerate(all_coords[r]):
+                    coord_key = tuple(np.round(coord, decimals=10))
+                    if r < self._rank:
+                        # Mark coords already claimed by earlier ranks
+                        seen_coords.add(coord_key)
+                    elif r == self._rank:
+                        # Only keep coords not already claimed by earlier ranks
+                        if coord_key in seen_coords:
+                            keep_mask[i] = False
+                        else:
+                            seen_coords.add(coord_key)
+
+            self._mesh_vertex_coords = self._mesh_vertex_coords[keep_mask]
+            self._mesh_vertex_ids = self._mesh_vertex_ids[keep_mask]
+
         if self._mesh_vertex_coords.size == 0:
             raise Exception("Macro mesh has no vertices.")
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -485,9 +485,10 @@ class MicroManagerCoupling(MicroManager):
             all_coords = self._comm.allgather(self._mesh_vertex_coords)
             all_ids = self._comm.allgather(self._mesh_vertex_ids)
 
-            self._mesh_vertex_coords, self._mesh_vertex_ids = (
-                domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
-            )
+            (
+                self._mesh_vertex_coords,
+                self._mesh_vertex_ids,
+            ) = domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
 
         if self._mesh_vertex_coords.size == 0:
             raise Exception("Macro mesh has no vertices.")

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -754,9 +754,9 @@ class MicroManagerCoupling(MicroManager):
                     # Save initial data from first micro simulation as we anyway have it
                     for name in initial_micro_output.keys():
                         if name in self._data_for_adaptivity:
-                            self._data_for_adaptivity[name][first_id] = (
-                                initial_micro_output[name]
-                            )
+                            self._data_for_adaptivity[name][
+                                first_id
+                            ] = initial_micro_output[name]
                         else:
                             raise Exception(
                                 "The initialize() method needs to return data which is required for the adaptivity calculation."
@@ -769,17 +769,17 @@ class MicroManagerCoupling(MicroManager):
                                 initial_data[i]
                             )
                             for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][i] = (
-                                    initial_micro_output[name]
-                                )
+                                self._data_for_adaptivity[name][
+                                    i
+                                ] = initial_micro_output[name]
                                 initial_micro_data[name][i] = initial_micro_output[name]
                     else:
                         for i in micro_sims_to_init:
                             initial_micro_output = self._micro_sims[i].initialize()
                             for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][i] = (
-                                    initial_micro_output[name]
-                                )
+                                self._data_for_adaptivity[name][
+                                    i
+                                ] = initial_micro_output[name]
                                 initial_micro_data[name][i] = initial_micro_output[name]
 
                     # If lazy initialization is on, initial states of inactive simulations need to be determined
@@ -991,9 +991,9 @@ class MicroManagerCoupling(MicroManager):
                     # Mark the micro sim as active for export
                     micro_sims_output[lid]["Active-State"] = 1
                     gid = self._global_ids_of_local_sims[lid]
-                    micro_sims_output[lid]["Active-Steps"] = (
-                        self._micro_sims_active_steps[gid]
-                    )
+                    micro_sims_output[lid][
+                        "Active-Steps"
+                    ] = self._micro_sims_active_steps[gid]
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
@@ -1047,9 +1047,9 @@ class MicroManagerCoupling(MicroManager):
         for inactive_lid in inactive_sim_lids:
             micro_sims_output[inactive_lid]["Active-State"] = 0
             gid = self._global_ids_of_local_sims[inactive_lid]
-            micro_sims_output[inactive_lid]["Active-Steps"] = (
-                self._micro_sims_active_steps[gid]
-            )
+            micro_sims_output[inactive_lid][
+                "Active-Steps"
+            ] = self._micro_sims_active_steps[gid]
 
         # Collect micro sim output for adaptivity calculation
         for i in range(self._local_number_of_sims):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -31,7 +31,7 @@ from .micro_manager_base import MicroManager
 from .adaptivity.model_adaptivity import ModelAdaptivity
 from .adaptivity.adaptivity_selection import create_adaptivity_calculator
 
-from .domain_decomposition import DomainDecomposer, filter_duplicate_coords
+from .domain_decomposition import DomainDecomposer
 from .tasking.connection import spawn_local_workers
 from .micro_simulation import create_simulation_class, load_backend_class
 from .tools.logging_wrapper import Logger
@@ -485,8 +485,8 @@ class MicroManagerCoupling(MicroManager):
             all_coords = self._comm.allgather(self._mesh_vertex_coords)
             all_ids = self._comm.allgather(self._mesh_vertex_ids)
 
-            self._mesh_vertex_coords, self._mesh_vertex_ids = filter_duplicate_coords(
-                self._rank, self._size, all_coords, all_ids
+            self._mesh_vertex_coords, self._mesh_vertex_ids = (
+                domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
             )
 
         if self._mesh_vertex_coords.size == 0:
@@ -737,9 +737,9 @@ class MicroManagerCoupling(MicroManager):
                     # Save initial data from first micro simulation as we anyway have it
                     for name in initial_micro_output.keys():
                         if name in self._data_for_adaptivity:
-                            self._data_for_adaptivity[name][
-                                first_id
-                            ] = initial_micro_output[name]
+                            self._data_for_adaptivity[name][first_id] = (
+                                initial_micro_output[name]
+                            )
                         else:
                             raise Exception(
                                 "The initialize() method needs to return data which is required for the adaptivity calculation."
@@ -752,17 +752,17 @@ class MicroManagerCoupling(MicroManager):
                                 initial_data[i]
                             )
                             for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][
-                                    i
-                                ] = initial_micro_output[name]
+                                self._data_for_adaptivity[name][i] = (
+                                    initial_micro_output[name]
+                                )
                                 initial_micro_data[name][i] = initial_micro_output[name]
                     else:
                         for i in micro_sims_to_init:
                             initial_micro_output = self._micro_sims[i].initialize()
                             for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][
-                                    i
-                                ] = initial_micro_output[name]
+                                self._data_for_adaptivity[name][i] = (
+                                    initial_micro_output[name]
+                                )
                                 initial_micro_data[name][i] = initial_micro_output[name]
 
                     # If lazy initialization is on, initial states of inactive simulations need to be determined
@@ -974,9 +974,9 @@ class MicroManagerCoupling(MicroManager):
                     # Mark the micro sim as active for export
                     micro_sims_output[lid]["Active-State"] = 1
                     gid = self._global_ids_of_local_sims[lid]
-                    micro_sims_output[lid][
-                        "Active-Steps"
-                    ] = self._micro_sims_active_steps[gid]
+                    micro_sims_output[lid]["Active-Steps"] = (
+                        self._micro_sims_active_steps[gid]
+                    )
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
@@ -1030,9 +1030,9 @@ class MicroManagerCoupling(MicroManager):
         for inactive_lid in inactive_sim_lids:
             micro_sims_output[inactive_lid]["Active-State"] = 0
             gid = self._global_ids_of_local_sims[inactive_lid]
-            micro_sims_output[inactive_lid][
-                "Active-Steps"
-            ] = self._micro_sims_active_steps[gid]
+            micro_sims_output[inactive_lid]["Active-Steps"] = (
+                self._micro_sims_active_steps[gid]
+            )
 
         # Collect micro sim output for adaptivity calculation
         for i in range(self._local_number_of_sims):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -36,7 +36,6 @@ from .tasking.connection import spawn_local_workers
 from .micro_simulation import create_simulation_class, load_backend_class
 from .tools.logging_wrapper import Logger
 
-
 try:
     from .interpolation import Interpolation
 except ImportError:
@@ -491,13 +490,13 @@ class MicroManagerCoupling(MicroManager):
             seen_coords = set()
             keep_mask = np.ones(len(self._mesh_vertex_coords), dtype=bool)
 
-            for r in range(self._size):
-                for i, coord in enumerate(all_coords[r]):
+            for rank in range(self._size):
+                for i, coord in enumerate(all_coords[rank]):
                     coord_key = tuple(np.round(coord, decimals=10))
-                    if r < self._rank:
+                    if rank < self._rank:
                         # Mark coords already claimed by earlier ranks
                         seen_coords.add(coord_key)
-                    elif r == self._rank:
+                    elif rank == self._rank:
                         # Only keep coords not already claimed by earlier ranks
                         if coord_key in seen_coords:
                             keep_mask[i] = False
@@ -755,9 +754,9 @@ class MicroManagerCoupling(MicroManager):
                     # Save initial data from first micro simulation as we anyway have it
                     for name in initial_micro_output.keys():
                         if name in self._data_for_adaptivity:
-                            self._data_for_adaptivity[name][
-                                first_id
-                            ] = initial_micro_output[name]
+                            self._data_for_adaptivity[name][first_id] = (
+                                initial_micro_output[name]
+                            )
                         else:
                             raise Exception(
                                 "The initialize() method needs to return data which is required for the adaptivity calculation."
@@ -770,17 +769,17 @@ class MicroManagerCoupling(MicroManager):
                                 initial_data[i]
                             )
                             for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][
-                                    i
-                                ] = initial_micro_output[name]
+                                self._data_for_adaptivity[name][i] = (
+                                    initial_micro_output[name]
+                                )
                                 initial_micro_data[name][i] = initial_micro_output[name]
                     else:
                         for i in micro_sims_to_init:
                             initial_micro_output = self._micro_sims[i].initialize()
                             for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][
-                                    i
-                                ] = initial_micro_output[name]
+                                self._data_for_adaptivity[name][i] = (
+                                    initial_micro_output[name]
+                                )
                                 initial_micro_data[name][i] = initial_micro_output[name]
 
                     # If lazy initialization is on, initial states of inactive simulations need to be determined
@@ -992,9 +991,9 @@ class MicroManagerCoupling(MicroManager):
                     # Mark the micro sim as active for export
                     micro_sims_output[lid]["Active-State"] = 1
                     gid = self._global_ids_of_local_sims[lid]
-                    micro_sims_output[lid][
-                        "Active-Steps"
-                    ] = self._micro_sims_active_steps[gid]
+                    micro_sims_output[lid]["Active-Steps"] = (
+                        self._micro_sims_active_steps[gid]
+                    )
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
@@ -1048,9 +1047,9 @@ class MicroManagerCoupling(MicroManager):
         for inactive_lid in inactive_sim_lids:
             micro_sims_output[inactive_lid]["Active-State"] = 0
             gid = self._global_ids_of_local_sims[inactive_lid]
-            micro_sims_output[inactive_lid][
-                "Active-Steps"
-            ] = self._micro_sims_active_steps[gid]
+            micro_sims_output[inactive_lid]["Active-Steps"] = (
+                self._micro_sims_active_steps[gid]
+            )
 
         # Collect micro sim output for adaptivity calculation
         for i in range(self._local_number_of_sims):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -31,7 +31,7 @@ from .micro_manager_base import MicroManager
 from .adaptivity.model_adaptivity import ModelAdaptivity
 from .adaptivity.adaptivity_selection import create_adaptivity_calculator
 
-from .domain_decomposition import DomainDecomposer
+from .domain_decomposition import DomainDecomposer, filter_duplicate_coords
 from .tasking.connection import spawn_local_workers
 from .micro_simulation import create_simulation_class, load_backend_class
 from .tools.logging_wrapper import Logger
@@ -481,30 +481,13 @@ class MicroManagerCoupling(MicroManager):
 
         if self._is_parallel:
             # Gather all vertex coords and IDs from all ranks onto all ranks,
-            # find globally duplicated coords, and remove them from this rank
-            # while preserving the preCICE ID-coord pairing.
+            # filter out coords already claimed by lower-ranked ranks.
             all_coords = self._comm.allgather(self._mesh_vertex_coords)
             all_ids = self._comm.allgather(self._mesh_vertex_ids)
 
-            # Build a global set of (coord, id) pairs seen by previous ranks
-            seen_coords = set()
-            keep_mask = np.ones(len(self._mesh_vertex_coords), dtype=bool)
-
-            for rank in range(self._size):
-                for i, coord in enumerate(all_coords[rank]):
-                    coord_key = tuple(np.round(coord, decimals=10))
-                    if rank < self._rank:
-                        # Mark coords already claimed by earlier ranks
-                        seen_coords.add(coord_key)
-                    elif rank == self._rank:
-                        # Only keep coords not already claimed by earlier ranks
-                        if coord_key in seen_coords:
-                            keep_mask[i] = False
-                        else:
-                            seen_coords.add(coord_key)
-
-            self._mesh_vertex_coords = self._mesh_vertex_coords[keep_mask]
-            self._mesh_vertex_ids = self._mesh_vertex_ids[keep_mask]
+            self._mesh_vertex_coords, self._mesh_vertex_ids = filter_duplicate_coords(
+                self._rank, self._size, all_coords, all_ids
+            )
 
         if self._mesh_vertex_coords.size == 0:
             raise Exception("Macro mesh has no vertices.")

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 import numpy as np
 from micro_manager.domain_decomposition import DomainDecomposer
 
-
 class TestDomainDecomposition(TestCase):
     def setUp(self) -> None:
         self._macro_bounds_3d = [
@@ -13,7 +12,6 @@ class TestDomainDecomposition(TestCase):
             -2,
             8,
         ]  # Cuboid which is not symmetric around origin
-
         self._macro_bounds_2d = [
             0,
             1,
@@ -33,7 +31,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_2d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, 1, 2]))
 
     def test_rank1_out_of_4_3d(self):
@@ -48,7 +45,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [0.0, 1, -2, 0.0, -2, 8]))
 
     def test_rank5_outof_10_3d(self):
@@ -63,7 +59,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [-1, 1, 0, 2, 2, 4]))
 
     def test_rank10_out_of_32_3d(self):
@@ -78,7 +73,6 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, -2, 2, 0.5, 1.75]))
 
     def test_rank7_out_of_16_3d(self):
@@ -93,5 +87,24 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
-
         self.assertTrue(np.allclose(mesh_bounds, [0.75, 1, -2, 0, -2, 8]))
+
+    def test_no_duplicate_coords_on_boundary_2d(self):
+        """
+        Check that a point on the boundary between two ranks is only assigned to one rank.
+        """
+        ranks_per_axis = [2, 1]
+        size = 2
+        macro_coords = np.array([[0.5, 0.5], [0.25, 0.5], [0.75, 0.5]])
+
+        decomposer_rank0 = DomainDecomposer(0, size)
+        decomposer_rank1 = DomainDecomposer(1, size)
+
+        n0, _ = decomposer_rank0.get_local_sims_and_macro_coords(
+            self._macro_bounds_2d, ranks_per_axis, macro_coords
+        )
+        n1, _ = decomposer_rank1.get_local_sims_and_macro_coords(
+            self._macro_bounds_2d, ranks_per_axis, macro_coords
+        )
+
+        self.assertEqual(n0 + n1, len(macro_coords))

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 import numpy as np
-from micro_manager.domain_decomposition import DomainDecomposer
+from micro_manager.domain_decomposition import DomainDecomposer, filter_duplicate_coords
 
 
 class TestDomainDecomposition(TestCase):
@@ -100,31 +100,8 @@ class TestDomainDecomposition(TestCase):
 class TestDuplicateCoordFiltering(TestCase):
     """
     Test that duplicate vertex coordinates returned by preCICE on rank boundaries
-    are correctly deduplicated, with lower-ranked ranks taking ownership.
+    are correctly filtered, with lower-ranked ranks taking ownership.
     """
-
-    def _run_dedup(self, my_rank, size, all_coords, all_ids):
-        """
-        Reproduce the deduplication logic from micro_manager.py for testing.
-        """
-        mesh_vertex_coords = np.array(all_coords[my_rank])
-        mesh_vertex_ids = np.array(all_ids[my_rank])
-
-        seen_coords = set()
-        keep_mask = np.ones(len(mesh_vertex_coords), dtype=bool)
-
-        for rank in range(size):
-            for i, coord in enumerate(all_coords[rank]):
-                coord_key = tuple(np.round(coord, decimals=10))
-                if rank < my_rank:
-                    seen_coords.add(coord_key)
-                elif rank == my_rank:
-                    if coord_key in seen_coords:
-                        keep_mask[i] = False
-                    else:
-                        seen_coords.add(coord_key)
-
-        return mesh_vertex_coords[keep_mask], mesh_vertex_ids[keep_mask]
 
     def test_no_duplicates(self):
         """
@@ -136,10 +113,10 @@ class TestDuplicateCoordFiltering(TestCase):
         ]
         all_ids = [[0, 1], [2, 3]]
 
-        coords, ids = self._run_dedup(0, 2, all_coords, all_ids)
+        coords, ids = filter_duplicate_coords(0, 2, all_coords, all_ids)
         self.assertEqual(len(coords), 2)
 
-        coords, ids = self._run_dedup(1, 2, all_coords, all_ids)
+        coords, ids = filter_duplicate_coords(1, 2, all_coords, all_ids)
         self.assertEqual(len(coords), 2)
 
     def test_duplicate_on_boundary_rank0_keeps(self):
@@ -155,12 +132,12 @@ class TestDuplicateCoordFiltering(TestCase):
         all_ids = [[0, 1], [1, 2]]
 
         # Rank 0 should keep both its coords
-        coords0, ids0 = self._run_dedup(0, 2, all_coords, all_ids)
+        coords0, ids0 = filter_duplicate_coords(0, 2, all_coords, all_ids)
         self.assertEqual(len(coords0), 2)
         self.assertTrue(np.allclose(coords0[1], shared))
 
         # Rank 1 should drop the shared coord
-        coords1, ids1 = self._run_dedup(1, 2, all_coords, all_ids)
+        coords1, ids1 = filter_duplicate_coords(1, 2, all_coords, all_ids)
         self.assertEqual(len(coords1), 1)
         self.assertTrue(np.allclose(coords1[0], [1.0, 0.0]))
 
@@ -176,13 +153,13 @@ class TestDuplicateCoordFiltering(TestCase):
         ]
         all_ids = [[0, 1], [0, 2], [0, 3]]
 
-        coords0, _ = self._run_dedup(0, 3, all_coords, all_ids)
+        coords0, _ = filter_duplicate_coords(0, 3, all_coords, all_ids)
         self.assertEqual(len(coords0), 2)
 
-        coords1, _ = self._run_dedup(1, 3, all_coords, all_ids)
+        coords1, _ = filter_duplicate_coords(1, 3, all_coords, all_ids)
         self.assertEqual(len(coords1), 1)
         self.assertTrue(np.allclose(coords1[0], [1.0, 0.0]))
 
-        coords2, _ = self._run_dedup(2, 3, all_coords, all_ids)
+        coords2, _ = filter_duplicate_coords(2, 3, all_coords, all_ids)
         self.assertEqual(len(coords2), 1)
         self.assertTrue(np.allclose(coords2[0], [2.0, 0.0]))

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import numpy as np
 from micro_manager.domain_decomposition import DomainDecomposer
 
+
 class TestDomainDecomposition(TestCase):
     def setUp(self) -> None:
         self._macro_bounds_3d = [
@@ -12,6 +13,7 @@ class TestDomainDecomposition(TestCase):
             -2,
             8,
         ]  # Cuboid which is not symmetric around origin
+
         self._macro_bounds_2d = [
             0,
             1,
@@ -31,6 +33,7 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_2d, ranks_per_axis
         )
+
         self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, 1, 2]))
 
     def test_rank1_out_of_4_3d(self):
@@ -45,6 +48,7 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
+
         self.assertTrue(np.allclose(mesh_bounds, [0.0, 1, -2, 0.0, -2, 8]))
 
     def test_rank5_outof_10_3d(self):
@@ -59,6 +63,7 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
+
         self.assertTrue(np.allclose(mesh_bounds, [-1, 1, 0, 2, 2, 4]))
 
     def test_rank10_out_of_32_3d(self):
@@ -73,6 +78,7 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
+
         self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, -2, 2, 0.5, 1.75]))
 
     def test_rank7_out_of_16_3d(self):
@@ -87,5 +93,96 @@ class TestDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
+
         self.assertTrue(np.allclose(mesh_bounds, [0.75, 1, -2, 0, -2, 8]))
 
+
+class TestDuplicateCoordFiltering(TestCase):
+    """
+    Test that duplicate vertex coordinates returned by preCICE on rank boundaries
+    are correctly deduplicated, with lower-ranked ranks taking ownership.
+    """
+
+    def _run_dedup(self, my_rank, size, all_coords, all_ids):
+        """
+        Reproduce the deduplication logic from micro_manager.py for testing.
+        """
+        mesh_vertex_coords = np.array(all_coords[my_rank])
+        mesh_vertex_ids = np.array(all_ids[my_rank])
+
+        seen_coords = set()
+        keep_mask = np.ones(len(mesh_vertex_coords), dtype=bool)
+
+        for rank in range(size):
+            for i, coord in enumerate(all_coords[rank]):
+                coord_key = tuple(np.round(coord, decimals=10))
+                if rank < my_rank:
+                    seen_coords.add(coord_key)
+                elif rank == my_rank:
+                    if coord_key in seen_coords:
+                        keep_mask[i] = False
+                    else:
+                        seen_coords.add(coord_key)
+
+        return mesh_vertex_coords[keep_mask], mesh_vertex_ids[keep_mask]
+
+    def test_no_duplicates(self):
+        """
+        If there are no shared coords across ranks, nothing should be filtered.
+        """
+        all_coords = [
+            np.array([[0.0, 0.0], [0.5, 0.0]]),
+            np.array([[1.0, 0.0], [1.5, 0.0]]),
+        ]
+        all_ids = [[0, 1], [2, 3]]
+
+        coords, ids = self._run_dedup(0, 2, all_coords, all_ids)
+        self.assertEqual(len(coords), 2)
+
+        coords, ids = self._run_dedup(1, 2, all_coords, all_ids)
+        self.assertEqual(len(coords), 2)
+
+    def test_duplicate_on_boundary_rank0_keeps(self):
+        """
+        A coord shared between rank 0 and rank 1 should be kept by rank 0
+        and dropped by rank 1.
+        """
+        shared = [0.5, 0.0]
+        all_coords = [
+            np.array([[0.0, 0.0], shared]),
+            np.array([shared, [1.0, 0.0]]),
+        ]
+        all_ids = [[0, 1], [1, 2]]
+
+        # Rank 0 should keep both its coords
+        coords0, ids0 = self._run_dedup(0, 2, all_coords, all_ids)
+        self.assertEqual(len(coords0), 2)
+        self.assertTrue(np.allclose(coords0[1], shared))
+
+        # Rank 1 should drop the shared coord
+        coords1, ids1 = self._run_dedup(1, 2, all_coords, all_ids)
+        self.assertEqual(len(coords1), 1)
+        self.assertTrue(np.allclose(coords1[0], [1.0, 0.0]))
+
+    def test_duplicate_on_boundary_three_ranks(self):
+        """
+        A coord shared across three ranks should only be kept by rank 0.
+        """
+        shared = [0.5, 0.5]
+        all_coords = [
+            np.array([shared, [0.0, 0.0]]),
+            np.array([shared, [1.0, 0.0]]),
+            np.array([shared, [2.0, 0.0]]),
+        ]
+        all_ids = [[0, 1], [0, 2], [0, 3]]
+
+        coords0, _ = self._run_dedup(0, 3, all_coords, all_ids)
+        self.assertEqual(len(coords0), 2)
+
+        coords1, _ = self._run_dedup(1, 3, all_coords, all_ids)
+        self.assertEqual(len(coords1), 1)
+        self.assertTrue(np.allclose(coords1[0], [1.0, 0.0]))
+
+        coords2, _ = self._run_dedup(2, 3, all_coords, all_ids)
+        self.assertEqual(len(coords2), 1)
+        self.assertTrue(np.allclose(coords2[0], [2.0, 0.0]))

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -89,22 +89,3 @@ class TestDomainDecomposition(TestCase):
         )
         self.assertTrue(np.allclose(mesh_bounds, [0.75, 1, -2, 0, -2, 8]))
 
-    def test_no_duplicate_coords_on_boundary_2d(self):
-        """
-        Check that a point on the boundary between two ranks is only assigned to one rank.
-        """
-        ranks_per_axis = [2, 1]
-        size = 2
-        macro_coords = np.array([[0.5, 0.5], [0.25, 0.5], [0.75, 0.5]])
-
-        decomposer_rank0 = DomainDecomposer(0, size)
-        decomposer_rank1 = DomainDecomposer(1, size)
-
-        n0, _ = decomposer_rank0.get_local_sims_and_macro_coords(
-            self._macro_bounds_2d, ranks_per_axis, macro_coords
-        )
-        n1, _ = decomposer_rank1.get_local_sims_and_macro_coords(
-            self._macro_bounds_2d, ranks_per_axis, macro_coords
-        )
-
-        self.assertEqual(n0 + n1, len(macro_coords))

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 import numpy as np
-from micro_manager.domain_decomposition import DomainDecomposer, filter_duplicate_coords
+from micro_manager.domain_decomposition import DomainDecomposer
 
 
 class TestDomainDecomposition(TestCase):
@@ -113,10 +113,14 @@ class TestDuplicateCoordFiltering(TestCase):
         ]
         all_ids = [[0, 1], [2, 3]]
 
-        coords, ids = filter_duplicate_coords(0, 2, all_coords, all_ids)
+        coords, ids = DomainDecomposer(0, 2).filter_duplicate_coords(
+            all_coords, all_ids
+        )
         self.assertEqual(len(coords), 2)
 
-        coords, ids = filter_duplicate_coords(1, 2, all_coords, all_ids)
+        coords, ids = DomainDecomposer(1, 2).filter_duplicate_coords(
+            all_coords, all_ids
+        )
         self.assertEqual(len(coords), 2)
 
     def test_duplicate_on_boundary_rank0_keeps(self):
@@ -132,12 +136,16 @@ class TestDuplicateCoordFiltering(TestCase):
         all_ids = [[0, 1], [1, 2]]
 
         # Rank 0 should keep both its coords
-        coords0, ids0 = filter_duplicate_coords(0, 2, all_coords, all_ids)
+        coords0, ids0 = DomainDecomposer(0, 2).filter_duplicate_coords(
+            all_coords, all_ids
+        )
         self.assertEqual(len(coords0), 2)
         self.assertTrue(np.allclose(coords0[1], shared))
 
         # Rank 1 should drop the shared coord
-        coords1, ids1 = filter_duplicate_coords(1, 2, all_coords, all_ids)
+        coords1, ids1 = DomainDecomposer(1, 2).filter_duplicate_coords(
+            all_coords, all_ids
+        )
         self.assertEqual(len(coords1), 1)
         self.assertTrue(np.allclose(coords1[0], [1.0, 0.0]))
 
@@ -153,13 +161,13 @@ class TestDuplicateCoordFiltering(TestCase):
         ]
         all_ids = [[0, 1], [0, 2], [0, 3]]
 
-        coords0, _ = filter_duplicate_coords(0, 3, all_coords, all_ids)
+        coords0, _ = DomainDecomposer(0, 3).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords0), 2)
 
-        coords1, _ = filter_duplicate_coords(1, 3, all_coords, all_ids)
+        coords1, _ = DomainDecomposer(1, 3).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords1), 1)
         self.assertTrue(np.allclose(coords1[0], [1.0, 0.0]))
 
-        coords2, _ = filter_duplicate_coords(2, 3, all_coords, all_ids)
+        coords2, _ = DomainDecomposer(2, 3).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords2), 1)
         self.assertTrue(np.allclose(coords2[0], [2.0, 0.0]))


### PR DESCRIPTION
Closes #102
Problem: When a macro-point lies exactly on the boundary between two rank bounding boxes, preCICE returns it to both ranks. This causes duplicate micro simulations, incorrect accumulated results in preCICE, and wasted computation.
Fix: After get_mesh_vertex_ids_and_coordinates(), each rank uses allgather to see all coords across all ranks, then drops any coord already owned by a lower-ranked rank — ensuring every vertex is processed by exactly one rank while preserving the preCICE ID-coord pairing safely.
Changes:

micro_manager/micro_manager.py: Added deduplication after get_mesh_vertex_ids_and_coordinates()
tests/unit/test_domain_decomposition.py: Removed incorrect test that tested wrong location