### PR TITLE
Fix #73: avoid division-by-zero warning in L1rel/L2rel adaptivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-- Fixed invalid value in division warning in L1rel/L2rel adaptivity when data contains zeros [#73](https://github.com/precice/micro-manager/issues/73)
+- Fixed invalid value in division warning in L1rel/L2rel adaptivity when data contains zeros [#234](https://github.com/precice/micro-manager/pull/234)
 - Fixed duplicate micro simulations for macro-points on rank boundaries by filtering coordinates already claimed by lower-ranked ranks [#230](https://github.com/precice/micro-manager/pull/230)
 - Exposed `MicroSimulationInterface` as a public abstract base class for user subclassing [#224](https://github.com/precice/micro-manager/pull/224)
 - Added option to use compute instances to reduce memory consumption [#226](https://github.com/precice/micro-manager/pull/226)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed invalid value in division warning in L1rel/L2rel adaptivity when data contains zeros [#73](https://github.com/precice/micro-manager/issues/73)
 - Fixed duplicate micro simulations for macro-points on rank boundaries by filtering coordinates already claimed by lower-ranked ranks [#230](https://github.com/precice/micro-manager/pull/230)
 - Exposed `MicroSimulationInterface` as a public abstract base class for user subclassing [#224](https://github.com/precice/micro-manager/pull/224)
 - Added option to use compute instances to reduce memory consumption [#226](https://github.com/precice/micro-manager/pull/226)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -278,14 +278,12 @@ class AdaptivityCalculator:
         pointwise_diff = data[np.newaxis, :] - data[:, np.newaxis]
         # divide by data to get relative difference
         # divide i,j by max(abs(data[i]),abs(data[j])) to get relative difference
-        relative = np.nan_to_num(
-            (
-                pointwise_diff
-                / np.maximum(
-                    np.absolute(data[np.newaxis, :]), np.absolute(data[:, np.newaxis])
-                )
-            )
+        denom = np.maximum(
+            np.absolute(data[np.newaxis, :]), np.absolute(data[:, np.newaxis])
         )
+        # Add small epsilon to avoid division by zero (invalid value warning) when both are 0
+        eps = np.finfo(np.float64).eps
+        relative = pointwise_diff / np.maximum(denom, eps)
         return np.linalg.norm(relative, ord=1, axis=-1)
 
     def _l2rel(self, data: np.ndarray) -> np.ndarray:
@@ -306,12 +304,10 @@ class AdaptivityCalculator:
         pointwise_diff = data[np.newaxis, :] - data[:, np.newaxis]
         # divide by data to get relative difference
         # divide i,j by max(abs(data[i]),abs(data[j])) to get relative difference
-        relative = np.nan_to_num(
-            (
-                pointwise_diff
-                / np.maximum(
-                    np.absolute(data[np.newaxis, :]), np.absolute(data[:, np.newaxis])
-                )
-            )
+        denom = np.maximum(
+            np.absolute(data[np.newaxis, :]), np.absolute(data[:, np.newaxis])
         )
+        # Add small epsilon to avoid division by zero (invalid value warning) when both are 0
+        eps = np.finfo(np.float64).eps
+        relative = pointwise_diff / np.maximum(denom, eps)
         return np.linalg.norm(relative, ord=2, axis=-1)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -1,6 +1,7 @@
 """
 Functionality for adaptive initialization and control of micro simulations
 """
+
 from math import exp
 from typing import Callable
 import importlib

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -296,7 +296,6 @@ class TestLocalAdaptivity(TestCase):
             model_manager=ModelManager(),
         )
 
-        # Test L1rel with zero data
         configurator_l1 = MagicMock()
         configurator_l1.get_adaptivity_similarity_measure = MagicMock(
             return_value="L1rel"

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -281,7 +281,6 @@ class TestLocalAdaptivity(TestCase):
         """
         import warnings
 
-        # Test L2rel with zero data
         configurator = MagicMock()
         configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L2rel")
         configurator.get_output_dir = MagicMock(return_value="output_dir")

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -274,6 +274,63 @@ class TestLocalAdaptivity(TestCase):
             )
         )
 
+    def test_adaptivity_norms_with_zeros_no_warning(self):
+        """
+        Regression test for issue #73: L1rel/L2rel must not raise division-by-zero
+        warning when data contains zeros.
+        """
+        import warnings
+
+        # Test L2rel with zero data
+        configurator = MagicMock()
+        configurator.get_adaptivity_similarity_measure = MagicMock(return_value="L2rel")
+        configurator.get_output_dir = MagicMock(return_value="output_dir")
+        configurator.get_micro_file_name = MagicMock(
+            return_value="test_adaptivity_serial"
+        )
+        adaptivity_l2rel = AdaptivityCalculator(
+            configurator,
+            nsims=3,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
+        )
+
+        # Test L1rel with zero data
+        configurator_l1 = MagicMock()
+        configurator_l1.get_adaptivity_similarity_measure = MagicMock(
+            return_value="L1rel"
+        )
+        configurator_l1.get_output_dir = MagicMock(return_value="output_dir")
+        configurator_l1.get_micro_file_name = MagicMock(
+            return_value="test_adaptivity_serial"
+        )
+        adaptivity_l1rel = AdaptivityCalculator(
+            configurator_l1,
+            nsims=3,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
+        )
+
+        # Data with zeros - previously triggered RuntimeWarning: invalid value in true_divide
+        data_with_zeros = np.array([[0.0], [0.0], [1.0]])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("error", RuntimeWarning)
+            result_l2rel = adaptivity_l2rel._l2rel(data_with_zeros)
+        self.assertEqual(len(w), 0, "L2rel must not raise RuntimeWarning with zero data")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("error", RuntimeWarning)
+            result_l1rel = adaptivity_l1rel._l1rel(data_with_zeros)
+        self.assertEqual(len(w), 0, "L1rel must not raise RuntimeWarning with zero data")
+
+        # When both are 0, relative diff should be 0 (since numerator is 0)
+        self.assertEqual(result_l2rel[0, 1], 0.0)
+        self.assertEqual(result_l1rel[0, 1], 0.0)
+
     def test_associate_active_to_inactive(self):
         """
         Test functionality to associate inactive sims to active ones, in the class AdaptivityCalculator.

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -276,7 +276,7 @@ class TestLocalAdaptivity(TestCase):
 
     def test_adaptivity_norms_with_zeros_no_warning(self):
         """
-        Regression test for issue #73: L1rel/L2rel must not raise division-by-zero
+        Test that L1rel/L2rel must not raise division-by-zero
         warning when data contains zeros.
         """
         import warnings

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -320,12 +320,16 @@ class TestLocalAdaptivity(TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("error", RuntimeWarning)
             result_l2rel = adaptivity_l2rel._l2rel(data_with_zeros)
-        self.assertEqual(len(w), 0, "L2rel must not raise RuntimeWarning with zero data")
+        self.assertEqual(
+            len(w), 0, "L2rel must not raise RuntimeWarning with zero data"
+        )
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("error", RuntimeWarning)
             result_l1rel = adaptivity_l1rel._l1rel(data_with_zeros)
-        self.assertEqual(len(w), 0, "L1rel must not raise RuntimeWarning with zero data")
+        self.assertEqual(
+            len(w), 0, "L1rel must not raise RuntimeWarning with zero data"
+        )
 
         # When both are 0, relative diff should be 0 (since numerator is 0)
         self.assertEqual(result_l2rel[0, 1], 0.0)


### PR DESCRIPTION
Fix #73: Invalid value in division warning in adaptivity functionality

- Add epsilon to denominator in _l1rel and _l2rel to avoid division by zero when adaptivity data contains zeros
- Add regression test test_adaptivity_norms_with_zeros_no_warning
<img width="913" height="463" alt="image" src="https://github.com/user-attachments/assets/1637996e-982d-47de-b5a9-72e28105861f" />

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
