### PR TITLE
Memory optimizations to norm calculations and a fix to lazy initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Optimized norm calculations and further fixed lazy initialization [#241](https://github.com/precice/micro-manager/pull/241)
 - Fixed lazy initialization for ranks without (active) micro simulations [#238](https://github.com/precice/micro-manager/pull/238)
 - Added coverage testing and simulation interface tests [#225](https://github.com/precice/micro-manager/pull/225)
 - Added `--test-dependencies` CLI flag to check if all required dependencies are correctly installed, with clear error messages listing missing packages and how to fix them [#221](https://github.com/precice/micro-manager/pull/221)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -275,16 +275,14 @@ class AdaptivityCalculator:
         similarity_dists : numpy array
             Updated 2D array having similarity distances between each micro simulation pair
         """
-        pointwise_diff = data[np.newaxis, :] - data[:, np.newaxis]
-        # divide by data to get relative difference
-        # divide i,j by max(abs(data[i]),abs(data[j])) to get relative difference
-        denom = np.maximum(
-            np.absolute(data[np.newaxis, :]), np.absolute(data[:, np.newaxis])
-        )
-        # Add small epsilon to avoid division by zero (invalid value warning) when both are 0
         eps = np.finfo(np.float64).eps
-        relative = pointwise_diff / np.maximum(denom, eps)
-        return np.linalg.norm(relative, ord=1, axis=-1)
+        data_abs = np.absolute(data)
+        denom = np.maximum(data_abs[np.newaxis, :], data_abs[:, np.newaxis])
+        return np.linalg.norm(
+            (data[np.newaxis, :] - data[:, np.newaxis]) / np.maximum(denom, eps),
+            ord=1,
+            axis=-1,
+        )
 
     def _l2rel(self, data: np.ndarray) -> np.ndarray:
         """
@@ -301,13 +299,11 @@ class AdaptivityCalculator:
         similarity_dists : numpy array
             Updated 2D array having similarity distances between each micro simulation pair
         """
-        pointwise_diff = data[np.newaxis, :] - data[:, np.newaxis]
-        # divide by data to get relative difference
-        # divide i,j by max(abs(data[i]),abs(data[j])) to get relative difference
-        denom = np.maximum(
-            np.absolute(data[np.newaxis, :]), np.absolute(data[:, np.newaxis])
-        )
-        # Add small epsilon to avoid division by zero (invalid value warning) when both are 0
         eps = np.finfo(np.float64).eps
-        relative = pointwise_diff / np.maximum(denom, eps)
-        return np.linalg.norm(relative, ord=2, axis=-1)
+        data_abs = np.absolute(data)
+        denom = np.maximum(data_abs[np.newaxis, :], data_abs[:, np.newaxis])
+        return np.linalg.norm(
+            (data[np.newaxis, :] - data[:, np.newaxis]) / np.maximum(denom, eps),
+            ord=2,
+            axis=-1,
+        )

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -276,10 +276,11 @@ class AdaptivityCalculator:
             Updated 2D array having similarity distances between each micro simulation pair
         """
         eps = np.finfo(np.float64).eps
-        data_abs = np.absolute(data)
-        denom = np.maximum(data_abs[np.newaxis, :], data_abs[:, np.newaxis])
+        data_bc = data[np.newaxis, :]
+        data_abs = np.absolute(data_bc)
+        denom = np.maximum(data_abs, np.swapaxis(data_abs, 0, 1))
         return np.linalg.norm(
-            (data[np.newaxis, :] - data[:, np.newaxis]) / np.maximum(denom, eps),
+            (data_bc - np.swapaxis(data_bc, 0, 1) / np.maximum(denom, eps),
             ord=1,
             axis=-1,
         )

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -124,7 +124,7 @@ class AdaptivityCalculator:
         self._similarity_dists *= exp(-self._hist_param * dt)
 
         for name in data.keys():
-            data_vals = np.array(data[name])
+            data_vals = np.asarray(data[name])
             if data_vals.ndim == 1:
                 # If the adaptivity data is a scalar for each simulation,
                 # expand the dimension to make it a 2D array to unify the calculation.

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -278,9 +278,9 @@ class AdaptivityCalculator:
         eps = np.finfo(np.float64).eps
         data_bc = data[np.newaxis, :]
         data_abs = np.absolute(data_bc)
-        denom = np.maximum(data_abs, np.swapaxis(data_abs, 0, 1))
+        denom = np.maximum(data_abs, np.swapaxes(data_abs, 0, 1))
         return np.linalg.norm(
-            (data_bc - np.swapaxis(data_bc, 0, 1) / np.maximum(denom, eps),
+            (data_bc - np.swapaxes(data_bc, 0, 1)) / np.maximum(denom, eps),
             ord=1,
             axis=-1,
         )

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -301,10 +301,11 @@ class AdaptivityCalculator:
             Updated 2D array having similarity distances between each micro simulation pair
         """
         eps = np.finfo(np.float64).eps
-        data_abs = np.absolute(data)
-        denom = np.maximum(data_abs[np.newaxis, :], data_abs[:, np.newaxis])
+        data_bc = data[np.newaxis, :]
+        data_abs = np.absolute(data_bc)
+        denom = np.maximum(data_abs, np.swapaxes(data_abs, 0, 1))
         return np.linalg.norm(
-            (data[np.newaxis, :] - data[:, np.newaxis]) / np.maximum(denom, eps),
+            (data_bc - np.swapaxes(data_bc, 0, 1)) / np.maximum(denom, eps),
             ord=2,
             axis=-1,
         )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -717,7 +717,7 @@ class MicroManagerCoupling(MicroManager):
                 "The initialize() method of the Micro simulation requires initial data, but no initial macro data has been provided."
             )
 
-        initial_micro_data = None
+        initial_micro_data: dict[str, list] = dict()
 
         if self._micro_sims_init:
             # Call initialize() method of the micro simulation to check if it returns any initial data
@@ -743,8 +743,6 @@ class MicroManagerCoupling(MicroManager):
                         self._micro_sims[i].initialize()
             else:  # Case where the initialize() method returns data
                 if self._is_adaptivity_on:
-                    initial_micro_data: dict[str, list] = dict()
-
                     for name in initial_micro_output.keys():
                         initial_micro_data[name] = [0] * self._local_number_of_sims
                         # Save initial data from first micro simulation as we anyway have it
@@ -811,15 +809,15 @@ class MicroManagerCoupling(MicroManager):
         # If lazy initialization is on, initial states of inactive simulations need to be determined
         if self._lazy_init:
             # Prepare data structure for collective communication
-            if initial_micro_data:
-                initial_micro_data_list = [
-                    dict(zip(initial_micro_data, t))
-                    for t in zip(*initial_micro_data.values())
+            if not initial_micro_data:
+                # Ranks without active simulations provide empty dicts
+                initial_micro_data_list: list[dict] = [
+                    dict() for _ in range(self._local_number_of_sims)
                 ]
             else:
-                # Ranks without active simulations provide empty dicts
-                initial_micro_data_list = [
-                    dict() for _ in range(self._local_number_of_sims)
+                initial_micro_data_list: list[dict] = [
+                    dict(zip(initial_micro_data, t))
+                    for t in zip(*initial_micro_data.values())
                 ]
 
             initial_micro_data_list = (

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -813,7 +813,7 @@ class MicroManagerCoupling(MicroManager):
 
         # If lazy initialization is on, initial states of inactive simulations need to be determined
         if self._lazy_init:
-            # If there is initial (macro or micro) data, and if this rank has sims to init, then the initial micro data needs to be gathered
+            # If there is initial micro data, and if this rank has sims to init, then the data is to be gathered
             if initial_micro_data and are_there_sims_to_init:
                 initial_micro_data_list: list[dict] = [
                     dict(zip(initial_micro_data, t))

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -646,15 +646,17 @@ class MicroManagerCoupling(MicroManager):
         self._micro_sims_init = False  # DECLARATION
 
         # Read initial data from preCICE, if it is available
-        initial_data = self._read_data_from_precice(dt=0)
+        initial_macro_data = self._read_data_from_precice(dt=0)
 
         first_id = 0  # 0 if lazy initialization is off, otherwise the first active simulation ID
         micro_sims_to_init = range(
             1, self._local_number_of_sims
         )  # All sims if lazy init is off, otherwise all active simulations
+
+        # Additional bool to check if there are sims to init
         are_there_sims_to_init = True
 
-        if not initial_data:
+        if not initial_macro_data:
             is_initial_data_available = False
 
             if self._lazy_init:
@@ -668,7 +670,7 @@ class MicroManagerCoupling(MicroManager):
             if self._lazy_init:
                 for i in range(self._local_number_of_sims):
                     for name in self._adaptivity_macro_data_names:
-                        self._data_for_adaptivity[name][i] = initial_data[i][name]
+                        self._data_for_adaptivity[name][i] = initial_macro_data[i][name]
 
                 self._adaptivity_controller.compute_adaptivity(
                     self._micro_dt, self._micro_sims, self._data_for_adaptivity
@@ -699,13 +701,12 @@ class MicroManagerCoupling(MicroManager):
                     )
                     are_there_sims_to_init = True
 
-        # Boolean which states if the initialize() method of the micro simulation requires initial data
         test_instance = self._model_manager.get_instance(
             self._global_number_of_sims + 1, micro_problem_cls
         )
         test_data = None
         if is_initial_data_available:
-            test_data = initial_data[0]
+            test_data = initial_macro_data[0]
         (
             self._micro_sims_init,
             sim_requires_init_data,
@@ -723,11 +724,11 @@ class MicroManagerCoupling(MicroManager):
 
         initial_micro_data: dict[str, list] = dict()
 
-        if are_there_sims_to_init:
+        if are_there_sims_to_init and self._micro_sims_init:
             # Call initialize() method of the micro simulation to check if it returns any initial data
             if sim_requires_init_data:
                 initial_micro_output = self._micro_sims[first_id].initialize(
-                    initial_data[first_id]
+                    initial_macro_data[first_id]
                 )
             else:
                 initial_micro_output = self._micro_sims[first_id].initialize()
@@ -741,7 +742,7 @@ class MicroManagerCoupling(MicroManager):
 
                 if sim_requires_init_data:
                     for i in micro_sims_to_init:
-                        self._micro_sims[i].initialize(initial_data[i])
+                        self._micro_sims[i].initialize(initial_macro_data[i])
                 else:
                     for i in micro_sims_to_init:
                         self._micro_sims[i].initialize()
@@ -767,7 +768,7 @@ class MicroManagerCoupling(MicroManager):
                     if sim_requires_init_data:
                         for i in micro_sims_to_init:
                             initial_micro_output = self._micro_sims[i].initialize(
-                                initial_data[i]
+                                initial_macro_data[i]
                             )
                             for name in self._adaptivity_micro_data_names:
                                 self._data_for_adaptivity[name][
@@ -782,13 +783,13 @@ class MicroManagerCoupling(MicroManager):
                                     i
                                 ] = initial_micro_output[name]
                                 initial_micro_data[name][i] = initial_micro_output[name]
-                else:
+                else:  # If adaptivity is off, the returned initial data from the initialize() method will be ignored
                     self._logger.log_warning_rank_zero(
                         "The initialize() method of the Micro simulation returns initial data, but adaptivity is turned off. The returned data will be ignored. The initialize method will nevertheless still be called."
                     )
                     if sim_requires_init_data:
                         for i in range(1, self._local_number_of_sims):
-                            self._micro_sims[i].initialize(initial_data[i])
+                            self._micro_sims[i].initialize(initial_macro_data[i])
                     else:
                         for i in range(1, self._local_number_of_sims):
                             self._micro_sims[i].initialize()
@@ -812,8 +813,8 @@ class MicroManagerCoupling(MicroManager):
 
         # If lazy initialization is on, initial states of inactive simulations need to be determined
         if self._lazy_init:
-            # Prepare data structure for collective communication
-            if are_there_sims_to_init:
+            # If there is initial (macro or micro) data, and if this rank has sims to init, then the initial micro data needs to be gathered
+            if initial_micro_data and are_there_sims_to_init:
                 initial_micro_data_list: list[dict] = [
                     dict(zip(initial_micro_data, t))
                     for t in zip(*initial_micro_data.values())

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -809,15 +809,15 @@ class MicroManagerCoupling(MicroManager):
         # If lazy initialization is on, initial states of inactive simulations need to be determined
         if self._lazy_init:
             # Prepare data structure for collective communication
-            if not initial_micro_data:
-                # Ranks without active simulations provide empty dicts
-                initial_micro_data_list: list[dict] = [
-                    dict() for _ in range(self._local_number_of_sims)
-                ]
-            else:
+            if micro_sims_to_init:
                 initial_micro_data_list: list[dict] = [
                     dict(zip(initial_micro_data, t))
                     for t in zip(*initial_micro_data.values())
+                ]
+            else:
+                # Ranks without active simulations provide empty dicts
+                initial_micro_data_list: list[dict] = [
+                    dict() for _ in range(self._local_number_of_sims)
                 ]
 
             initial_micro_data_list = (

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -813,7 +813,7 @@ class MicroManagerCoupling(MicroManager):
         # If lazy initialization is on, initial states of inactive simulations need to be determined
         if self._lazy_init:
             # Prepare data structure for collective communication
-            if micro_sims_to_init:
+            if are_there_sims_to_init:
                 initial_micro_data_list: list[dict] = [
                     dict(zip(initial_micro_data, t))
                     for t in zip(*initial_micro_data.values())

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -652,6 +652,7 @@ class MicroManagerCoupling(MicroManager):
         micro_sims_to_init = range(
             1, self._local_number_of_sims
         )  # All sims if lazy init is off, otherwise all active simulations
+        are_there_sims_to_init = True
 
         if not initial_data:
             is_initial_data_available = False
@@ -662,6 +663,7 @@ class MicroManagerCoupling(MicroManager):
                 )
         else:
             is_initial_data_available = True
+
             # For lazy initialization, compute adaptivity with the initial macro data
             if self._lazy_init:
                 for i in range(self._local_number_of_sims):
@@ -679,6 +681,7 @@ class MicroManagerCoupling(MicroManager):
                         "There are no active simulations on this rank."
                     )
                     micro_sims_to_init = []
+                    are_there_sims_to_init = False
                 else:
                     for i in active_sim_lids:
                         self._micro_sims[i] = micro_problem_cls(
@@ -694,6 +697,7 @@ class MicroManagerCoupling(MicroManager):
                     micro_sims_to_init = (
                         active_sim_lids  # Only active simulations will be initialized
                     )
+                    are_there_sims_to_init = True
 
         # Boolean which states if the initialize() method of the micro simulation requires initial data
         test_instance = self._model_manager.get_instance(
@@ -719,7 +723,7 @@ class MicroManagerCoupling(MicroManager):
 
         initial_micro_data: dict[str, list] = dict()
 
-        if self._micro_sims_init:
+        if are_there_sims_to_init:
             # Call initialize() method of the micro simulation to check if it returns any initial data
             if sim_requires_init_data:
                 initial_micro_output = self._micro_sims[first_id].initialize(

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -685,15 +685,15 @@ class MicroManagerCoupling(MicroManager):
                             self._global_ids_of_local_sims[i]
                         )
 
-                for i in active_sim_lids:
-                    self._micro_sims[i] = self._model_manager.get_instance(
-                        self._global_ids_of_local_sims[i], micro_problem_cls
-                    )
+                    for i in active_sim_lids:
+                        self._micro_sims[i] = self._model_manager.get_instance(
+                            self._global_ids_of_local_sims[i], micro_problem_cls
+                        )
 
-                first_id = active_sim_lids[0]  # First active simulation ID
-                micro_sims_to_init = (
-                    active_sim_lids  # Only active simulations will be initialized
-                )
+                    first_id = active_sim_lids[0]  # First active simulation ID
+                    micro_sims_to_init = (
+                        active_sim_lids  # Only active simulations will be initialized
+                    )
 
         # Boolean which states if the initialize() method of the micro simulation requires initial data
         test_instance = self._model_manager.get_instance(


### PR DESCRIPTION
This PR consists of two fixes:

- Avoid creation of intermediate arrays in norm calculations to save memory.
- Fix lazy initialization when there are ranks without any active simulations.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
