### PR TITLE
Reduce size of similarity distance matrix for memory efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Reduced size of similarity distance matrix for memory efficiency [#239](https://github.com/precice/micro-manager/pull/239)
 - Fixed lazy initialization for ranks without (active) micro simulations [#238](https://github.com/precice/micro-manager/pull/238)
 - Added coverage testing and simulation interface tests [#225](https://github.com/precice/micro-manager/pull/225)
 - Added `--test-dependencies` CLI flag to check if all required dependencies are correctly installed, with clear error messages listing missing packages and how to fix them [#221](https://github.com/precice/micro-manager/pull/221)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -58,15 +58,17 @@ class AdaptivityCalculator:
 
         self._max_similarity_dist = 0.0
 
+        self._nsims = nsims
+
         # is_sim_active: 1D array having state (active or inactive) of each micro simulation
         # Start adaptivity calculation with all sims active
         # This array is modified in place via the function update_active_sims and update_inactive_sims
-        self._is_sim_active = np.array([True] * nsims, dtype=np.bool_)
+        self._is_sim_active = np.array([True] * self._nsims, dtype=np.bool_)
 
         # sim_is_associated_to: 1D array with values of associated simulations of inactive simulations. Active simulations have None
         # Active sims do not have an associated sim
         # This array is modified in place via the function associate_inactive_to_active
-        self._sim_is_associated_to = np.full((nsims), -2, dtype=np.intc)
+        self._sim_is_associated_to = np.full((self._nsims), -2, dtype=np.intc)
 
         self._just_deactivated: list[int] = []
 
@@ -131,7 +133,9 @@ class AdaptivityCalculator:
                 # The axis is later reduced with a norm.
                 data_vals = np.expand_dims(data_vals, axis=1)
 
-            self._similarity_dists += dt * self._similarity_measure(data_vals)
+            self._similarity_measure(data_vals)
+
+        self._similarity_dists *= dt
 
     def _associate_inactive_to_active(self) -> None:
         """
@@ -149,10 +153,11 @@ class AdaptivityCalculator:
             # Begin with a large distance to trigger the search for the most similar active sim
             dist_min = dist_min_start_value
             for active_id in active_ids:
+                flat_idx = self._map2dto1d([inactive_id, active_id])
                 # Find most similar active sim for every inactive sim
-                if self._similarity_dists[inactive_id, active_id] < dist_min:
+                if self._similarity_dists[flat_idx] < dist_min:
                     associated_active_id = active_id
-                    dist_min = self._similarity_dists[inactive_id, active_id]
+                    dist_min = self._similarity_dists[flat_idx]
 
             self._sim_is_associated_to[inactive_id] = associated_active_id
 
@@ -171,7 +176,10 @@ class AdaptivityCalculator:
         tag : bool
             True if the inactive simulation needs to be activated, False otherwise.
         """
-        dists = self._similarity_dists[inactive_id, active_ids]
+        flat_ids = [
+            self._map2dto1d([inactive_id, active_id]) for active_id in active_ids
+        ]
+        dists = self._similarity_dists[flat_ids]
 
         # If inactive sim is not similar to any active sim, activate it
         return min(dists) > self._ref_tol
@@ -194,14 +202,15 @@ class AdaptivityCalculator:
         """
         for active_id_2 in active_ids:
             if active_id != active_id_2:  # don't compare active sim to itself
+                flat_idx = self._map2dto1d([active_id, active_id_2])
                 # If active sim is similar to another active sim, deactivate it
-                if self._similarity_dists[active_id, active_id_2] < self._coarse_tol:
+                if self._similarity_dists[flat_idx] < self._coarse_tol:
                     return True
         return False
 
     def _get_similarity_measure(
         self, similarity_measure: str
-    ) -> Callable[[np.ndarray], np.ndarray]:
+    ) -> Callable[[np.ndarray], None]:
         """
         Get similarity measure to be used for similarity calculation
 
@@ -228,7 +237,7 @@ class AdaptivityCalculator:
                 'Similarity measure not supported. Currently supported similarity measures are "L1", "L2", "L1rel", "L2rel".'
             )
 
-    def _l1(self, data: np.ndarray) -> np.ndarray:
+    def _l1(self, data: np.ndarray) -> None:
         """
         Calculate L1 norm of data
 
@@ -236,15 +245,14 @@ class AdaptivityCalculator:
         ----------
         data : numpy array
             Data to be used in similarity distance calculation
-
-        Returns
-        -------
-        similarity_dists : numpy array
-            Updated 2D array having similarity distances between each micro simulation pair
         """
-        return np.linalg.norm(data[np.newaxis, :] - data[:, np.newaxis], ord=1, axis=-1)
+        for i in range(1, self._nsims):
+            for j in range(i):
+                p_diff = np.abs(data[i] - data[j])
+                flat_idx = self._map2dto1d([i, j])
+                self._similarity_dists[flat_idx] += np.linalg.norm(p_diff, ord=1)
 
-    def _l2(self, data: np.ndarray) -> np.ndarray:
+    def _l2(self, data: np.ndarray) -> None:
         """
         Calculate L2 norm of data
 
@@ -252,15 +260,14 @@ class AdaptivityCalculator:
         ----------
         data : numpy array
             Data to be used in similarity distance calculation
-
-        Returns
-        -------
-        similarity_dists : numpy array
-            Updated 2D array having similarity distances between each micro simulation pair
         """
-        return np.linalg.norm(data[np.newaxis, :] - data[:, np.newaxis], ord=2, axis=-1)
+        for i in range(1, self._nsims):
+            for j in range(i):
+                p_diff = np.abs(data[i] - data[j])
+                flat_idx = self._map2dto1d([i, j])
+                self._similarity_dists[flat_idx] += np.linalg.norm(p_diff, ord=2)
 
-    def _l1rel(self, data: np.ndarray) -> np.ndarray:
+    def _l1rel(self, data: np.ndarray) -> None:
         """
         Calculate L1 norm of relative difference of data.
         The relative difference is calculated by dividing the difference of two data points by the maximum of the absolute value of the two data points.
@@ -269,24 +276,17 @@ class AdaptivityCalculator:
         ----------
         data : numpy array
             Data to be used in similarity distance calculation
-
-        Returns
-        -------
-        similarity_dists : numpy array
-            Updated 2D array having similarity distances between each micro simulation pair
         """
-        pointwise_diff = data[np.newaxis, :] - data[:, np.newaxis]
-        # divide by data to get relative difference
-        # divide i,j by max(abs(data[i]),abs(data[j])) to get relative difference
-        denom = np.maximum(
-            np.absolute(data[np.newaxis, :]), np.absolute(data[:, np.newaxis])
-        )
-        # Add small epsilon to avoid division by zero (invalid value warning) when both are 0
         eps = np.finfo(np.float64).eps
-        relative = pointwise_diff / np.maximum(denom, eps)
-        return np.linalg.norm(relative, ord=1, axis=-1)
+        for i in range(1, self._nsims):
+            for j in range(i):
+                p_diff = np.abs(data[i] - data[j])
+                denom = np.maximum(np.abs(data[i]), np.abs(data[j]))
+                rel_diff = p_diff / np.maximum(denom, eps)
+                flat_idx = self._map2dto1d([i, j])
+                self._similarity_dists[flat_idx] += np.linalg.norm(rel_diff, ord=1)
 
-    def _l2rel(self, data: np.ndarray) -> np.ndarray:
+    def _l2rel(self, data: np.ndarray) -> None:
         """
         Calculate L2 norm of relative difference of data.
         The relative difference is calculated by dividing the difference of two data points by the maximum of the absolute value of the two data points.
@@ -295,19 +295,57 @@ class AdaptivityCalculator:
         ----------
         data : numpy array
             Data to be used in similarity distance calculation
+        """
+        eps = np.finfo(np.float64).eps
+        for i in range(1, self._nsims):
+            for j in range(i):
+                p_diff = np.abs(data[i] - data[j])
+                denom = np.maximum(np.abs(data[i]), np.abs(data[j]))
+                rel_diff = p_diff / np.maximum(denom, eps)
+                flat_idx = self._map2dto1d([i, j])
+                self._similarity_dists[flat_idx] += np.linalg.norm(rel_diff, ord=2)
+
+    def _map1dto2d(self, flat_idx: int) -> tuple:
+        """
+        Map a 1D index to 2D coordinates in strictly lower triangular part.
+
+        Parameters
+        ----------
+        flat_idx : int
+            1D index to be mapped
 
         Returns
         -------
-        similarity_dists : numpy array
-            Updated 2D array having similarity distances between each micro simulation pair
+        coord : tuple
+            2D coordinates (i, j) corresponding to the 1D index, where i > j
         """
-        pointwise_diff = data[np.newaxis, :] - data[:, np.newaxis]
-        # divide by data to get relative difference
-        # divide i,j by max(abs(data[i]),abs(data[j])) to get relative difference
-        denom = np.maximum(
-            np.absolute(data[np.newaxis, :]), np.absolute(data[:, np.newaxis])
-        )
-        # Add small epsilon to avoid division by zero (invalid value warning) when both are 0
-        eps = np.finfo(np.float64).eps
-        relative = pointwise_diff / np.maximum(denom, eps)
-        return np.linalg.norm(relative, ord=2, axis=-1)
+        # Find row i: solve i(i-1)/2 <= flat_idx < i(i+1)/2
+        i = 1
+        while i * (i + 1) // 2 <= flat_idx:
+            i += 1
+        j = flat_idx - i * (i - 1) // 2
+        return (i, j)
+
+    def _map2dto1d(self, coords: list) -> int:
+        """
+        Map 2D coordinates to a 1D index in strictly lower triangular storage.
+
+        Parameters
+        ----------
+        coords : list
+            2D coordinates [i, j] to be mapped, where i > j
+
+        Returns
+        -------
+        flat_idx : int
+            1D index corresponding to the 2D coordinates in strictly lower triangular part
+        """
+        i, j = coords[0], coords[1]
+        if i <= j:
+            # For symmetric matrix access, swap if needed
+            i, j = j, i
+        if i <= j:
+            raise ValueError(
+                f"Invalid indices for lower triangular: ({i}, {j}). Need i > j."
+            )
+        return i * (i - 1) // 2 + j

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -340,12 +340,14 @@ class AdaptivityCalculator:
         if type(flat_idx) == int:
             flat_idx = [flat_idx]
         flat_idx = np.array(flat_idx)
+        t_num = self._calc_tri_num(self._nsims - 1)
+        i = self._nsims - 2 - np.floor(np.sqrt(-8 * flat_idx + 8 * t_num - 7) / 2 - 0.5)
+        j = flat_idx + i + 1 - t_num + self._calc_tri_num(self._nsims - i - 1)
+        return np.vstack((i.astype(np.int32), j.astype(np.int32)), dtype=np.int32).T
 
-        i = flat_idx // (self._nsims - 1)
-        j = (
-            flat_idx % (self._nsims - 1)
-        ) + 1  # shift by one to transfrom back from n-1 mat to n mat
-        return np.vstack((i, j), dtype=np.int32).T
+    @staticmethod
+    def _calc_tri_num(n: int):
+        return n * (n + 1) / 2
 
     def _map2dto1d(self, coords: list) -> int:
         """
@@ -365,5 +367,8 @@ class AdaptivityCalculator:
         # assert i < j invariant
         coords = np.sort(coords, axis=-1)
         i, j = coords[:, 0], coords[:, 1]
-
-        return i * (self._nsims - 1) + (j - 1)
+        # num entries till row i
+        base = self._similarity_dists.shape[0] - self._calc_tri_num(self._nsims - 1 - i)
+        # row offset
+        offset = j - 1 - i
+        return (base + offset).astype(np.int32)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -254,11 +254,14 @@ class AdaptivityCalculator:
         dt : float
             Time step to scale the similarity distances
         """
-        for i in range(1, self._nsims):
-            for j in range(i):
-                p_diff = np.abs(data[i] - data[j])
-                flat_idx = self._map2dto1d([i, j])
-                self._similarity_dists[flat_idx] += np.linalg.norm(p_diff, ord=1) * dt
+        idx = 0
+        for i in range(self._nsims - 1):
+            # Vectorized computation for all j > i
+            diffs = np.abs(data[i] - data[i + 1 :])
+            norms = np.linalg.norm(diffs, ord=1, axis=-1 if diffs.ndim > 1 else ())
+            n_pairs = self._nsims - i - 1
+            self._similarity_dists[idx : idx + n_pairs] += norms * dt
+            idx += n_pairs
 
     def _l2(self, data: np.ndarray, dt: float) -> None:
         """
@@ -271,11 +274,14 @@ class AdaptivityCalculator:
         dt : float
             Time step to scale the similarity distances
         """
-        for i in range(1, self._nsims):
-            for j in range(i):
-                p_diff = np.abs(data[i] - data[j])
-                flat_idx = self._map2dto1d([i, j])
-                self._similarity_dists[flat_idx] += np.linalg.norm(p_diff, ord=2) * dt
+        idx = 0
+        for i in range(self._nsims - 1):
+            # Vectorized computation for all j > i
+            diffs = np.abs(data[i] - data[i + 1 :])
+            norms = np.linalg.norm(diffs, ord=2, axis=-1 if diffs.ndim > 1 else ())
+            n_pairs = self._nsims - i - 1
+            self._similarity_dists[idx : idx + n_pairs] += norms * dt
+            idx += n_pairs
 
     def _l1rel(self, data: np.ndarray, dt: float) -> None:
         """
@@ -290,16 +296,18 @@ class AdaptivityCalculator:
             Time step to scale the similarity distances
         """
         eps = np.finfo(np.float64).eps
-        for i in range(1, self._nsims):
-            p_diff = np.abs(data[i] - data[i + 1 : self._nsims])
-            denom = np.maximum(
-                np.abs(data[i])[None, :], np.abs(data[i + 1 : self._nsims])
+        idx = 0
+        for i in range(self._nsims - 1):
+            # Vectorized computation for all j > i
+            diffs = np.abs(data[i] - data[i + 1 :])
+            denoms = np.maximum(np.abs(data[i]), np.abs(data[i + 1 :]))
+            rel_diffs = diffs / np.maximum(denoms, eps)
+            norms = np.linalg.norm(
+                rel_diffs, ord=1, axis=-1 if rel_diffs.ndim > 1 else ()
             )
-            rel_diff = p_diff / np.maximum(denom, eps)
-            base_idx = self._map2dto1d([i, i + 1])
-            self._similarity_dists[base_idx : base_idx + p_diff.shape[0]] += (
-                np.linalg.norm(rel_diff, ord=1) * dt
-            )
+            n_pairs = self._nsims - i - 1
+            self._similarity_dists[idx : idx + n_pairs] += norms * dt
+            idx += n_pairs
 
     def _l2rel(self, data: np.ndarray, dt: float) -> None:
         """
@@ -314,20 +322,22 @@ class AdaptivityCalculator:
             Time step to scale the similarity distances
         """
         eps = np.finfo(np.float64).eps
-        for i in range(1, self._nsims):
-            p_diff = np.abs(data[i] - data[i + 1 : self._nsims])
-            denom = np.maximum(
-                np.abs(data[i])[None, :], np.abs(data[i + 1 : self._nsims])
+        idx = 0
+        for i in range(self._nsims - 1):
+            # Vectorized computation for all j > i
+            diffs = np.abs(data[i] - data[i + 1 :])
+            denoms = np.maximum(np.abs(data[i]), np.abs(data[i + 1 :]))
+            rel_diffs = diffs / np.maximum(denoms, eps)
+            norms = np.linalg.norm(
+                rel_diffs, ord=2, axis=-1 if rel_diffs.ndim > 1 else ()
             )
-            rel_diff = p_diff / np.maximum(denom, eps)
-            base_idx = self._map2dto1d([i, i + 1])
-            self._similarity_dists[base_idx : base_idx + p_diff.shape[0]] += (
-                np.linalg.norm(rel_diff, ord=2) * dt
-            )
+            n_pairs = self._nsims - i - 1
+            self._similarity_dists[idx : idx + n_pairs] += norms * dt
+            idx += n_pairs
 
-    def _map1dto2d(self, flat_idx: int) -> tuple:
+    def _map1dto2d(self, flat_idx: int) -> np.ndarray:
         """
-        Map a 1D index to 2D coordinates in strictly lower triangular part.
+        Map a 1D index to 2D coordinates in strictly upper triangular part.
 
         Parameters
         ----------
@@ -336,42 +346,47 @@ class AdaptivityCalculator:
 
         Returns
         -------
-        coord : tuple
-            2D coordinates (i, j) corresponding to the 1D index, where i > j
+        coord : numpy array
+            2D coordinates (i, j) corresponding to the 1D index, where i < j
         """
-        # Find row i: solve i(i-1)/2 <= flat_idx < i(i+1)/2
         if type(flat_idx) == int:
             flat_idx = [flat_idx]
         flat_idx = np.array(flat_idx)
-        t_num = self._calc_tri_num(self._nsims - 1)
-        i = self._nsims - 2 - np.floor(np.sqrt(-8 * flat_idx + 8 * t_num - 7) / 2 - 0.5)
-        j = flat_idx + i + 1 - t_num + self._calc_tri_num(self._nsims - i - 1)
-        return np.vstack((i.astype(np.int32), j.astype(np.int32)), dtype=np.int32).T
 
-    @staticmethod
-    def _calc_tri_num(n: int):
-        return n * (n + 1) / 2
+        # For upper triangular: flat_idx = i * (2*n - i - 1) // 2 + (j - i - 1)
+        # Solve for i: i*(2*n - i - 1)/2 <= flat_idx
+        # Rearranging: -i^2 + (2*n - 1)*i <= 2*flat_idx
+        # i^2 - (2*n - 1)*i + 2*flat_idx >= 0
+        # Using quadratic formula: i = ((2*n - 1) - sqrt((2*n - 1)^2 - 8*flat_idx)) / 2
+        discriminant = (2 * self._nsims - 1) ** 2 - 8 * flat_idx
+        i = np.floor(((2 * self._nsims - 1) - np.sqrt(discriminant)) / 2).astype(
+            np.int32
+        )
 
-    def _map2dto1d(self, coords: list) -> int:
+        # Calculate j from: flat_idx = i * (2*n - i - 1) // 2 + (j - i - 1)
+        base_idx = i * (2 * self._nsims - i - 1) // 2
+        j = flat_idx - base_idx + i + 1
+
+        return np.vstack((i.astype(np.int32), j.astype(np.int32))).T
+
+    def _map2dto1d(self, coords: np.ndarray) -> int:
         """
-        Map 2D coordinates to a 1D index in strictly lower triangular storage.
+        Map 2D coordinates to a 1D index in strictly upper triangular storage.
 
         Parameters
         ----------
-        coords : list
-            2D coordinates [i, j] to be mapped, where i > j
+        coords : numpy array
+            2D coordinates [i, j] to be mapped, where i < j
 
         Returns
         -------
         flat_idx : int
-            1D index corresponding to the 2D coordinates in strictly lower triangular part
+            1D index corresponding to the 2D coordinates in strictly upper triangular part
         """
         coords = np.array(coords, dtype=np.int32).reshape(-1, 2)
-        # assert i < j invariant
+        # Ensure i < j for upper triangular
         coords = np.sort(coords, axis=-1)
         i, j = coords[:, 0], coords[:, 1]
-        # num entries till row i
-        base = self._similarity_dists.shape[0] - self._calc_tri_num(self._nsims - 1 - i)
-        # row offset
-        offset = j - 1 - i
-        return (base + offset).astype(np.int32)
+        # flat_idx = i * (2*n - i - 1) // 2 + (j - i - 1)
+        flat_idx = i * (2 * self._nsims - i - 1) // 2 + (j - i - 1)
+        return flat_idx.astype(np.int32)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -133,9 +133,7 @@ class AdaptivityCalculator:
                 # The axis is later reduced with a norm.
                 data_vals = np.expand_dims(data_vals, axis=1)
 
-            self._similarity_measure(data_vals)
-
-        self._similarity_dists *= dt
+            self._similarity_measure(data_vals, dt)
 
     def _associate_inactive_to_active(self) -> None:
         """
@@ -210,7 +208,7 @@ class AdaptivityCalculator:
 
     def _get_similarity_measure(
         self, similarity_measure: str
-    ) -> Callable[[np.ndarray], None]:
+    ) -> Callable[[np.ndarray, float], None]:
         """
         Get similarity measure to be used for similarity calculation
 
@@ -237,7 +235,7 @@ class AdaptivityCalculator:
                 'Similarity measure not supported. Currently supported similarity measures are "L1", "L2", "L1rel", "L2rel".'
             )
 
-    def _l1(self, data: np.ndarray) -> None:
+    def _l1(self, data: np.ndarray, dt: float) -> None:
         """
         Calculate L1 norm of data
 
@@ -245,14 +243,16 @@ class AdaptivityCalculator:
         ----------
         data : numpy array
             Data to be used in similarity distance calculation
+        dt : float
+            Time step to scale the similarity distances
         """
         for i in range(1, self._nsims):
             for j in range(i):
                 p_diff = np.abs(data[i] - data[j])
                 flat_idx = self._map2dto1d([i, j])
-                self._similarity_dists[flat_idx] += np.linalg.norm(p_diff, ord=1)
+                self._similarity_dists[flat_idx] += np.linalg.norm(p_diff, ord=1) * dt
 
-    def _l2(self, data: np.ndarray) -> None:
+    def _l2(self, data: np.ndarray, dt: float) -> None:
         """
         Calculate L2 norm of data
 
@@ -260,14 +260,16 @@ class AdaptivityCalculator:
         ----------
         data : numpy array
             Data to be used in similarity distance calculation
+        dt : float
+            Time step to scale the similarity distances
         """
         for i in range(1, self._nsims):
             for j in range(i):
                 p_diff = np.abs(data[i] - data[j])
                 flat_idx = self._map2dto1d([i, j])
-                self._similarity_dists[flat_idx] += np.linalg.norm(p_diff, ord=2)
+                self._similarity_dists[flat_idx] += np.linalg.norm(p_diff, ord=2) * dt
 
-    def _l1rel(self, data: np.ndarray) -> None:
+    def _l1rel(self, data: np.ndarray, dt: float) -> None:
         """
         Calculate L1 norm of relative difference of data.
         The relative difference is calculated by dividing the difference of two data points by the maximum of the absolute value of the two data points.
@@ -276,6 +278,8 @@ class AdaptivityCalculator:
         ----------
         data : numpy array
             Data to be used in similarity distance calculation
+        dt : float
+            Time step to scale the similarity distances
         """
         eps = np.finfo(np.float64).eps
         for i in range(1, self._nsims):
@@ -284,9 +288,9 @@ class AdaptivityCalculator:
                 denom = np.maximum(np.abs(data[i]), np.abs(data[j]))
                 rel_diff = p_diff / np.maximum(denom, eps)
                 flat_idx = self._map2dto1d([i, j])
-                self._similarity_dists[flat_idx] += np.linalg.norm(rel_diff, ord=1)
+                self._similarity_dists[flat_idx] += np.linalg.norm(rel_diff, ord=1) * dt
 
-    def _l2rel(self, data: np.ndarray) -> None:
+    def _l2rel(self, data: np.ndarray, dt: float) -> None:
         """
         Calculate L2 norm of relative difference of data.
         The relative difference is calculated by dividing the difference of two data points by the maximum of the absolute value of the two data points.
@@ -295,6 +299,8 @@ class AdaptivityCalculator:
         ----------
         data : numpy array
             Data to be used in similarity distance calculation
+        dt : float
+            Time step to scale the similarity distances
         """
         eps = np.finfo(np.float64).eps
         for i in range(1, self._nsims):
@@ -303,7 +309,7 @@ class AdaptivityCalculator:
                 denom = np.maximum(np.abs(data[i]), np.abs(data[j]))
                 rel_diff = p_diff / np.maximum(denom, eps)
                 flat_idx = self._map2dto1d([i, j])
-                self._similarity_dists[flat_idx] += np.linalg.norm(rel_diff, ord=2)
+                self._similarity_dists[flat_idx] += np.linalg.norm(rel_diff, ord=2) * dt
 
     def _map1dto2d(self, flat_idx: int) -> tuple:
         """

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -174,9 +174,10 @@ class AdaptivityCalculator:
         tag : bool
             True if the inactive simulation needs to be activated, False otherwise.
         """
-        flat_ids = [
-            self._map2dto1d([inactive_id, active_id]) for active_id in active_ids
-        ]
+        coords = np.zeros((len(active_ids), 2))
+        coords[:, 0] = inactive_id
+        coords[:, 1] = active_ids[:]
+        flat_ids = self._map2dto1d(coords)
         dists = self._similarity_dists[flat_ids]
 
         # If inactive sim is not similar to any active sim, activate it
@@ -283,12 +284,11 @@ class AdaptivityCalculator:
         """
         eps = np.finfo(np.float64).eps
         for i in range(1, self._nsims):
-            for j in range(i):
-                p_diff = np.abs(data[i] - data[j])
-                denom = np.maximum(np.abs(data[i]), np.abs(data[j]))
-                rel_diff = p_diff / np.maximum(denom, eps)
-                flat_idx = self._map2dto1d([i, j])
-                self._similarity_dists[flat_idx] += np.linalg.norm(rel_diff, ord=1) * dt
+            p_diff = np.abs(data[i] - data[i+1:self._nsims])
+            denom = np.maximum(np.abs(data[i])[None, :], np.abs(data[i+1:self._nsims]))
+            rel_diff = p_diff / np.maximum(denom, eps)
+            base_idx = self._map2dto1d([i, i+1])
+            self._similarity_dists[base_idx:base_idx+p_diff.shape[0]] += np.linalg.norm(rel_diff, ord=1) * dt
 
     def _l2rel(self, data: np.ndarray, dt: float) -> None:
         """
@@ -326,11 +326,13 @@ class AdaptivityCalculator:
             2D coordinates (i, j) corresponding to the 1D index, where i > j
         """
         # Find row i: solve i(i-1)/2 <= flat_idx < i(i+1)/2
-        i = 1
-        while i * (i + 1) // 2 <= flat_idx:
-            i += 1
-        j = flat_idx - i * (i - 1) // 2
-        return (i, j)
+        if type(flat_idx) == int:
+            flat_idx = [flat_idx]
+        flat_idx = np.array(flat_idx)
+        
+        i = flat_idx // (self._nsims - 1)
+        j = (flat_idx % (self._nsims - 1)) + 1 # shift by one to transfrom back from n-1 mat to n mat
+        return np.vstack((i, j), dtype=np.int32).T
 
     def _map2dto1d(self, coords: list) -> int:
         """
@@ -346,12 +348,9 @@ class AdaptivityCalculator:
         flat_idx : int
             1D index corresponding to the 2D coordinates in strictly lower triangular part
         """
-        i, j = coords[0], coords[1]
-        if i <= j:
-            # For symmetric matrix access, swap if needed
-            i, j = j, i
-        if i <= j:
-            raise ValueError(
-                f"Invalid indices for lower triangular: ({i}, {j}). Need i > j."
-            )
-        return i * (i - 1) // 2 + j
+        coords = np.array(coords, dtype=np.int32).reshape(-1, 2)
+        # assert i < j invariant
+        coords = np.sort(coords, axis=-1)
+        i, j = coords[:, 0], coords[:, 1]
+        
+        return i * (self._nsims - 1) + (j - 1)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -315,12 +315,15 @@ class AdaptivityCalculator:
         """
         eps = np.finfo(np.float64).eps
         for i in range(1, self._nsims):
-            for j in range(i):
-                p_diff = np.abs(data[i] - data[j])
-                denom = np.maximum(np.abs(data[i]), np.abs(data[j]))
-                rel_diff = p_diff / np.maximum(denom, eps)
-                flat_idx = self._map2dto1d([i, j])
-                self._similarity_dists[flat_idx] += np.linalg.norm(rel_diff, ord=2) * dt
+            p_diff = np.abs(data[i] - data[i + 1 : self._nsims])
+            denom = np.maximum(
+                np.abs(data[i])[None, :], np.abs(data[i + 1 : self._nsims])
+            )
+            rel_diff = p_diff / np.maximum(denom, eps)
+            base_idx = self._map2dto1d([i, i + 1])
+            self._similarity_dists[base_idx : base_idx + p_diff.shape[0]] += (
+                np.linalg.norm(rel_diff, ord=2) * dt
+            )
 
     def _map1dto2d(self, flat_idx: int) -> tuple:
         """
@@ -344,7 +347,7 @@ class AdaptivityCalculator:
         i = flat_idx // (self._nsims - 1)
         j = (
             flat_idx % (self._nsims - 1)
-        ) + 1  # shift by one to transfrom back from n-1 mat to n mat
+        ) + 1  # shift by one to transform back from n-1 mat to n mat
         return np.vstack((i, j), dtype=np.int32).T
 
     def _map2dto1d(self, coords: list) -> int:

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -199,13 +199,20 @@ class AdaptivityCalculator:
         tag : bool
             True if the active simulation needs to be deactivated, False otherwise.
         """
-        for active_id_2 in active_ids:
-            if active_id != active_id_2:  # don't compare active sim to itself
-                flat_idx = self._map2dto1d([active_id, active_id_2])
-                # If active sim is similar to another active sim, deactivate it
-                if self._similarity_dists[flat_idx] < self._coarse_tol:
-                    return True
-        return False
+        active_ids = np.array(active_ids, dtype=np.int32)
+
+        if active_ids.shape[0] == 1 and active_ids[0] == active_id:
+            return False
+
+        mask = active_ids != active_id
+        active_ids_to_check = active_ids[mask]
+        coords = np.zeros((active_ids_to_check.shape[0], 2), dtype=np.int32)
+        coords[:, 0] = active_id
+        coords[:, 1] = active_ids_to_check[:]
+        flat_idx = self._map2dto1d(coords)
+        dists = self._similarity_dists[flat_idx]
+
+        return np.any(dists < self._coarse_tol)
 
     def _get_similarity_measure(
         self, similarity_measure: str
@@ -284,11 +291,15 @@ class AdaptivityCalculator:
         """
         eps = np.finfo(np.float64).eps
         for i in range(1, self._nsims):
-            p_diff = np.abs(data[i] - data[i+1:self._nsims])
-            denom = np.maximum(np.abs(data[i])[None, :], np.abs(data[i+1:self._nsims]))
+            p_diff = np.abs(data[i] - data[i + 1 : self._nsims])
+            denom = np.maximum(
+                np.abs(data[i])[None, :], np.abs(data[i + 1 : self._nsims])
+            )
             rel_diff = p_diff / np.maximum(denom, eps)
-            base_idx = self._map2dto1d([i, i+1])
-            self._similarity_dists[base_idx:base_idx+p_diff.shape[0]] += np.linalg.norm(rel_diff, ord=1) * dt
+            base_idx = self._map2dto1d([i, i + 1])
+            self._similarity_dists[base_idx : base_idx + p_diff.shape[0]] += (
+                np.linalg.norm(rel_diff, ord=1) * dt
+            )
 
     def _l2rel(self, data: np.ndarray, dt: float) -> None:
         """
@@ -329,9 +340,11 @@ class AdaptivityCalculator:
         if type(flat_idx) == int:
             flat_idx = [flat_idx]
         flat_idx = np.array(flat_idx)
-        
+
         i = flat_idx // (self._nsims - 1)
-        j = (flat_idx % (self._nsims - 1)) + 1 # shift by one to transfrom back from n-1 mat to n mat
+        j = (
+            flat_idx % (self._nsims - 1)
+        ) + 1  # shift by one to transfrom back from n-1 mat to n mat
         return np.vstack((i, j), dtype=np.int32).T
 
     def _map2dto1d(self, coords: list) -> int:
@@ -352,5 +365,5 @@ class AdaptivityCalculator:
         # assert i < j invariant
         coords = np.sort(coords, axis=-1)
         i, j = coords[:, 0], coords[:, 1]
-        
+
         return i * (self._nsims - 1) + (j - 1)

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -85,12 +85,15 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         # Size of data type
         itemsize = MPI.FLOAT.Get_size()
 
+        # Number of similarity distances to be stored (strictly lower triangular)
+        n_dists = int(
+            self._global_number_of_sims * (self._global_number_of_sims - 1) / 2
+        )
+
         if (
             self._MPI_local_rank == 0
         ):  # Only the first rank in the node allocates the shared memory
-            nbytes = (
-                self._global_number_of_sims * self._global_number_of_sims * itemsize
-            )
+            nbytes = n_dists * itemsize
         else:
             nbytes = 0
 
@@ -110,7 +113,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         self._similarity_dists: np.ndarray = np.ndarray(
             buffer=array_buffer,
             dtype="f",
-            shape=(self._global_number_of_sims, self._global_number_of_sims),
+            shape=(n_dists,),
         )
 
         if self._MPI_local_rank == 0:

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -51,9 +51,14 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         )
         self._comm = comm
 
-        # similarity_dists: 2D array having similarity distances between each micro simulation pair
-        # This matrix is modified in place via the function update_similarity_dists
-        self._similarity_dists = np.zeros((num_sims, num_sims))
+        n_dists = int(num_sims * (num_sims - 1) / 2)
+        self._base_logger.log_info(
+            "Number of similarity distances to be calculated: {}".format(n_dists)
+        )
+
+        # similarity_dists: 1D array storing strictly lower triangular elements of similarity distances
+        # This vector is modified in place via the function update_similarity_dists
+        self._similarity_dists = np.zeros((n_dists,))
 
     def compute_adaptivity(
         self,

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -52,9 +52,6 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         self._comm = comm
 
         n_dists = int(num_sims * (num_sims - 1) / 2)
-        self._base_logger.log_info(
-            "Number of similarity distances to be calculated: {}".format(n_dists)
-        )
 
         # similarity_dists: 1D array storing strictly lower triangular elements of similarity distances
         # This vector is modified in place via the function update_similarity_dists

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -88,37 +88,6 @@ class TestLocalAdaptivity(TestCase):
         # Convert 2D matrix to 1D strictly lower triangular vector
         self._similarity_dists = self._convert_2d_to_1d(self._dt * self._data_diff)
 
-    def _convert_2d_to_1d(self, matrix_2d: np.ndarray) -> np.ndarray:
-        """
-        Convert a 2D symmetric matrix to 1D strictly lower triangular vector.
-        """
-        n = matrix_2d.shape[0]
-        vec_size = n * (n - 1) // 2
-        vector_1d = np.zeros(vec_size)
-
-        idx = 0
-        for i in range(1, n):
-            for j in range(i):
-                vector_1d[idx] = matrix_2d[i, j]
-                idx += 1
-
-        return vector_1d
-
-    def _convert_1d_to_2d(self, vector_1d: np.ndarray, n: int) -> np.ndarray:
-        """
-        Convert a 1D strictly lower triangular vector back to 2D symmetric matrix.
-        """
-        matrix_2d = np.zeros((n, n))
-
-        idx = 0
-        for i in range(1, n):
-            for j in range(i):
-                matrix_2d[i, j] = vector_1d[idx]
-                matrix_2d[j, i] = vector_1d[idx]
-                idx += 1
-
-        return matrix_2d
-
     def test_update_similarity_dists(self):
         """
         Test functionality of calculating the similarity distance matrix in class AdaptivityCalculator.
@@ -234,7 +203,7 @@ class TestLocalAdaptivity(TestCase):
 
         fake_data = np.array([[1], [2], [3]])
         adaptivity_l1._similarity_dists = np.zeros(nsims_3 * (nsims_3 - 1) // 2)
-        adaptivity_l1._l1(fake_data)
+        adaptivity_l1._l1(fake_data, dt=1.0)
         # Expected strictly lower triangular: (1,0)=1, (2,0)=2, (2,1)=1
         expected_l1_3 = np.array([1.0, 2.0, 1.0])
         self.assertTrue(np.allclose(adaptivity_l1._similarity_dists, expected_l1_3))
@@ -249,7 +218,7 @@ class TestLocalAdaptivity(TestCase):
         )
         configurator.get_adaptivity_similarity_measure.return_value = "L2"
         adaptivity_l2._similarity_dists = np.zeros(nsims_3 * (nsims_3 - 1) // 2)
-        adaptivity_l2._l2(fake_data)
+        adaptivity_l2._l2(fake_data, dt=1.0)
         # L2 norm of scalars is same as L1 for 1D data
         expected_l2_3 = np.array([1.0, 2.0, 1.0])
         self.assertTrue(np.allclose(adaptivity_l2._similarity_dists, expected_l2_3))
@@ -264,7 +233,7 @@ class TestLocalAdaptivity(TestCase):
         )
         configurator.get_adaptivity_similarity_measure.return_value = "L1rel"
         adaptivity_l1rel._similarity_dists = np.zeros(nsims_3 * (nsims_3 - 1) // 2)
-        adaptivity_l1rel._l1rel(fake_data)
+        adaptivity_l1rel._l1rel(fake_data, dt=1.0)
         # Expected: (1,0)=|2-1|/max(2,1)=1/2, (2,0)=|3-1|/max(3,1)=2/3, (2,1)=|3-2|/max(3,2)=1/3
         expected_l1rel_3 = np.array([0.5, 2.0 / 3.0, 1.0 / 3.0])
         self.assertTrue(
@@ -281,7 +250,7 @@ class TestLocalAdaptivity(TestCase):
         )
         configurator.get_adaptivity_similarity_measure.return_value = "L2rel"
         adaptivity_l2rel._similarity_dists = np.zeros(nsims_3 * (nsims_3 - 1) // 2)
-        adaptivity_l2rel._l2rel(fake_data)
+        adaptivity_l2rel._l2rel(fake_data, dt=1.0)
         # L2rel of scalars is same as L1rel for 1D data
         expected_l2rel_3 = np.array([0.5, 2.0 / 3.0, 1.0 / 3.0])
         self.assertTrue(
@@ -302,7 +271,7 @@ class TestLocalAdaptivity(TestCase):
 
         fake_2d_data = np.array([[1, 2], [3, 4]])
         adaptivity_l1_2d._similarity_dists = np.zeros(nsims_2 * (nsims_2 - 1) // 2)
-        adaptivity_l1_2d._l1(fake_2d_data)
+        adaptivity_l1_2d._l1(fake_2d_data, dt=1.0)
         # Expected: (1,0)=|3-1|+|4-2|=2+2=4
         expected_l1_2d = np.array([4.0])
         self.assertTrue(np.allclose(adaptivity_l1_2d._similarity_dists, expected_l1_2d))
@@ -317,7 +286,7 @@ class TestLocalAdaptivity(TestCase):
             model_manager=ModelManager(),
         )
         adaptivity_l2_2d._similarity_dists = np.zeros(nsims_2 * (nsims_2 - 1) // 2)
-        adaptivity_l2_2d._l2(fake_2d_data)
+        adaptivity_l2_2d._l2(fake_2d_data, dt=1.0)
         # Expected: (1,0)=sqrt((3-1)^2+(4-2)^2)=sqrt(8)=2*sqrt(2)
         expected_l2_2d = np.array([np.sqrt(8.0)])
         self.assertTrue(np.allclose(adaptivity_l2_2d._similarity_dists, expected_l2_2d))
@@ -332,7 +301,7 @@ class TestLocalAdaptivity(TestCase):
             model_manager=ModelManager(),
         )
         adaptivity_l1rel_2d._similarity_dists = np.zeros(nsims_2 * (nsims_2 - 1) // 2)
-        adaptivity_l1rel_2d._l1rel(fake_2d_data)
+        adaptivity_l1rel_2d._l1rel(fake_2d_data, dt=1.0)
         # Expected: (1,0)=|3-1|/max(1,3)+|4-2|/max(2,4)=2/3+2/4=2/3+1/2
         expected_l1rel_2d = np.array([2.0 / 3.0 + 1.0 / 2.0])
         self.assertTrue(
@@ -349,7 +318,7 @@ class TestLocalAdaptivity(TestCase):
             model_manager=ModelManager(),
         )
         adaptivity_l2rel_2d._similarity_dists = np.zeros(nsims_2 * (nsims_2 - 1) // 2)
-        adaptivity_l2rel_2d._l2rel(fake_2d_data)
+        adaptivity_l2rel_2d._l2rel(fake_2d_data, dt=1.0)
         # Expected: (1,0)=sqrt((3-1)^2/max(1,3)^2+(4-2)^2/max(2,4)^2)=sqrt(4/9+4/16)
         expected_l2rel_2d = np.array([np.sqrt((2.0 / 3.0) ** 2 + (2.0 / 4.0) ** 2)])
         self.assertTrue(
@@ -405,7 +374,7 @@ class TestLocalAdaptivity(TestCase):
         adaptivity_l2rel._similarity_dists = np.zeros(zero_vec_size)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("error", RuntimeWarning)
-            adaptivity_l2rel._l2rel(data_with_zeros)
+            adaptivity_l2rel._l2rel(data_with_zeros, dt=1.0)
         self.assertEqual(
             len(w), 0, "L2rel must not raise RuntimeWarning with zero data"
         )
@@ -417,7 +386,7 @@ class TestLocalAdaptivity(TestCase):
         adaptivity_l1rel._similarity_dists = np.zeros(zero_vec_size)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("error", RuntimeWarning)
-            adaptivity_l1rel._l1rel(data_with_zeros)
+            adaptivity_l1rel._l1rel(data_with_zeros, dt=1.0)
         self.assertEqual(
             len(w), 0, "L1rel must not raise RuntimeWarning with zero data"
         )
@@ -525,3 +494,34 @@ class TestLocalAdaptivity(TestCase):
                 adaptivity_controller._sim_is_associated_to,
             )
         )
+
+    def _convert_2d_to_1d(self, matrix_2d: np.ndarray) -> np.ndarray:
+        """
+        Convert a 2D symmetric matrix to 1D strictly lower triangular vector.
+        """
+        n = matrix_2d.shape[0]
+        vec_size = n * (n - 1) // 2
+        vector_1d = np.zeros(vec_size)
+
+        idx = 0
+        for i in range(1, n):
+            for j in range(i):
+                vector_1d[idx] = matrix_2d[i, j]
+                idx += 1
+
+        return vector_1d
+
+    def _convert_1d_to_2d(self, vector_1d: np.ndarray, n: int) -> np.ndarray:
+        """
+        Convert a 1D strictly lower triangular vector back to 2D symmetric matrix.
+        """
+        matrix_2d = np.zeros((n, n))
+
+        idx = 0
+        for i in range(1, n):
+            for j in range(i):
+                matrix_2d[i, j] = vector_1d[idx]
+                matrix_2d[j, i] = vector_1d[idx]
+                idx += 1
+
+        return matrix_2d

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -497,15 +497,15 @@ class TestLocalAdaptivity(TestCase):
 
     def _convert_2d_to_1d(self, matrix_2d: np.ndarray) -> np.ndarray:
         """
-        Convert a 2D symmetric matrix to 1D strictly lower triangular vector.
+        Convert a 2D symmetric matrix to 1D strictly upper triangular vector.
         """
         n = matrix_2d.shape[0]
         vec_size = n * (n - 1) // 2
         vector_1d = np.zeros(vec_size)
 
         idx = 0
-        for i in range(1, n):
-            for j in range(i):
+        for i in range(n - 1):
+            for j in range(i + 1, n):
                 vector_1d[idx] = matrix_2d[i, j]
                 idx += 1
 
@@ -513,13 +513,13 @@ class TestLocalAdaptivity(TestCase):
 
     def _convert_1d_to_2d(self, vector_1d: np.ndarray, n: int) -> np.ndarray:
         """
-        Convert a 1D strictly lower triangular vector back to 2D symmetric matrix.
+        Convert a 1D strictly upper triangular vector back to 2D symmetric matrix.
         """
         matrix_2d = np.zeros((n, n))
 
         idx = 0
-        for i in range(1, n):
-            for j in range(i):
+        for i in range(n - 1):
+            for j in range(i + 1, n):
                 matrix_2d[i, j] = vector_1d[idx]
                 matrix_2d[j, i] = vector_1d[idx]
                 idx += 1

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -85,7 +85,39 @@ class TestLocalAdaptivity(TestCase):
                     )
                 self._data_diff[i, j] = dist
 
-        self._similarity_dists = self._dt * self._data_diff
+        # Convert 2D matrix to 1D strictly lower triangular vector
+        self._similarity_dists = self._convert_2d_to_1d(self._dt * self._data_diff)
+
+    def _convert_2d_to_1d(self, matrix_2d: np.ndarray) -> np.ndarray:
+        """
+        Convert a 2D symmetric matrix to 1D strictly lower triangular vector.
+        """
+        n = matrix_2d.shape[0]
+        vec_size = n * (n - 1) // 2
+        vector_1d = np.zeros(vec_size)
+
+        idx = 0
+        for i in range(1, n):
+            for j in range(i):
+                vector_1d[idx] = matrix_2d[i, j]
+                idx += 1
+
+        return vector_1d
+
+    def _convert_1d_to_2d(self, vector_1d: np.ndarray, n: int) -> np.ndarray:
+        """
+        Convert a 1D strictly lower triangular vector back to 2D symmetric matrix.
+        """
+        matrix_2d = np.zeros((n, n))
+
+        idx = 0
+        for i in range(1, n):
+            for j in range(i):
+                matrix_2d[i, j] = vector_1d[idx]
+                matrix_2d[j, i] = vector_1d[idx]
+                idx += 1
+
+        return matrix_2d
 
     def test_update_similarity_dists(self):
         """
@@ -126,13 +158,16 @@ class TestLocalAdaptivity(TestCase):
 
         adaptivity_controller._update_similarity_dists(self._dt, adaptivity_data)
 
-        expected_similarity_dists = (
-            exp(-adaptivity_controller._hist_param * self._dt) * old_similarity_dists
+        # Convert expected 2D result back to 1D for comparison
+        expected_2d = (
+            exp(-adaptivity_controller._hist_param * self._dt)
+            * self._convert_1d_to_2d(old_similarity_dists, self._number_of_sims)
             + self._dt * self._data_diff
         )
+        expected_similarity_dists = self._convert_2d_to_1d(expected_2d)
 
         self.assertTrue(
-            np.array_equal(
+            np.allclose(
                 expected_similarity_dists, adaptivity_controller._similarity_dists
             )
         )
@@ -186,9 +221,11 @@ class TestLocalAdaptivity(TestCase):
             return_value="test_adaptivity_serial"
         )
 
-        adaptivity_controller = AdaptivityCalculator(
+        # Test with 3-element data
+        nsims_3 = 3
+        adaptivity_l1 = AdaptivityCalculator(
             configurator,
-            nsims=self._number_of_sims,
+            nsims=nsims_3,
             base_logger=MagicMock(),
             rank=0,
             micro_problem_cls=MicroSimulation,
@@ -196,82 +233,127 @@ class TestLocalAdaptivity(TestCase):
         )
 
         fake_data = np.array([[1], [2], [3]])
-        self.assertTrue(
-            np.allclose(
-                adaptivity_controller._l1(fake_data),
-                np.array([[0, 1, 2], [1, 0, 1], [2, 1, 0]]),
-            )
+        adaptivity_l1._similarity_dists = np.zeros(nsims_3 * (nsims_3 - 1) // 2)
+        adaptivity_l1._l1(fake_data)
+        # Expected strictly lower triangular: (1,0)=1, (2,0)=2, (2,1)=1
+        expected_l1_3 = np.array([1.0, 2.0, 1.0])
+        self.assertTrue(np.allclose(adaptivity_l1._similarity_dists, expected_l1_3))
+
+        adaptivity_l2 = AdaptivityCalculator(
+            configurator,
+            nsims=nsims_3,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
-        # norm taken over last axis -> same as before
-        self.assertTrue(
-            np.allclose(
-                adaptivity_controller._l2(fake_data),
-                np.array([[0, 1, 2], [1, 0, 1], [2, 1, 0]]),
-            )
+        configurator.get_adaptivity_similarity_measure.return_value = "L2"
+        adaptivity_l2._similarity_dists = np.zeros(nsims_3 * (nsims_3 - 1) // 2)
+        adaptivity_l2._l2(fake_data)
+        # L2 norm of scalars is same as L1 for 1D data
+        expected_l2_3 = np.array([1.0, 2.0, 1.0])
+        self.assertTrue(np.allclose(adaptivity_l2._similarity_dists, expected_l2_3))
+
+        adaptivity_l1rel = AdaptivityCalculator(
+            configurator,
+            nsims=nsims_3,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
+        configurator.get_adaptivity_similarity_measure.return_value = "L1rel"
+        adaptivity_l1rel._similarity_dists = np.zeros(nsims_3 * (nsims_3 - 1) // 2)
+        adaptivity_l1rel._l1rel(fake_data)
+        # Expected: (1,0)=|2-1|/max(2,1)=1/2, (2,0)=|3-1|/max(3,1)=2/3, (2,1)=|3-2|/max(3,2)=1/3
+        expected_l1rel_3 = np.array([0.5, 2.0 / 3.0, 1.0 / 3.0])
         self.assertTrue(
-            np.allclose(
-                adaptivity_controller._l1rel(fake_data),
-                np.array([[0, 0.5, 2 / 3], [0.5, 0, 1 / 3], [2 / 3, 1 / 3, 0]]),
-            )
+            np.allclose(adaptivity_l1rel._similarity_dists, expected_l1rel_3)
         )
+
+        adaptivity_l2rel = AdaptivityCalculator(
+            configurator,
+            nsims=nsims_3,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
+        )
+        configurator.get_adaptivity_similarity_measure.return_value = "L2rel"
+        adaptivity_l2rel._similarity_dists = np.zeros(nsims_3 * (nsims_3 - 1) // 2)
+        adaptivity_l2rel._l2rel(fake_data)
+        # L2rel of scalars is same as L1rel for 1D data
+        expected_l2rel_3 = np.array([0.5, 2.0 / 3.0, 1.0 / 3.0])
         self.assertTrue(
-            np.allclose(
-                adaptivity_controller._l2rel(fake_data),
-                np.array([[0, 0.5, 2 / 3], [0.5, 0, 1 / 3], [2 / 3, 1 / 3, 0]]),
-            )
+            np.allclose(adaptivity_l2rel._similarity_dists, expected_l2rel_3)
+        )
+
+        # Test with 2-element 2D data
+        nsims_2 = 2
+        configurator.get_adaptivity_similarity_measure.return_value = "L1"
+        adaptivity_l1_2d = AdaptivityCalculator(
+            configurator,
+            nsims=nsims_2,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
 
         fake_2d_data = np.array([[1, 2], [3, 4]])
-        self.assertTrue(
-            np.allclose(
-                adaptivity_controller._l1(fake_2d_data), np.array([[0, 4], [4, 0]])
-            )
+        adaptivity_l1_2d._similarity_dists = np.zeros(nsims_2 * (nsims_2 - 1) // 2)
+        adaptivity_l1_2d._l1(fake_2d_data)
+        # Expected: (1,0)=|3-1|+|4-2|=2+2=4
+        expected_l1_2d = np.array([4.0])
+        self.assertTrue(np.allclose(adaptivity_l1_2d._similarity_dists, expected_l1_2d))
+
+        configurator.get_adaptivity_similarity_measure.return_value = "L2"
+        adaptivity_l2_2d = AdaptivityCalculator(
+            configurator,
+            nsims=nsims_2,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
-        self.assertTrue(
-            np.allclose(
-                adaptivity_controller._l2(fake_2d_data),
-                np.array(
-                    [
-                        [0, np.sqrt((1 - 3) ** 2 + (2 - 4) ** 2)],
-                        [np.sqrt((1 - 3) ** 2 + (2 - 4) ** 2), 0],
-                    ]
-                ),
-            )
+        adaptivity_l2_2d._similarity_dists = np.zeros(nsims_2 * (nsims_2 - 1) // 2)
+        adaptivity_l2_2d._l2(fake_2d_data)
+        # Expected: (1,0)=sqrt((3-1)^2+(4-2)^2)=sqrt(8)=2*sqrt(2)
+        expected_l2_2d = np.array([np.sqrt(8.0)])
+        self.assertTrue(np.allclose(adaptivity_l2_2d._similarity_dists, expected_l2_2d))
+
+        configurator.get_adaptivity_similarity_measure.return_value = "L1rel"
+        adaptivity_l1rel_2d = AdaptivityCalculator(
+            configurator,
+            nsims=nsims_2,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
         )
+        adaptivity_l1rel_2d._similarity_dists = np.zeros(nsims_2 * (nsims_2 - 1) // 2)
+        adaptivity_l1rel_2d._l1rel(fake_2d_data)
+        # Expected: (1,0)=|3-1|/max(1,3)+|4-2|/max(2,4)=2/3+2/4=2/3+1/2
+        expected_l1rel_2d = np.array([2.0 / 3.0 + 1.0 / 2.0])
         self.assertTrue(
-            np.allclose(
-                adaptivity_controller._l1rel(fake_2d_data),
-                np.array(
-                    [
-                        [0, abs((1 - 3) / max(1, 3) + (2 - 4) / max(2, 4))],
-                        [abs((1 - 3) / max(1, 3) + (2 - 4) / max(2, 4)), 0],
-                    ]
-                ),
-            )
+            np.allclose(adaptivity_l1rel_2d._similarity_dists, expected_l1rel_2d)
         )
+
+        configurator.get_adaptivity_similarity_measure.return_value = "L2rel"
+        adaptivity_l2rel_2d = AdaptivityCalculator(
+            configurator,
+            nsims=nsims_2,
+            base_logger=MagicMock(),
+            rank=0,
+            micro_problem_cls=MicroSimulation,
+            model_manager=ModelManager(),
+        )
+        adaptivity_l2rel_2d._similarity_dists = np.zeros(nsims_2 * (nsims_2 - 1) // 2)
+        adaptivity_l2rel_2d._l2rel(fake_2d_data)
+        # Expected: (1,0)=sqrt((3-1)^2/max(1,3)^2+(4-2)^2/max(2,4)^2)=sqrt(4/9+4/16)
+        expected_l2rel_2d = np.array([np.sqrt((2.0 / 3.0) ** 2 + (2.0 / 4.0) ** 2)])
         self.assertTrue(
-            np.allclose(
-                adaptivity_controller._l2rel(fake_2d_data),
-                np.array(
-                    [
-                        [
-                            0,
-                            np.sqrt(
-                                (1 - 3) ** 2 / max(1, 3) ** 2
-                                + (2 - 4) ** 2 / max(2, 4) ** 2
-                            ),
-                        ],
-                        [
-                            np.sqrt(
-                                (1 - 3) ** 2 / max(1, 3) ** 2
-                                + (2 - 4) ** 2 / max(2, 4) ** 2
-                            ),
-                            0,
-                        ],
-                    ]
-                ),
-            )
+            np.allclose(adaptivity_l2rel_2d._similarity_dists, expected_l2rel_2d)
         )
 
     def test_adaptivity_norms_with_zeros_no_warning(self):
@@ -315,23 +397,33 @@ class TestLocalAdaptivity(TestCase):
 
         # Data with zeros - previously triggered RuntimeWarning: invalid value in true_divide
         data_with_zeros = np.array([[0.0], [0.0], [1.0]])
+        # Initialize vectors for testing
+        nsims_zero_test = 3
+        zero_vec_size = nsims_zero_test * (nsims_zero_test - 1) // 2
+
+        # Test L2rel with zero data
+        adaptivity_l2rel._similarity_dists = np.zeros(zero_vec_size)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("error", RuntimeWarning)
-            result_l2rel = adaptivity_l2rel._l2rel(data_with_zeros)
+            adaptivity_l2rel._l2rel(data_with_zeros)
         self.assertEqual(
             len(w), 0, "L2rel must not raise RuntimeWarning with zero data"
         )
+        # When both are 0, relative diff should be 0 (since numerator is 0)
+        # (0,0) pair is at index 0
+        self.assertEqual(adaptivity_l2rel._similarity_dists[0], 0.0)
 
+        # Test L1rel with zero data
+        adaptivity_l1rel._similarity_dists = np.zeros(zero_vec_size)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("error", RuntimeWarning)
-            result_l1rel = adaptivity_l1rel._l1rel(data_with_zeros)
+            adaptivity_l1rel._l1rel(data_with_zeros)
         self.assertEqual(
             len(w), 0, "L1rel must not raise RuntimeWarning with zero data"
         )
-
         # When both are 0, relative diff should be 0 (since numerator is 0)
-        self.assertEqual(result_l2rel[0, 1], 0.0)
-        self.assertEqual(result_l1rel[0, 1], 0.0)
+        # (0,0) pair is at index 0
+        self.assertEqual(adaptivity_l1rel._similarity_dists[0], 0.0)
 
     def test_associate_active_to_inactive(self):
         """
@@ -360,7 +452,9 @@ class TestLocalAdaptivity(TestCase):
         ]
 
         adaptivity_controller._similarity_dists = self._similarity_dists
-        adaptivity_controller._max_similarity_dist = np.amax(self._similarity_dists)
+        adaptivity_controller._max_similarity_dist = (
+            np.amax(self._similarity_dists) if len(self._similarity_dists) > 0 else 0.0
+        )
 
         adaptivity_controller._is_sim_active = np.array(
             [True, False, False, True, False]
@@ -408,6 +502,9 @@ class TestLocalAdaptivity(TestCase):
         expected_sim_is_associated_to = np.array([-2, 0, 0, -2, 3])
 
         adaptivity_controller._similarity_dists = self._similarity_dists
+        adaptivity_controller._max_similarity_dist = (
+            np.amax(self._similarity_dists) if len(self._similarity_dists) > 0 else 0.0
+        )
         adaptivity_controller._is_sim_active = np.array(
             [True, False, False, False, False]
         )


### PR DESCRIPTION
It is not necessary to store the N² matrix of similarity distances. Only storing the lower (or upper) triangular part is sufficient. This PR implements such storage and access. This is done to mitigate the memory costs of global adaptivity.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
