### PR TITLE
Refactor DomainDecomposer class and add new functionality to decompose the macro-scale coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Refactored `DomainDecomposer` class and added a new variant of non-uniform decomposition [#243](https://github.com/precice/micro-manager/pull/243)
 - Fixed load balancing configuration `partitioning` parameter setting [#245](https://github.com/precice/micro-manager/pull/245)
 - Fixed comparison of zero values of type float32 and float64 in simulation deactivation [#244](https://github.com/precice/micro-manager/pull/244)
 - Optimized norm calculations and further fixed lazy initialization [#241](https://github.com/precice/micro-manager/pull/241)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,15 +34,19 @@ Apart from the base settings, there are three main sections in the configuration
 
 ## Simulation Parameters
 
-| Parameter             | Description                                                                                                                                          | Default                 |
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
-| `macro_domain_bounds` | Minimum and maximum bounds of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]` in 3D and `[xmin, xmax, ymin, ymax]` in 2D. | -                       |
-| `decomposition`       | List of number of ranks in each axis with format `[xranks, yranks, zranks]` in 3D and `[xranks, yranks]` in 2D.                                      | `[1, 1, 1]` or `[1, 1]` |
-| `micro_dt`            | Initial time window size (dt) of the micro simulation.                                                                                               | -                       |
-| `adaptivity`          | Set `true` for simulations with adaptivity. See section on [adaptivity](#adaptivity).                                                                | `false`                 |
-| `load_balancing`      | Set `true` for load balancing. See section on [load balancing](#load-balancing).                                                                     | `false`                 |
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `macro_domain_bounds` | Minimum and maximum bounds of the macro-domain, having the format `[xmin, xmax, ymin, ymax, zmin, zmax]` in 3D and `[xmin, xmax, ymin, ymax]` in 2D. | - |
+| `decomposition` | List of number of ranks in each axis with format `[xranks, yranks, zranks]` in 3D and `[xranks, yranks]` in 2D. | `[1, 1, 1]` or `[1, 1]` |
+| `decomposition_type` | Type of domain decomposition. Either `uniform` or `nonuniform`. | `uniform` |
+| `minimum_access_region_size` | If `nonuniform` decomposition, optionally set a minimum domain width in each axis. Format `[xmin, ymin, zmin]` | - |
+| `micro_dt` | Initial time window size (dt) of the micro simulation. | - |
+| `adaptivity` | Set `true` for simulations with adaptivity. See section on [adaptivity](#adaptivity). | `false` |
+| `load_balancing` | Set `true` for load balancing. See section on [load balancing](#load-balancing). | `false` |
 
 The total number of partitions ranks in the `decomposition` list should be the same as the number of ranks in the `mpirun` or `mpiexec` command.
+
+Non-uniform domain decomposition is based on a geometric progression.
 
 ## Diagnostics
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -37,6 +37,7 @@ class Config:
         self._macro_domain_bounds = None
         self._ranks_per_axis = None
         self._decomposition_type = "uniform"
+        self._minimum_access_region_size: list = []
 
         self._micro_output_n = 1
         self._diagnostics_data_names = None
@@ -269,6 +270,19 @@ class Config:
                     raise Exception(
                         "Decomposition type can be either 'uniform' or 'nonuniform'."
                     )
+                if (
+                    self._data["simulation_params"]["decomposition_type"]
+                    == "nonuniform"
+                ):
+                    if self._data["simulation_params"]["minimum_access_region_size"]:
+                        self._minimum_access_region_size = self._data[
+                            "simulation_params"
+                        ]["minimum_access_region_size"]
+                    else:
+                        self._logger.log_info_rank_zero(
+                            "Minimum access region size is not specified. Calculating it as 1 / (2^ranks_per_axis - 1) of the macro domain size in each axis."
+                        )
+
             self._logger.log_info_rank_zero(
                 "Domain decomposition type: " + self._decomposition_type
             )
@@ -766,6 +780,17 @@ class Config:
             Type of domain decomposition, can be either "uniform" or "non-uniform".
         """
         return self._decomposition_type
+
+    def get_minimum_access_region_size(self):
+        """
+        Get the minimum access region size for non-uniform domain decomposition.
+
+        Returns
+        -------
+        minimum_access_region_size : list
+            List containing the minimum access region size in each axis for non-uniform domain decomposition.
+        """
+        return self._minimum_access_region_size
 
     def get_micro_file_name(self):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -33,8 +33,11 @@ class Config:
         self._write_data_names = None
         self._micro_dt = None
 
+        # Domain decomposition information
         self._macro_domain_bounds = None
         self._ranks_per_axis = None
+        self._decomposition_type = "uniform"
+
         self._micro_output_n = 1
         self._diagnostics_data_names = None
 
@@ -257,6 +260,17 @@ class Config:
                 raise Exception("Ranks per axis entry is not a list")
             self._logger.log_info_rank_zero(
                 "Axis-wise domain decomposition: " + str(self._ranks_per_axis)
+            )
+            if self._data["simulation_params"]["decomposition_type"]:
+                self._decomposition_type = self._data["simulation_params"][
+                    "decomposition_type"
+                ]
+                if self._decomposition_type not in ["uniform", "non-uniform"]:
+                    raise Exception(
+                        "Decomposition type can be either 'uniform' or 'non-uniform'."
+                    )
+            self._logger.log_info_rank_zero(
+                "Domain decomposition type: " + self._decomposition_type
             )
         except BaseException:
             self._logger.log_info_rank_zero(
@@ -741,6 +755,17 @@ class Config:
             List containing ranks in the x, y and z axis respectively.
         """
         return self._ranks_per_axis
+
+    def get_decomposition_type(self):
+        """
+        Get the type of domain decomposition.
+
+        Returns
+        -------
+        decomposition_type : str
+            Type of domain decomposition, can be either "uniform" or "non-uniform".
+        """
+        return self._decomposition_type
 
     def get_micro_file_name(self):
         """

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -265,9 +265,9 @@ class Config:
                 self._decomposition_type = self._data["simulation_params"][
                     "decomposition_type"
                 ]
-                if self._decomposition_type not in ["uniform", "non-uniform"]:
+                if self._decomposition_type not in ["uniform", "nonuniform"]:
                     raise Exception(
-                        "Decomposition type can be either 'uniform' or 'non-uniform'."
+                        "Decomposition type can be either 'uniform' or 'nonuniform'."
                     )
             self._logger.log_info_rank_zero(
                 "Domain decomposition type: " + self._decomposition_type

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -92,23 +92,21 @@ class DomainDecomposer:
         else:
             raise ValueError("Domain decomposition only supports 2D and 3D cases.")
 
-        dx = []
+        mesh_bounds = []
         for d in range(self._dims):
-            dx.append(
+            dx = (
                 abs(self._macro_bounds[d * 2 + 1] - self._macro_bounds[d * 2])
                 / self._ranks_per_axis[d]
             )
 
-        mesh_bounds = []
-        for d in range(self._dims):
             if rank_in_axis[d] > 0:
-                mesh_bounds.append(self._macro_bounds[d * 2] + rank_in_axis[d] * dx[d])
+                mesh_bounds.append(self._macro_bounds[d * 2] + rank_in_axis[d] * dx)
                 mesh_bounds.append(
-                    self._macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx[d]
+                    self._macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx
                 )
             elif rank_in_axis[d] == 0:
                 mesh_bounds.append(self._macro_bounds[d * 2])
-                mesh_bounds.append(self._macro_bounds[d * 2] + dx[d])
+                mesh_bounds.append(self._macro_bounds[d * 2] + dx)
 
             # Adjust the maximum bound to be exactly the domain size
             if rank_in_axis[d] + 1 == self._ranks_per_axis[d]:

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -20,7 +20,9 @@ class DomainDecomposer:
         self._rank = rank
         self._size = size
 
-    def get_local_mesh_bounds(self, macro_bounds: list, ranks_per_axis: list) -> list:
+    def get_uniform_local_mesh_bounds(
+        self, macro_bounds: list, ranks_per_axis: list
+    ) -> list:
         """
         Decompose the macro domain equally among all ranks, if the Micro Manager is run in parallel.
 
@@ -82,6 +84,88 @@ class DomainDecomposer:
             elif rank_in_axis[d] == 0:
                 mesh_bounds.append(macro_bounds[d * 2])
                 mesh_bounds.append(macro_bounds[d * 2] + dx[d])
+
+            # Adjust the maximum bound to be exactly the domain size
+            if rank_in_axis[d] + 1 == ranks_per_axis[d]:
+                mesh_bounds[d * 2 + 1] = macro_bounds[d * 2 + 1]
+
+        return mesh_bounds
+
+    def get_nonuniform_local_mesh_bounds(
+        self, macro_bounds: list, ranks_per_axis: list
+    ) -> list:
+        """
+        Decompose the macro domain among all ranks with an non-uniform distribution, if the Micro Manager is run in parallel.
+        The non-uniform distribution is based on a geometric progression, where the size of the local mesh bounds increases
+        by a factor of 2 in each rank.
+
+        Note: This method is experimental and hence not available via a configuration option yet.
+
+        Parameters
+        ----------
+        macro_bounds : list
+            List containing upper and lower bounds of the macro domain.
+            Format in 2D is [x_min, x_max, y_min, y_max]
+            Format in 3D is [x_min, x_max, y_min, y_max, z_min, z_max]
+        ranks_per_axis : list
+            List containing axis wise ranks for a parallel run
+            Format in 2D is [ranks_x, ranks_y]
+            Format in 3D is [ranks_x, ranks_y, ranks_z]
+
+        Returns
+        -------
+        mesh_bounds : list
+            List containing the upper and lower bounds of the domain pertaining to this rank.
+            Format is same as input parameter macro_bounds.
+        """
+        if np.prod(ranks_per_axis) != self._size:
+            raise ValueError(
+                "Total number of processors provided in the Micro Manager configuration and in the MPI execution command do not match."
+            )
+
+        dims = len(ranks_per_axis)
+
+        if dims == 3:
+            for z in range(ranks_per_axis[2]):
+                for y in range(ranks_per_axis[1]):
+                    for x in range(ranks_per_axis[0]):
+                        n = (
+                            x
+                            + y * ranks_per_axis[0]
+                            + z * ranks_per_axis[0] * ranks_per_axis[1]
+                        )
+                        if n == self._rank:
+                            rank_in_axis = [x, y, z]
+        elif dims == 2:
+            for y in range(ranks_per_axis[1]):
+                for x in range(ranks_per_axis[0]):
+                    n = x + y * ranks_per_axis[0]
+                    if n == self._rank:
+                        rank_in_axis = [x, y]
+        else:
+            raise ValueError("Domain decomposition only supports 2D and 3D cases.")
+
+        dx: list = []
+        for d in range(dims):
+            dx.append(np.zeros(ranks_per_axis[d]))
+            for rank in range(ranks_per_axis[d]):
+                if rank == 0:
+                    dx[d][rank] = abs(macro_bounds[d * 2 + 1] - macro_bounds[d * 2]) / (
+                        2 ** (ranks_per_axis[d]) - 1
+                    )
+                else:
+                    dx[d][rank] = 2 * dx[d][rank - 1]
+
+        mesh_bounds = []
+        for d in range(dims):
+            rank = rank_in_axis[d]
+            if rank > 0:
+                min_bound = macro_bounds[d * 2] + sum(dx[d][:rank])
+                mesh_bounds.append(min_bound)
+                mesh_bounds.append(min_bound + dx[d][rank])
+            elif rank == 0:
+                mesh_bounds.append(macro_bounds[d * 2])
+                mesh_bounds.append(macro_bounds[d * 2] + dx[d][rank])
 
             # Adjust the maximum bound to be exactly the domain size
             if rank_in_axis[d] + 1 == ranks_per_axis[d]:

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -4,6 +4,7 @@ Class DomainDecomposer provides the method decompose_macro_domain which returns 
 
 import numpy as np
 from micro_manager.config import Config
+from typing import Callable
 
 
 class DomainDecomposer:
@@ -23,7 +24,19 @@ class DomainDecomposer:
         self._rank = rank
         self._size = size
 
+        self._ranks_per_axis = (
+            configurator.get_ranks_per_axis()
+        )  # Check if ranks per axis is provided in the configuration file for parallel runs
+
+        self._dims = len(self._ranks_per_axis)
+
         self._is_minimum_access_region_size_specified = False
+
+        self._decomposition_type = configurator.get_decomposition_type()
+
+        self._macro_bounds = configurator.get_macro_domain_bounds()
+
+        self._get_local_mesh_bounds = self._get_local_mesh_bounds_variant()
 
         self._minimum_access_region_size: list = (
             configurator.get_minimum_access_region_size()
@@ -31,22 +44,9 @@ class DomainDecomposer:
         if self._minimum_access_region_size:  # if list is not empty
             self._is_minimum_access_region_size_specified = True
 
-    def get_uniform_local_mesh_bounds(
-        self, macro_bounds: list, ranks_per_axis: list
-    ) -> list:
+    def get_local_mesh_bounds(self) -> list:
         """
-        Decompose the macro domain equally among all ranks, if the Micro Manager is run in parallel.
-
-        Parameters
-        ----------
-        macro_bounds : list
-            List containing upper and lower bounds of the macro domain.
-            Format in 2D is [x_min, x_max, y_min, y_max]
-            Format in 3D is [x_min, x_max, y_min, y_max, z_min, z_max]
-        ranks_per_axis : list
-            List containing axis wise ranks for a parallel run
-            Format in 2D is [ranks_x, ranks_y]
-            Format in 3D is [ranks_x, ranks_y, ranks_z]
+        Get the local mesh bounds for this rank based on the domain decomposition type specified in the configuration file.
 
         Returns
         -------
@@ -54,72 +54,72 @@ class DomainDecomposer:
             List containing the upper and lower bounds of the domain pertaining to this rank.
             Format is same as input parameter macro_bounds.
         """
-        if np.prod(ranks_per_axis) != self._size:
+        return self._get_local_mesh_bounds()
+
+    def _get_uniform_local_mesh_bounds(self) -> list:
+        """
+        Decompose the macro domain equally among all ranks, if the Micro Manager is run in parallel.
+
+        Returns
+        -------
+        mesh_bounds : list
+            List containing the upper and lower bounds of the domain pertaining to this rank.
+            Format is same as input parameter macro_bounds.
+        """
+        if np.prod(self._ranks_per_axis) != self._size:
             raise ValueError(
                 "Total number of processors provided in the Micro Manager configuration and in the MPI execution command do not match."
             )
 
-        dims = len(ranks_per_axis)
-
-        if dims == 3:
-            for z in range(ranks_per_axis[2]):
-                for y in range(ranks_per_axis[1]):
-                    for x in range(ranks_per_axis[0]):
+        if self._dims == 3:
+            for z in range(self._ranks_per_axis[2]):
+                for y in range(self._ranks_per_axis[1]):
+                    for x in range(self._ranks_per_axis[0]):
                         n = (
                             x
-                            + y * ranks_per_axis[0]
-                            + z * ranks_per_axis[0] * ranks_per_axis[1]
+                            + y * self._ranks_per_axis[0]
+                            + z * self._ranks_per_axis[0] * self._ranks_per_axis[1]
                         )
                         if n == self._rank:
                             rank_in_axis = [x, y, z]
-        elif dims == 2:
-            for y in range(ranks_per_axis[1]):
-                for x in range(ranks_per_axis[0]):
-                    n = x + y * ranks_per_axis[0]
+        elif self._dims == 2:
+            for y in range(self._ranks_per_axis[1]):
+                for x in range(self._ranks_per_axis[0]):
+                    n = x + y * self._ranks_per_axis[0]
                     if n == self._rank:
                         rank_in_axis = [x, y]
         else:
             raise ValueError("Domain decomposition only supports 2D and 3D cases.")
 
         dx = []
-        for d in range(dims):
+        for d in range(self._dims):
             dx.append(
-                abs(macro_bounds[d * 2 + 1] - macro_bounds[d * 2]) / ranks_per_axis[d]
+                abs(self._macro_bounds[d * 2 + 1] - self._macro_bounds[d * 2])
+                / self._ranks_per_axis[d]
             )
 
         mesh_bounds = []
-        for d in range(dims):
+        for d in range(self._dims):
             if rank_in_axis[d] > 0:
-                mesh_bounds.append(macro_bounds[d * 2] + rank_in_axis[d] * dx[d])
-                mesh_bounds.append(macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx[d])
+                mesh_bounds.append(self._macro_bounds[d * 2] + rank_in_axis[d] * dx[d])
+                mesh_bounds.append(
+                    self._macro_bounds[d * 2] + (rank_in_axis[d] + 1) * dx[d]
+                )
             elif rank_in_axis[d] == 0:
-                mesh_bounds.append(macro_bounds[d * 2])
-                mesh_bounds.append(macro_bounds[d * 2] + dx[d])
+                mesh_bounds.append(self._macro_bounds[d * 2])
+                mesh_bounds.append(self._macro_bounds[d * 2] + dx[d])
 
             # Adjust the maximum bound to be exactly the domain size
-            if rank_in_axis[d] + 1 == ranks_per_axis[d]:
-                mesh_bounds[d * 2 + 1] = macro_bounds[d * 2 + 1]
+            if rank_in_axis[d] + 1 == self._ranks_per_axis[d]:
+                mesh_bounds[d * 2 + 1] = self._macro_bounds[d * 2 + 1]
 
         return mesh_bounds
 
-    def get_nonuniform_local_mesh_bounds(
-        self, macro_bounds: list, ranks_per_axis: list
-    ) -> list:
+    def _get_nonuniform_local_mesh_bounds(self) -> list:
         """
         Decompose the macro domain among all ranks with an non-uniform distribution, if the Micro Manager is run in parallel.
         The non-uniform distribution is based on a geometric progression, where the size of the local mesh bounds increases
         by a factor of 2 in each rank. This is just one of many possible non-uniform domain decompositions.
-
-        Parameters
-        ----------
-        macro_bounds : list
-            List containing upper and lower bounds of the macro domain.
-            Format in 2D is [x_min, x_max, y_min, y_max]
-            Format in 3D is [x_min, x_max, y_min, y_max, z_min, z_max]
-        ranks_per_axis : list
-            List containing axis wise ranks for a parallel run
-            Format in 2D is [ranks_x, ranks_y]
-            Format in 3D is [ranks_x, ranks_y, ranks_z]
 
         Returns
         -------
@@ -127,41 +127,39 @@ class DomainDecomposer:
             List containing the upper and lower bounds of the domain pertaining to this rank.
             Format is same as input parameter macro_bounds.
         """
-        if np.prod(ranks_per_axis) != self._size:
+        if np.prod(self._ranks_per_axis) != self._size:
             raise ValueError(
                 "Total number of processors provided in the Micro Manager configuration and in the MPI execution command do not match."
             )
 
-        dims = len(ranks_per_axis)
-
-        if dims == 3:
-            for z in range(ranks_per_axis[2]):
-                for y in range(ranks_per_axis[1]):
-                    for x in range(ranks_per_axis[0]):
+        if self._dims == 3:
+            for z in range(self._ranks_per_axis[2]):
+                for y in range(self._ranks_per_axis[1]):
+                    for x in range(self._ranks_per_axis[0]):
                         n = (
                             x
-                            + y * ranks_per_axis[0]
-                            + z * ranks_per_axis[0] * ranks_per_axis[1]
+                            + y * self._ranks_per_axis[0]
+                            + z * self._ranks_per_axis[0] * self._ranks_per_axis[1]
                         )
                         if n == self._rank:
                             rank_in_axis = [x, y, z]
-        elif dims == 2:
-            for y in range(ranks_per_axis[1]):
-                for x in range(ranks_per_axis[0]):
-                    n = x + y * ranks_per_axis[0]
+        elif self._dims == 2:
+            for y in range(self._ranks_per_axis[1]):
+                for x in range(self._ranks_per_axis[0]):
+                    n = x + y * self._ranks_per_axis[0]
                     if n == self._rank:
                         rank_in_axis = [x, y]
         else:
             raise ValueError("Domain decomposition only supports 2D and 3D cases.")
 
         dx: list = []
-        for d in range(dims):
-            dx.append(np.zeros(ranks_per_axis[d]))
-            for rank in range(ranks_per_axis[d]):
+        for d in range(self._dims):
+            dx.append(np.zeros(self._ranks_per_axis[d]))
+            for rank in range(self._ranks_per_axis[d]):
                 if rank == 0:
-                    base_dx = abs(macro_bounds[d * 2 + 1] - macro_bounds[d * 2]) / (
-                        2 ** ranks_per_axis[d] - 1
-                    )
+                    base_dx = abs(
+                        self._macro_bounds[d * 2 + 1] - self._macro_bounds[d * 2]
+                    ) / (2 ** self._ranks_per_axis[d] - 1)
                     if self._is_minimum_access_region_size_specified:
                         if base_dx < self._minimum_access_region_size[d]:
                             base_dx = self._minimum_access_region_size[d]
@@ -171,56 +169,65 @@ class DomainDecomposer:
                     dx[d][rank] = 2 * dx[d][rank - 1]
 
         mesh_bounds = []
-        for d in range(dims):
+        for d in range(self._dims):
             rank = rank_in_axis[d]
             if rank > 0:
-                min_bound = macro_bounds[d * 2] + sum(dx[d][:rank])
+                min_bound = self._macro_bounds[d * 2] + sum(dx[d][:rank])
                 mesh_bounds.append(min_bound)
                 mesh_bounds.append(min_bound + dx[d][rank])
             elif rank == 0:
-                mesh_bounds.append(macro_bounds[d * 2])
-                mesh_bounds.append(macro_bounds[d * 2] + dx[d][rank])
+                mesh_bounds.append(self._macro_bounds[d * 2])
+                mesh_bounds.append(self._macro_bounds[d * 2] + dx[d][rank])
 
             # Adjust the maximum bound to be exactly the domain size
-            if rank_in_axis[d] + 1 == ranks_per_axis[d]:
-                mesh_bounds[d * 2 + 1] = macro_bounds[d * 2 + 1]
+            if rank_in_axis[d] + 1 == self._ranks_per_axis[d]:
+                mesh_bounds[d * 2 + 1] = self._macro_bounds[d * 2 + 1]
 
         return mesh_bounds
 
+    def _get_local_mesh_bounds_variant(self) -> Callable:
+        """
+        Get uniform or nonuniform variant of calculating local mesh bounds
+
+        Returns
+        -------
+        get_local_mesh_bounds_variant : function
+            Function to calculate local mesh bounds based on the decomposition type specified in the configuration file.
+        """
+        if self._decomposition_type == "uniform":
+            return self._get_uniform_local_mesh_bounds
+        elif self._decomposition_type == "nonuniform":
+            return self._get_nonuniform_local_mesh_bounds
+        else:
+            raise ValueError(
+                "Decomposition type can be either 'uniform' or 'nonuniform'."
+            )
+
     def get_local_sims_and_macro_coords(
-        self, macro_bounds: list, ranks_per_axis: list, macro_coords: np.ndarray
+        self, macro_coords: np.ndarray
     ) -> tuple[int, list[np.ndarray]]:
         """
         Decompose the micro simulations among all ranks based on their positions in the macro domain.
-
         Parameters
         ----------
-        macro_bounds : list
-            List containing upper and lower bounds of the macro domain.
-            Format in 2D is [x_min, x_max, y_min, y_max]
-            Format in 3D is [x_min, x_max, y_min, y_max, z_min, z_max]
-        ranks_per_axis : list
-            List containing axis wise ranks for a parallel run
-            Format in 2D is [ranks_x, ranks_y]
-            Format in 3D is [ranks_x, ranks_y, ranks_z]
         macro_coords : numpy.ndarray
-            The coordinates associated to the IDs and corresponding data values (dim * size)
+            Array containing the coordinates of the macro points corresponding to the micro simulations.
 
         Returns
         -------
         micro_sims_on_rank : int
-            Number of micro simulations assigned to this rank.
-        macro_coords_on_this_rank : list
-            List of macro coordinates assigned to this rank.
+            Number of micro simulations pertaining to this rank.
+        macro_coords_on_this_rank : list of numpy.ndarray
+            List of coordinates of the macro points pertaining to this rank.
         """
-        local_mesh_bounds = self.get_local_mesh_bounds(macro_bounds, ranks_per_axis)
+        local_mesh_bounds = self.get_local_mesh_bounds()
 
         macro_coords_on_this_rank = []
 
         micro_sims_on_rank = 0
         for position in macro_coords:
             inside = True
-            for d in range(len(ranks_per_axis)):
+            for d in range(self._dims):
                 if not (
                     position[d] >= local_mesh_bounds[d * 2]
                     and position[d] <= local_mesh_bounds[d * 2 + 1]

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -149,7 +149,7 @@ class DomainDecomposer:
             for rank in range(ranks_per_axis[d]):
                 if rank == 0:
                     dx[d][rank] = abs(macro_bounds[d * 2 + 1] - macro_bounds[d * 2]) / (
-                        2 ** (ranks_per_axis[d]) - 1
+                        2 ** ranks_per_axis[d] - 1
                     )
                 else:
                     dx[d][rank] = 2 * dx[d][rank - 1]

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -153,20 +153,26 @@ class DomainDecomposer:
             raise ValueError("Domain decomposition only supports 2D and 3D cases.")
 
         dx: list = []
+        multiplier = 2  # factor by which the local mesh bounds increase in each rank. 2 means geometric progression.
         for d in range(self._dims):
             dx.append(np.zeros(self._ranks_per_axis[d]))
             for rank in range(self._ranks_per_axis[d]):
                 if rank == 0:
-                    base_dx = abs(
+                    macro_bounds_diff = abs(
                         self._macro_bounds[d * 2 + 1] - self._macro_bounds[d * 2]
-                    ) / (2 ** self._ranks_per_axis[d] - 1)
-                    if self._is_minimum_access_region_size_specified:
-                        if base_dx < self._minimum_access_region_size[d]:
-                            base_dx = self._minimum_access_region_size[d]
+                    )
+                    dx0 = macro_bounds_diff / (multiplier ** (self._ranks_per_axis[d]))
 
-                    dx[d][rank] = base_dx
+                    if self._is_minimum_access_region_size_specified:
+                        if dx0 < self._minimum_access_region_size[d]:
+                            dx0 = self._minimum_access_region_size[d]
+                            multiplier = (macro_bounds_diff / dx0) ** (
+                                1 / (self._ranks_per_axis[d])
+                            )
+
+                    dx[d][rank] = dx0
                 else:
-                    dx[d][rank] = 2 * dx[d][rank - 1]
+                    dx[d][rank] = multiplier * dx[d][rank - 1]
 
         mesh_bounds = []
         for d in range(self._dims):

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -3,15 +3,18 @@ Class DomainDecomposer provides the method decompose_macro_domain which returns 
 """
 
 import numpy as np
+from micro_manager.config import Config
 
 
 class DomainDecomposer:
-    def __init__(self, rank, size) -> None:
+    def __init__(self, configurator: Config, rank: int, size: int) -> None:
         """
         Class constructor.
 
         Parameters
         ----------
+        configurator : object of class Config
+            Object which has getter functions to get parameters defined in the configuration file.
         rank : int
             MPI rank.
         size : int
@@ -19,6 +22,14 @@ class DomainDecomposer:
         """
         self._rank = rank
         self._size = size
+
+        self._is_minimum_access_region_size_specified = False
+
+        self._minimum_access_region_size: list = (
+            configurator.get_minimum_access_region_size()
+        )
+        if self._minimum_access_region_size:  # if list is not empty
+            self._is_minimum_access_region_size_specified = True
 
     def get_uniform_local_mesh_bounds(
         self, macro_bounds: list, ranks_per_axis: list
@@ -148,9 +159,14 @@ class DomainDecomposer:
             dx.append(np.zeros(ranks_per_axis[d]))
             for rank in range(ranks_per_axis[d]):
                 if rank == 0:
-                    dx[d][rank] = abs(macro_bounds[d * 2 + 1] - macro_bounds[d * 2]) / (
+                    base_dx = abs(macro_bounds[d * 2 + 1] - macro_bounds[d * 2]) / (
                         2 ** ranks_per_axis[d] - 1
                     )
+                    if self._is_minimum_access_region_size_specified:
+                        if base_dx < self._minimum_access_region_size[d]:
+                            base_dx = self._minimum_access_region_size[d]
+
+                    dx[d][rank] = base_dx
                 else:
                     dx[d][rank] = 2 * dx[d][rank - 1]
 

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -3,6 +3,7 @@ Class DomainDecomposer provides the method decompose_macro_domain which returns 
 """
 
 import numpy as np
+from scipy.optimize import brentq
 from micro_manager.config import Config
 from typing import Callable
 
@@ -152,40 +153,53 @@ class DomainDecomposer:
         else:
             raise ValueError("Domain decomposition only supports 2D and 3D cases.")
 
-        dx: list = []
+        mesh_bounds = []
         multiplier = 2  # factor by which the local mesh bounds increase in each rank. 2 means geometric progression.
         for d in range(self._dims):
-            dx.append(np.zeros(self._ranks_per_axis[d]))
+            macro_bounds_diff = abs(
+                self._macro_bounds[d * 2 + 1] - self._macro_bounds[d * 2]
+            )
+
+            dx0 = (
+                macro_bounds_diff
+                * (multiplier - 1)
+                / (multiplier ** self._ranks_per_axis[d] - 1)
+            )
+
+            if self._is_minimum_access_region_size_specified:
+                if dx0 < self._minimum_access_region_size[d]:
+                    dx0 = self._minimum_access_region_size[d]
+                    n_ranks = self._ranks_per_axis[d]
+
+                    def _geom_sum_residual(r):
+                        return dx0 * (r**n_ranks - 1) / (r - 1) - macro_bounds_diff
+
+                    # Find upper bracket where residual is positive
+                    r_upper = 2.0
+                    while _geom_sum_residual(r_upper) <= 0:
+                        r_upper *= 2.0
+
+                    multiplier = brentq(_geom_sum_residual, 1.0 + 1e-12, r_upper)
+
+            dx = np.zeros(self._ranks_per_axis[d])
+
             for rank in range(self._ranks_per_axis[d]):
                 if rank == 0:
-                    macro_bounds_diff = abs(
-                        self._macro_bounds[d * 2 + 1] - self._macro_bounds[d * 2]
-                    )
-                    dx0 = macro_bounds_diff / (multiplier ** (self._ranks_per_axis[d]))
-
-                    if self._is_minimum_access_region_size_specified:
-                        if dx0 < self._minimum_access_region_size[d]:
-                            dx0 = self._minimum_access_region_size[d]
-                            multiplier = (macro_bounds_diff / dx0) ** (
-                                1 / (self._ranks_per_axis[d])
-                            )
-
-                    dx[d][rank] = dx0
+                    dx[rank] = dx0
                 else:
-                    dx[d][rank] = multiplier * dx[d][rank - 1]
+                    dx[rank] = multiplier * dx[rank - 1]
 
-        mesh_bounds = []
-        for d in range(self._dims):
             rank = rank_in_axis[d]
-            if rank > 0:
-                min_bound = self._macro_bounds[d * 2] + sum(dx[d][:rank])
-                mesh_bounds.append(min_bound)
-                mesh_bounds.append(min_bound + dx[d][rank])
-            elif rank == 0:
+            if rank == 0:
                 mesh_bounds.append(self._macro_bounds[d * 2])
-                mesh_bounds.append(self._macro_bounds[d * 2] + dx[d][rank])
+                mesh_bounds.append(self._macro_bounds[d * 2] + dx[rank])
 
-            # Adjust the maximum bound to be exactly the domain size
+            if rank > 0:
+                min_bound = self._macro_bounds[d * 2] + sum(dx[: rank - 1])
+                mesh_bounds.append(min_bound)
+                mesh_bounds.append(min_bound + dx[rank])
+
+            # Adjust the maximum bound of the access region of ranks on the boundary to be exactly the upper bound of the macro domain
             if rank_in_axis[d] + 1 == self._ranks_per_axis[d]:
                 mesh_bounds[d * 2 + 1] = self._macro_bounds[d * 2 + 1]
 

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -99,8 +99,6 @@ class DomainDecomposer:
         The non-uniform distribution is based on a geometric progression, where the size of the local mesh bounds increases
         by a factor of 2 in each rank.
 
-        Note: This method is experimental and hence not available via a configuration option yet.
-
         Parameters
         ----------
         macro_bounds : list

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -179,6 +179,10 @@ class DomainDecomposer:
                     while _geom_sum_residual(r_upper) <= 0:
                         r_upper *= 2.0
 
+                    # When the minimum access region size is specified,
+                    # the multiplier is numerically calculated such that the sum of
+                    # the geometric progression of the local mesh bounds equals
+                    # the macro domain size in that axis.
                     multiplier = brentq(_geom_sum_residual, 1.0 + 1e-12, r_upper)
 
             dx = np.zeros(self._ranks_per_axis[d])
@@ -195,7 +199,7 @@ class DomainDecomposer:
                 mesh_bounds.append(self._macro_bounds[d * 2] + dx[rank])
 
             if rank > 0:
-                min_bound = self._macro_bounds[d * 2] + sum(dx[: rank - 1])
+                min_bound = self._macro_bounds[d * 2] + sum(dx[:rank])
                 mesh_bounds.append(min_bound)
                 mesh_bounds.append(min_bound + dx[rank])
 

--- a/micro_manager/domain_decomposition.py
+++ b/micro_manager/domain_decomposition.py
@@ -97,7 +97,7 @@ class DomainDecomposer:
         """
         Decompose the macro domain among all ranks with an non-uniform distribution, if the Micro Manager is run in parallel.
         The non-uniform distribution is based on a geometric progression, where the size of the local mesh bounds increases
-        by a factor of 2 in each rank.
+        by a factor of 2 in each rank. This is just one of many possible non-uniform domain decompositions.
 
         Parameters
         ----------

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -457,7 +457,7 @@ class MicroManagerCoupling(MicroManager):
                 coupling_mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
                     self._macro_bounds, self._ranks_per_axis
                 )
-            elif self._decomposition_type == "non-uniform":
+            elif self._decomposition_type == "nonuniform":
                 coupling_mesh_bounds = (
                     domain_decomposer.get_nonuniform_local_mesh_bounds(
                         self._macro_bounds, self._ranks_per_axis

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -88,6 +88,8 @@ class MicroManagerCoupling(MicroManager):
         if self._is_parallel:  # Simulation is run in parallel
             self._ranks_per_axis = self._config.get_ranks_per_axis()
 
+        self._decomposition_type = self._config.get_decomposition_type()
+
         # Parameter for interpolation in case of a simulation crash
         self._interpolate_crashed_sims = self._config.interpolate_crashed_micro_sim()
         if self._interpolate_crashed_sims:
@@ -451,9 +453,16 @@ class MicroManagerCoupling(MicroManager):
             domain_decomposer = DomainDecomposer(self._rank, self._size)
 
         if self._is_parallel and not self._is_load_balancing:
-            coupling_mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
-                self._macro_bounds, self._ranks_per_axis
-            )
+            if self._decomposition_type == "uniform":
+                coupling_mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
+                    self._macro_bounds, self._ranks_per_axis
+                )
+            elif self._decomposition_type == "non-uniform":
+                coupling_mesh_bounds = (
+                    domain_decomposer.get_nonuniform_local_mesh_bounds(
+                        self._macro_bounds, self._ranks_per_axis
+                    )
+                )
         else:  # When serial or load balancing, the whole macro domain is assigned to one/each rank
             coupling_mesh_bounds = self._macro_bounds
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -88,8 +88,6 @@ class MicroManagerCoupling(MicroManager):
         if self._is_parallel:  # Simulation is run in parallel
             self._ranks_per_axis = self._config.get_ranks_per_axis()
 
-        self._decomposition_type = self._config.get_decomposition_type()
-
         # Parameter for interpolation in case of a simulation crash
         self._interpolate_crashed_sims = self._config.interpolate_crashed_micro_sim()
         if self._interpolate_crashed_sims:
@@ -453,16 +451,9 @@ class MicroManagerCoupling(MicroManager):
             domain_decomposer = DomainDecomposer(self._rank, self._size)
 
         if self._is_parallel and not self._is_load_balancing:
-            if self._decomposition_type == "uniform":
-                coupling_mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
-                    self._macro_bounds, self._ranks_per_axis
-                )
-            elif self._decomposition_type == "nonuniform":
-                coupling_mesh_bounds = (
-                    domain_decomposer.get_nonuniform_local_mesh_bounds(
-                        self._macro_bounds, self._ranks_per_axis
-                    )
-                )
+            coupling_mesh_bounds = domain_decomposer.get_local_mesh_bounds(
+                self._macro_bounds, self._ranks_per_axis
+            )
         else:  # When serial or load balancing, the whole macro domain is assigned to one/each rank
             coupling_mesh_bounds = self._macro_bounds
 
@@ -497,7 +488,15 @@ class MicroManagerCoupling(MicroManager):
             ) = domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
 
         if self._mesh_vertex_coords.size == 0:
-            raise Exception("Macro mesh has no vertices.")
+            if self._is_parallel:
+                self._is_rank_empty = True
+                self._logger.log_warning(
+                    "The access region of this rank has no macro-scale vertices. This rank will not have any micro simulations. To avoid this, change the domain decomposition"
+                )
+            else:
+                raise Exception(
+                    "The macro mesh has no vertices in the specified access region."
+                )
 
         if self._is_load_balancing and self._is_parallel:
             (
@@ -508,17 +507,6 @@ class MicroManagerCoupling(MicroManager):
             )
         else:
             self._local_number_of_sims, _ = self._mesh_vertex_coords.shape
-
-        if self._local_number_of_sims == 0:
-            if self._is_parallel:
-                self._logger.log_info(
-                    "Rank {} has no micro simulations and hence will not do any computation.".format(
-                        self._rank
-                    )
-                )
-                self._is_rank_empty = True
-            else:
-                raise Exception("Micro Manager has no micro simulations.")
 
         nms_all_ranks = np.zeros(self._size, dtype=np.int64)
         # Gather number of micro simulations that each rank has, because this rank needs to know how many micro

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -451,7 +451,7 @@ class MicroManagerCoupling(MicroManager):
             domain_decomposer = DomainDecomposer(self._rank, self._size)
 
         if self._is_parallel and not self._is_load_balancing:
-            coupling_mesh_bounds = domain_decomposer.get_local_mesh_bounds(
+            coupling_mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
                 self._macro_bounds, self._ranks_per_axis
             )
         else:  # When serial or load balancing, the whole macro domain is assigned to one/each rank

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -85,6 +85,8 @@ class MicroManagerCoupling(MicroManager):
 
         self._macro_bounds = self._config.get_macro_domain_bounds()
 
+        self._decomposition_type = self._config.get_decomposition_type()
+
         if self._is_parallel:  # Simulation is run in parallel
             self._ranks_per_axis = self._config.get_ranks_per_axis()
 
@@ -451,9 +453,16 @@ class MicroManagerCoupling(MicroManager):
             domain_decomposer = DomainDecomposer(self._rank, self._size)
 
         if self._is_parallel and not self._is_load_balancing:
-            coupling_mesh_bounds = domain_decomposer.get_local_mesh_bounds(
-                self._macro_bounds, self._ranks_per_axis
-            )
+            if self._decomposition_type == "uniform":
+                coupling_mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
+                    self._macro_bounds, self._ranks_per_axis
+                )
+            elif self._decomposition_type == "nonuniform":
+                coupling_mesh_bounds = (
+                    domain_decomposer.get_nonuniform_local_mesh_bounds(
+                        self._macro_bounds, self._ranks_per_axis
+                    )
+                )
         else:  # When serial or load balancing, the whole macro domain is assigned to one/each rank
             coupling_mesh_bounds = self._macro_bounds
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -83,13 +83,6 @@ class MicroManagerCoupling(MicroManager):
 
         self._macro_mesh_name = self._config.get_macro_mesh_name()
 
-        self._macro_bounds = self._config.get_macro_domain_bounds()
-
-        self._decomposition_type = self._config.get_decomposition_type()
-
-        if self._is_parallel:  # Simulation is run in parallel
-            self._ranks_per_axis = self._config.get_ranks_per_axis()
-
         # Parameter for interpolation in case of a simulation crash
         self._interpolate_crashed_sims = self._config.interpolate_crashed_micro_sim()
         if self._interpolate_crashed_sims:
@@ -436,15 +429,15 @@ class MicroManagerCoupling(MicroManager):
         )
 
         # Decompose the macro-domain and set the mesh access region for each partition in preCICE
-        if not len(self._macro_bounds) / 2 == self._participant.get_mesh_dimensions(
-            self._macro_mesh_name
-        ):
+        if not len(
+            self._config.get_macro_domain_bounds()
+        ) / 2 == self._participant.get_mesh_dimensions(self._macro_mesh_name):
             raise Exception("Provided macro mesh bounds are of incorrect dimension")
 
         if self._is_parallel:
-            if not len(self._ranks_per_axis) == self._participant.get_mesh_dimensions(
-                self._macro_mesh_name
-            ):
+            if not len(
+                self._config.get_ranks_per_axis()
+            ) == self._participant.get_mesh_dimensions(self._macro_mesh_name):
                 raise Exception(
                     "Provided ranks combination is of incorrect dimension"
                     " and does not match the dimensions of the macro mesh."
@@ -453,18 +446,9 @@ class MicroManagerCoupling(MicroManager):
             domain_decomposer = DomainDecomposer(self._config, self._rank, self._size)
 
         if self._is_parallel and not self._is_load_balancing:
-            if self._decomposition_type == "uniform":
-                coupling_mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
-                    self._macro_bounds, self._ranks_per_axis
-                )
-            elif self._decomposition_type == "nonuniform":
-                coupling_mesh_bounds = (
-                    domain_decomposer.get_nonuniform_local_mesh_bounds(
-                        self._macro_bounds, self._ranks_per_axis
-                    )
-                )
+            coupling_mesh_bounds = domain_decomposer.get_local_mesh_bounds()
         else:  # When serial or load balancing, the whole macro domain is assigned to one/each rank
-            coupling_mesh_bounds = self._macro_bounds
+            coupling_mesh_bounds = self._config.get_macro_domain_bounds()
 
         self._participant.set_mesh_access_region(
             self._macro_mesh_name, coupling_mesh_bounds
@@ -512,7 +496,7 @@ class MicroManagerCoupling(MicroManager):
                 self._local_number_of_sims,
                 local_macro_coords,
             ) = domain_decomposer.get_local_sims_and_macro_coords(
-                self._macro_bounds, self._ranks_per_axis, self._mesh_vertex_coords
+                self._mesh_vertex_coords
             )
         else:
             self._local_number_of_sims, _ = self._mesh_vertex_coords.shape

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -486,6 +486,10 @@ class MicroManagerCoupling(MicroManager):
                 self._logger.log_warning(
                     "The access region of this rank has no macro-scale vertices. This rank will not have any micro simulations. To avoid this, change the domain decomposition"
                 )
+                if self._lazy_init:
+                    raise Exception(
+                        "The macro mesh has no vertices in the specified access region, but lazy initialization is turned on. Lazy initialization cannot be used if there are no vertices in the access region, as there would be no data to compute the adaptivity and determine which simulations to initialize."
+                    )
             else:
                 raise Exception(
                     "The macro mesh has no vertices in the specified access region."

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -450,7 +450,7 @@ class MicroManagerCoupling(MicroManager):
                     " and does not match the dimensions of the macro mesh."
                 )
 
-            domain_decomposer = DomainDecomposer(self._rank, self._size)
+            domain_decomposer = DomainDecomposer(self._config, self._rank, self._size)
 
         if self._is_parallel and not self._is_load_balancing:
             if self._decomposition_type == "uniform":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name="micro-manager-precice"
 dynamic = [ "version" ]
 dependencies = [
-    "pyprecice>=3.2", "numpy", "mpi4py", "psutil", "packaging"
+    "pyprecice>=3.2", "numpy", "mpi4py", "psutil", "packaging", "scipy"
 ]
 requires-python = ">=3.8"
 authors = [

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -155,17 +155,19 @@ class TestNonUniformDomainDecomposition(TestCase):
         )
         mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
-        print(mesh_bounds)
+        self.assertTrue(
+            np.allclose(mesh_bounds, [0.756153, 1.0, 0.0, 0.019664], atol=1e-5)
+        )
 
-        self.assertTrue(np.allclose(mesh_bounds, [0.756153, 1.0, 0.0, 0.019664]))
+        # In a 16 x 8 grid, rank 112 is in the lower right corner.
+        domain_decomposer = DomainDecomposer(
+            self._configuration_mock, rank=112, size=128
+        )
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
-        # In a 16 x 8 grid, rank 1 is in the lower right corner.
-        # domain_decomposer = DomainDecomposer(self._configuration_mock, rank=17, size=128)
-        # mesh_bounds = domain_decomposer.get_local_mesh_bounds()
-
-        # self.assertTrue(
-        #     np.allclose(mesh_bounds, [0.0, 1.0 / 256.0, 15.0 / 16.0, 0.5])
-        # )
+        self.assertTrue(
+            np.allclose(mesh_bounds, [0.0, 1.0 / 256.0, 0.364631, 0.5], atol=1e-5)
+        )
 
     def test_nonuniform_rank1_out_of_4_3d(self):
         """

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-import unittest
+from unittest.mock import MagicMock
 import numpy as np
 from micro_manager.domain_decomposition import DomainDecomposer
 
@@ -22,18 +22,20 @@ class TestDomainDecomposition(TestCase):
             2,
         ]
 
+        self._configuration_mock = MagicMock()
+
     def test_rank2_out_of_4_2d(self):
         """
         Check bounds for rank 2 in a setting of axis-wise ranks: [2, 2]
         """
-        rank = 2
-        size = 4
-        ranks_per_axis = [2, 2]
-        domain_decomposer = DomainDecomposer(rank, size)
-        domain_decomposer._dims = 2
-        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
-            self._macro_bounds_2d, ranks_per_axis
+        self._configuration_mock.get_decomposition_type.return_value = "uniform"
+        self._configuration_mock.get_macro_domain_bounds.return_value = (
+            self._macro_bounds_2d
         )
+        self._configuration_mock.get_ranks_per_axis.return_value = [2, 2]
+
+        domain_decomposer = DomainDecomposer(self._configuration_mock, rank=2, size=4)
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
         self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, 1, 2]))
 
@@ -41,14 +43,14 @@ class TestDomainDecomposition(TestCase):
         """
         Check bounds for rank 1 in a setting of axis-wise ranks: [2, 2, 1]
         """
-        rank = 1
-        size = 4
-        ranks_per_axis = [2, 2, 1]
-        domain_decomposer = DomainDecomposer(rank, size)
-        domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
-            self._macro_bounds_3d, ranks_per_axis
+        self._configuration_mock.get_decomposition_type.return_value = "uniform"
+        self._configuration_mock.get_macro_domain_bounds.return_value = (
+            self._macro_bounds_3d
         )
+        self._configuration_mock.get_ranks_per_axis.return_value = [2, 2, 1]
+
+        domain_decomposer = DomainDecomposer(self._configuration_mock, rank=1, size=4)
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
         self.assertTrue(np.allclose(mesh_bounds, [0.0, 1, -2, 0.0, -2, 8]))
 
@@ -56,14 +58,14 @@ class TestDomainDecomposition(TestCase):
         """
         Test domain decomposition for rank 5 in a setting of axis-wise ranks: [1, 2, 5]
         """
-        rank = 5
-        size = 10
-        ranks_per_axis = [1, 2, 5]
-        domain_decomposer = DomainDecomposer(rank, size)
-        domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
-            self._macro_bounds_3d, ranks_per_axis
+        self._configuration_mock.get_decomposition_type.return_value = "uniform"
+        self._configuration_mock.get_macro_domain_bounds.return_value = (
+            self._macro_bounds_3d
         )
+        self._configuration_mock.get_ranks_per_axis.return_value = [1, 2, 5]
+
+        domain_decomposer = DomainDecomposer(self._configuration_mock, rank=5, size=10)
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
         self.assertTrue(np.allclose(mesh_bounds, [-1, 1, 0, 2, 2, 4]))
 
@@ -71,14 +73,14 @@ class TestDomainDecomposition(TestCase):
         """
         Test domain decomposition for rank 10 in a setting of axis-wise ranks: [4, 1, 8]
         """
-        rank = 10
-        size = 32
-        ranks_per_axis = [4, 1, 8]
-        domain_decomposer = DomainDecomposer(rank, size)
-        domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
-            self._macro_bounds_3d, ranks_per_axis
+        self._configuration_mock.get_decomposition_type.return_value = "uniform"
+        self._configuration_mock.get_macro_domain_bounds.return_value = (
+            self._macro_bounds_3d
         )
+        self._configuration_mock.get_ranks_per_axis.return_value = [4, 1, 8]
+
+        domain_decomposer = DomainDecomposer(self._configuration_mock, rank=10, size=32)
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
         self.assertTrue(np.allclose(mesh_bounds, [0, 0.5, -2, 2, 0.5, 1.75]))
 
@@ -86,14 +88,14 @@ class TestDomainDecomposition(TestCase):
         """
         Test domain decomposition for rank 7 in a setting of axis-wise ranks: [8, 2, 1]
         """
-        rank = 7
-        size = 16
-        ranks_per_axis = [8, 2, 1]
-        domain_decomposer = DomainDecomposer(rank, size)
-        domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
-            self._macro_bounds_3d, ranks_per_axis
+        self._configuration_mock.get_decomposition_type.return_value = "uniform"
+        self._configuration_mock.get_macro_domain_bounds.return_value = (
+            self._macro_bounds_3d
         )
+        self._configuration_mock.get_ranks_per_axis.return_value = [8, 2, 1]
+
+        domain_decomposer = DomainDecomposer(self._configuration_mock, rank=7, size=16)
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
         self.assertTrue(np.allclose(mesh_bounds, [0.75, 1, -2, 0, -2, 8]))
 
@@ -115,18 +117,21 @@ class TestNonUniformDomainDecomposition(TestCase):
             2,
         ]
 
+        self._configuration_mock = MagicMock()
+
     def test_nonuniform_rank2_out_of_4_2d(self):
         """
         Check non-uniform bounds for rank 2 in a setting of axis-wise ranks: [2, 2].
         Along each axis, the local width doubles from one rank to the next.
         """
-        rank = 2
-        size = 4
-        ranks_per_axis = [2, 2]
-        domain_decomposer = DomainDecomposer(rank, size)
-        mesh_bounds = domain_decomposer.get_nonuniform_local_mesh_bounds(
-            self._macro_bounds_2d, ranks_per_axis
+        self._configuration_mock.get_decomposition_type.return_value = "nonuniform"
+        self._configuration_mock.get_macro_domain_bounds.return_value = (
+            self._macro_bounds_2d
         )
+        self._configuration_mock.get_ranks_per_axis.return_value = [2, 2]
+
+        domain_decomposer = DomainDecomposer(self._configuration_mock, rank=2, size=4)
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
         self.assertTrue(np.allclose(mesh_bounds, [0.0, 1.0 / 3.0, 2.0 / 3.0, 2.0]))
 
@@ -134,13 +139,14 @@ class TestNonUniformDomainDecomposition(TestCase):
         """
         Check non-uniform bounds for rank 1 in a setting of axis-wise ranks: [2, 2, 1].
         """
-        rank = 1
-        size = 4
-        ranks_per_axis = [2, 2, 1]
-        domain_decomposer = DomainDecomposer(rank, size)
-        mesh_bounds = domain_decomposer.get_nonuniform_local_mesh_bounds(
-            self._macro_bounds_3d, ranks_per_axis
+        self._configuration_mock.get_decomposition_type.return_value = "nonuniform"
+        self._configuration_mock.get_macro_domain_bounds.return_value = (
+            self._macro_bounds_3d
         )
+        self._configuration_mock.get_ranks_per_axis.return_value = [2, 2, 1]
+
+        domain_decomposer = DomainDecomposer(self._configuration_mock, rank=1, size=4)
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
         self.assertTrue(
             np.allclose(mesh_bounds, [-1.0 / 3.0, 1.0, -2.0, -2.0 / 3.0, -2.0, 8.0])
@@ -150,7 +156,7 @@ class TestNonUniformDomainDecomposition(TestCase):
         """
         A mismatch between `ranks_per_axis` and communicator size should raise a ValueError.
         """
-        domain_decomposer = DomainDecomposer(rank=0, size=4)
+        domain_decomposer = DomainDecomposer(self._configuration_mock, rank=0, size=4)
 
         with self.assertRaises(ValueError):
             domain_decomposer.get_nonuniform_local_mesh_bounds(
@@ -164,6 +170,9 @@ class TestDuplicateCoordFiltering(TestCase):
     are correctly filtered, with lower-ranked ranks taking ownership.
     """
 
+    def setUp(self) -> None:
+        self._configuration_mock = MagicMock()
+
     def test_no_duplicates(self):
         """
         If there are no shared coords across ranks, nothing should be filtered.
@@ -174,9 +183,9 @@ class TestDuplicateCoordFiltering(TestCase):
         ]
         all_ids = [[0, 1], [2, 3]]
 
-        coords, ids = DomainDecomposer(0, 2).filter_duplicate_coords(
-            all_coords, all_ids
-        )
+        coords, ids = DomainDecomposer(
+            self._configuration_mock, rank=0, size=2
+        ).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords), 2)
 
         coords, ids = DomainDecomposer(1, 2).filter_duplicate_coords(
@@ -197,16 +206,16 @@ class TestDuplicateCoordFiltering(TestCase):
         all_ids = [[0, 1], [1, 2]]
 
         # Rank 0 should keep both its coords
-        coords0, ids0 = DomainDecomposer(0, 2).filter_duplicate_coords(
-            all_coords, all_ids
-        )
+        coords0, ids0 = DomainDecomposer(
+            self._configuration_mock, rank=0, size=2
+        ).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords0), 2)
         self.assertTrue(np.allclose(coords0[1], shared))
 
         # Rank 1 should drop the shared coord
-        coords1, ids1 = DomainDecomposer(1, 2).filter_duplicate_coords(
-            all_coords, all_ids
-        )
+        coords1, ids1 = DomainDecomposer(
+            self._configuration_mock, rank=1, size=2
+        ).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords1), 1)
         self.assertTrue(np.allclose(coords1[0], [1.0, 0.0]))
 
@@ -222,13 +231,19 @@ class TestDuplicateCoordFiltering(TestCase):
         ]
         all_ids = [[0, 1], [0, 2], [0, 3]]
 
-        coords0, _ = DomainDecomposer(0, 3).filter_duplicate_coords(all_coords, all_ids)
+        coords0, _ = DomainDecomposer(
+            self._configuration_mock, rank=0, size=3
+        ).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords0), 2)
 
-        coords1, _ = DomainDecomposer(1, 3).filter_duplicate_coords(all_coords, all_ids)
+        coords1, _ = DomainDecomposer(
+            self._configuration_mock, rank=1, size=3
+        ).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords1), 1)
         self.assertTrue(np.allclose(coords1[0], [1.0, 0.0]))
 
-        coords2, _ = DomainDecomposer(2, 3).filter_duplicate_coords(all_coords, all_ids)
+        coords2, _ = DomainDecomposer(
+            self._configuration_mock, rank=2, size=3
+        ).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords2), 1)
         self.assertTrue(np.allclose(coords2[0], [2.0, 0.0]))

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, skip
 from unittest.mock import MagicMock
 import numpy as np
 from micro_manager.domain_decomposition import DomainDecomposer
@@ -135,6 +135,37 @@ class TestNonUniformDomainDecomposition(TestCase):
         mesh_bounds = domain_decomposer.get_local_mesh_bounds()
 
         self.assertTrue(np.allclose(mesh_bounds, [0.0, 1.0 / 3.0, 2.0 / 3.0, 2.0]))
+
+    def test_nonuniform_rank15_out_of_128_2d(self):
+        """
+        Check non-uniform bounds for rank 15 in a setting of axis-wise ranks: [16, 8].
+        Along each axis, the local width doubles from one rank to the next.
+        """
+        self._configuration_mock.get_decomposition_type.return_value = "nonuniform"
+        self._configuration_mock.get_macro_domain_bounds.return_value = [0, 1, 0, 0.5]
+        self._configuration_mock.get_ranks_per_axis.return_value = [16, 8]
+        self._configuration_mock.get_minimum_access_region_size.return_value = [
+            1.0 / 256.0,
+            1.0 / 128.0,
+        ]
+
+        # In a 16 x 8 grid, rank 15 is in the lower right corner.
+        domain_decomposer = DomainDecomposer(
+            self._configuration_mock, rank=15, size=128
+        )
+        mesh_bounds = domain_decomposer.get_local_mesh_bounds()
+
+        print(mesh_bounds)
+
+        self.assertTrue(np.allclose(mesh_bounds, [0.756153, 1.0, 0.0, 0.019664]))
+
+        # In a 16 x 8 grid, rank 1 is in the lower right corner.
+        # domain_decomposer = DomainDecomposer(self._configuration_mock, rank=17, size=128)
+        # mesh_bounds = domain_decomposer.get_local_mesh_bounds()
+
+        # self.assertTrue(
+        #     np.allclose(mesh_bounds, [0.0, 1.0 / 256.0, 15.0 / 16.0, 0.5])
+        # )
 
     def test_nonuniform_rank1_out_of_4_3d(self):
         """

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import unittest
 import numpy as np
 from micro_manager.domain_decomposition import DomainDecomposer
 
@@ -30,7 +31,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [2, 2]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 2
-        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
+        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
             self._macro_bounds_2d, ranks_per_axis
         )
 
@@ -45,7 +46,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [2, 2, 1]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
+        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
 
@@ -60,7 +61,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [1, 2, 5]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
+        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
 
@@ -75,7 +76,7 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [4, 1, 8]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
+        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
 
@@ -90,11 +91,71 @@ class TestDomainDecomposition(TestCase):
         ranks_per_axis = [8, 2, 1]
         domain_decomposer = DomainDecomposer(rank, size)
         domain_decomposer._dims = 3
-        mesh_bounds = domain_decomposer.get_local_mesh_bounds(
+        mesh_bounds = domain_decomposer.get_uniform_local_mesh_bounds(
             self._macro_bounds_3d, ranks_per_axis
         )
 
         self.assertTrue(np.allclose(mesh_bounds, [0.75, 1, -2, 0, -2, 8]))
+
+
+class TestNonUniformDomainDecomposition(TestCase):
+    def setUp(self) -> None:
+        self._macro_bounds_3d = [
+            -1,
+            1,
+            -2,
+            2,
+            -2,
+            8,
+        ]
+        self._macro_bounds_2d = [
+            0,
+            1,
+            0,
+            2,
+        ]
+
+    def test_nonuniform_rank2_out_of_4_2d(self):
+        """
+        Check non-uniform bounds for rank 2 in a setting of axis-wise ranks: [2, 2].
+        Along each axis, the local width doubles from one rank to the next.
+        """
+        rank = 2
+        size = 4
+        ranks_per_axis = [2, 2]
+        domain_decomposer = DomainDecomposer(rank, size)
+        mesh_bounds = domain_decomposer.get_nonuniform_local_mesh_bounds(
+            self._macro_bounds_2d, ranks_per_axis
+        )
+
+        self.assertTrue(np.allclose(mesh_bounds, [0.0, 1.0 / 3.0, 2.0 / 3.0, 2.0]))
+
+    def test_nonuniform_rank1_out_of_4_3d(self):
+        """
+        Check non-uniform bounds for rank 1 in a setting of axis-wise ranks: [2, 2, 1].
+        """
+        rank = 1
+        size = 4
+        ranks_per_axis = [2, 2, 1]
+        domain_decomposer = DomainDecomposer(rank, size)
+        mesh_bounds = domain_decomposer.get_nonuniform_local_mesh_bounds(
+            self._macro_bounds_3d, ranks_per_axis
+        )
+
+        self.assertTrue(
+            np.allclose(mesh_bounds, [-1.0 / 3.0, 1.0, -2.0, -2.0 / 3.0, -2.0, 8.0])
+        )
+
+    def test_nonuniform_invalid_processor_count_raises(self):
+        """
+        A mismatch between `ranks_per_axis` and communicator size should raise a ValueError.
+        """
+        domain_decomposer = DomainDecomposer(rank=0, size=4)
+
+        with self.assertRaises(ValueError):
+            domain_decomposer.get_nonuniform_local_mesh_bounds(
+                self._macro_bounds_2d, [3, 2]
+            )
 
 
 class TestDuplicateCoordFiltering(TestCase):

--- a/tests/unit/test_domain_decomposition.py
+++ b/tests/unit/test_domain_decomposition.py
@@ -129,6 +129,7 @@ class TestNonUniformDomainDecomposition(TestCase):
             self._macro_bounds_2d
         )
         self._configuration_mock.get_ranks_per_axis.return_value = [2, 2]
+        self._configuration_mock.get_minimum_access_region_size.return_value = []
 
         domain_decomposer = DomainDecomposer(self._configuration_mock, rank=2, size=4)
         mesh_bounds = domain_decomposer.get_local_mesh_bounds()
@@ -144,6 +145,7 @@ class TestNonUniformDomainDecomposition(TestCase):
             self._macro_bounds_3d
         )
         self._configuration_mock.get_ranks_per_axis.return_value = [2, 2, 1]
+        self._configuration_mock.get_minimum_access_region_size.return_value = []
 
         domain_decomposer = DomainDecomposer(self._configuration_mock, rank=1, size=4)
         mesh_bounds = domain_decomposer.get_local_mesh_bounds()
@@ -156,12 +158,12 @@ class TestNonUniformDomainDecomposition(TestCase):
         """
         A mismatch between `ranks_per_axis` and communicator size should raise a ValueError.
         """
+        self._configuration_mock.get_decomposition_type.return_value = "nonuniform"
+
         domain_decomposer = DomainDecomposer(self._configuration_mock, rank=0, size=4)
 
         with self.assertRaises(ValueError):
-            domain_decomposer.get_nonuniform_local_mesh_bounds(
-                self._macro_bounds_2d, [3, 2]
-            )
+            domain_decomposer.get_local_mesh_bounds()
 
 
 class TestDuplicateCoordFiltering(TestCase):
@@ -183,14 +185,16 @@ class TestDuplicateCoordFiltering(TestCase):
         ]
         all_ids = [[0, 1], [2, 3]]
 
+        self._configuration_mock.get_decomposition_type.return_value = "uniform"
+
         coords, ids = DomainDecomposer(
             self._configuration_mock, rank=0, size=2
         ).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords), 2)
 
-        coords, ids = DomainDecomposer(1, 2).filter_duplicate_coords(
-            all_coords, all_ids
-        )
+        coords, ids = DomainDecomposer(
+            self._configuration_mock, rank=1, size=2
+        ).filter_duplicate_coords(all_coords, all_ids)
         self.assertEqual(len(coords), 2)
 
     def test_duplicate_on_boundary_rank0_keeps(self):
@@ -204,6 +208,8 @@ class TestDuplicateCoordFiltering(TestCase):
             np.array([shared, [1.0, 0.0]]),
         ]
         all_ids = [[0, 1], [1, 2]]
+
+        self._configuration_mock.get_decomposition_type.return_value = "uniform"
 
         # Rank 0 should keep both its coords
         coords0, ids0 = DomainDecomposer(
@@ -230,6 +236,8 @@ class TestDuplicateCoordFiltering(TestCase):
             np.array([shared, [2.0, 0.0]]),
         ]
         all_ids = [[0, 1], [0, 2], [0, 3]]
+
+        self._configuration_mock.get_decomposition_type.return_value = "uniform"
 
         coords0, _ = DomainDecomposer(
             self._configuration_mock, rank=0, size=3

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -59,7 +59,6 @@ class TestFunctioncalls(TestCase):
         """
         manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
 
-        self.assertListEqual(manager._macro_bounds, self.macro_bounds)
         self.assertListEqual(manager._read_data_names, self.fake_read_data_names)
         self.assertListEqual(self.fake_write_data_names, manager._write_data_names)
         self.assertEqual(manager._micro_n_out, 10)
@@ -73,7 +72,6 @@ class TestFunctioncalls(TestCase):
 
         self.assertEqual(manager._micro_dt, 0.1)  # from Interface.initialize
         self.assertEqual(manager._global_number_of_sims, 4)
-        self.assertListEqual(manager._macro_bounds, self.macro_bounds)
         self.assertListEqual(manager._mesh_vertex_ids.tolist(), [0, 1, 2, 3])
         self.assertEqual(len(manager._micro_sims), 4)
         self.assertEqual(


### PR DESCRIPTION
Apart from general refactoring of the `DomainDecomposer` class, this PR also adds the following:

- A new non-uniform domain decomposition variant based on geometric progression is intended to address asymmetrical loaded scenarios such as the [two-scale heat conduction](https://github.com/precice/tutorials/tree/develop/two-scale-heat-conduction).
- There is a corresponding new optional configuration parameter, `decomposition_type`, which can be either `uniform` or `nonuniform`.
- Additionally, a new optional configuration parameter `minimum_access_region_size` can be set. This sets the minimum axis width of the access region, which is essential when a non-uniform domain decomposition is required.
- Remove the `Exception` when a rank does not receive macro-scale vertices via direct access. This can happen if the access region is too small or too obscure, leaving no macro-scale vertices within it.
- Add an `Exception` when a rank has no macro-scale vertices, but lazy initialization is used, because then the rank cannot collect initial data to calculate the initial adaptivity on.

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
