### PR TITLE
Fix load balancing configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed load balancing configuration `partitioning` parameter setting [#245](https://github.com/precice/micro-manager/pull/245)
 - Fixed comparison of zero values of type float32 and float64 in simulation deactivation [#244](https://github.com/precice/micro-manager/pull/244)
 - Optimized norm calculations and further fixed lazy initialization [#241](https://github.com/precice/micro-manager/pull/241)
 - Fixed lazy initialization for ranks without (active) micro simulations [#238](https://github.com/precice/micro-manager/pull/238)

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -460,16 +460,6 @@ class Config:
             )
 
             try:
-                self._load_balancing_partitioning = self._data["simulation_params"][
-                    "load_balancing_settings"
-                ]["partitioning"]
-            except BaseException:
-                self._logger.log_info_rank_zero(
-                    "Micro Manager will not load balance. Must provide partitioning type."
-                )
-                self._load_balancing = False
-
-            try:
                 self._load_balancing_type = self._data["simulation_params"][
                     "load_balancing_settings"
                 ]["type"]
@@ -514,6 +504,17 @@ class Config:
                     self._logger.log_info_rank_zero(
                         'Load balancing is not using active simulation balancing. Field "balance_inactive_sims" will be ignored.'
                     )
+
+            if self._load_balancing_type == "time":
+                try:
+                    self._load_balancing_partitioning = self._data["simulation_params"][
+                        "load_balancing_settings"
+                    ]["partitioning"]
+                except BaseException:
+                    self._logger.log_info_rank_zero(
+                        "Partitioning type must be provided for time based load balancing. Defaulting to 'lpt'."
+                    )
+                    self._load_balancing_partitioning = "lpt"
 
         try:
             if self._data["simulation_params"]["model_adaptivity"]:


### PR DESCRIPTION
The load balancing configuration parameter `partitioning` is only relevant for time-based load balancing. For balancing based on active simulations, it should not be necessary to set `partitioning`. This PR fixes that.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
