### PR TITLE
Fix comparison of zero values of type float32 and float64 in simulation deactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed comparison of zero values of type float32 and float64 in simulation deactivation [#244](https://github.com/precice/micro-manager/pull/244)
 - Optimized norm calculations and further fixed lazy initialization [#241](https://github.com/precice/micro-manager/pull/241)
 - Fixed lazy initialization for ranks without (active) micro simulations [#238](https://github.com/precice/micro-manager/pull/238)
 - Added coverage testing and simulation interface tests [#225](https://github.com/precice/micro-manager/pull/225)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -195,7 +195,7 @@ class AdaptivityCalculator:
         for active_id_2 in active_ids:
             if active_id != active_id_2:  # don't compare active sim to itself
                 # If active sim is similar to another active sim, deactivate it
-                if self._similarity_dists[active_id, active_id_2] < self._coarse_tol:
+                if self._similarity_dists[active_id, active_id_2] <= self._coarse_tol:
                     return True
         return False
 

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -6,7 +6,6 @@ on each rank is done.
 Note: All ID variables used in the methods of this class are global IDs, unless they have *local* in their name.
 """
 from copy import deepcopy
-import sys
 from typing import Dict
 import numpy as np
 from mpi4py import MPI
@@ -359,15 +358,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         Update set of active micro simulations.
         Pairs of active simulations (A, B) are compared and if found to be similar, B is deactivated.
         """
-        if self._max_similarity_dist == 0.0:
-            self._base_logger.log_warning_rank_zero(
-                "All similarity distances are zero, which means all the data for adaptivity is the same. Coarsening tolerance will be manually set to minimum float number."
-            )
-            self._coarse_tol = sys.float_info.min
-        else:
-            self._coarse_tol = (
-                self._coarse_const * self._refine_const * self._max_similarity_dist
-            )
+        self._coarse_tol = (
+            self._coarse_const * self._refine_const * self._max_similarity_dist
+        )
 
         active_gids_this_rank = self.get_active_sim_global_ids()
         # Gather global ids of active sims from all ranks

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -3,7 +3,6 @@ Class LocalAdaptivityCalculator provides methods to adaptively control of micro 
 in a local way. If the Micro Manager is run in parallel, simulations on one rank are compared to
 each other. A global comparison is not done.
 """
-import sys
 import numpy as np
 from copy import deepcopy
 from mpi4py import MPI
@@ -246,15 +245,9 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         Update set of active micro simulations. Active micro simulations are compared to each other
         and if found similar, one of them is deactivated.
         """
-        if self._max_similarity_dist == 0.0:
-            self._base_logger.log_warning(
-                "All similarity distances are zero, which means all the data for adaptivity is the same. Coarsening tolerance will be manually set to minimum float number."
-            )
-            self._coarse_tol = sys.float_info.min
-        else:
-            self._coarse_tol = (
-                self._coarse_const * self._refine_const * self._max_similarity_dist
-            )
+        self._coarse_tol = (
+            self._coarse_const * self._refine_const * self._max_similarity_dist
+        )
 
         active_gids = self.get_active_sim_local_ids().tolist()
 


### PR DESCRIPTION
If the adaptivity data is zero and the coarsening tolerance is set to `sys.float.min`, the `if` condition in deactivation can lead to a false negative.

Checklist:

- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
