### PR TITLE
Fix model adaptivity infinite loop at resolution boundary

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -71,6 +71,13 @@ jobs:
           cd tests/unit
           python3 -m unittest test_micro_manager.py
 
+      - name: Run model adaptivity unit tests
+        working-directory: micro-manager
+        run: |
+          . .venv/bin/activate
+          cd tests/unit
+          python3 -m unittest test_model_adaptivity.py
+
       - name: Install Micro Manager and run tasking unit test
         working-directory: micro-manager
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.9.0
 
+- Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#251](https://github.com/precice/micro-manager/issues/251)
 - Refactored `DomainDecomposer` class and added a new variant of non-uniform decomposition [#243](https://github.com/precice/micro-manager/pull/243)
 - Fixed load balancing configuration `partitioning` parameter setting [#245](https://github.com/precice/micro-manager/pull/245)
 - Fixed comparison of zero values of type float32 and float64 in simulation deactivation [#244](https://github.com/precice/micro-manager/pull/244)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## latest
 
+- Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#251](https://github.com/precice/micro-manager/issues/251)
 - Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)
 
 ## v0.9.0
 
-- Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#251](https://github.com/precice/micro-manager/issues/251)
 - Refactored `DomainDecomposer` class and added a new variant of non-uniform decomposition [#243](https://github.com/precice/micro-manager/pull/243)
 - Fixed load balancing configuration `partitioning` parameter setting [#245](https://github.com/precice/micro-manager/pull/245)
 - Fixed comparison of zero values of type float32 and float64 in simulation deactivation [#244](https://github.com/precice/micro-manager/pull/244)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-- Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#251](https://github.com/precice/micro-manager/issues/251)
+- Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)
 - Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)
 
 ## v0.9.0

--- a/docs/model-adaptivity.md
+++ b/docs/model-adaptivity.md
@@ -169,3 +169,5 @@ The output is expected to be an integer and is interpreted in the following mann
 | 0     | No resolution change                                  |
 | -1    | Increase model fidelity by one (go back one in list)  |
 | 1     | Decrease model fidelity by one (go one ahead in list) |
+
+If the switching function requests a change beyond the available resolution range, the request is ignored and does not trigger another model-adaptivity iteration.

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -219,7 +219,7 @@ class ModelAdaptivity:
             sims[idx].destroy()
             sims[idx] = sim_new
 
-        return np.argwhere((current_res - target_res) != 0).tolist()
+        return np.flatnonzero(current_res != target_res).tolist()
 
     def update_states(
         self,
@@ -304,15 +304,10 @@ class ModelAdaptivity:
         size = len(sims)
         active_sims = self._create_active_mask(active_sim_ids, size)
         resolutions = self._gather_current_resolutions(sims, active_sims)
-        next_switch = np.zeros_like(resolutions)
-        for idx in range(active_sims.shape[0]):
-            if active_sims[idx] != 1:
-                continue
-            prev_out = prev_output[idx] if prev_output is not None else None
-            next_switch[idx] = self._switching_func(
-                resolutions[idx], locations[idx], t, inputs[idx], prev_out
-            )
-        local_num_changes = np.sum(next_switch != 0)
+        target_resolutions = self._gather_target_resolutions(
+            resolutions, locations, t, inputs, prev_output, active_sims
+        )
+        local_num_changes = np.sum(target_resolutions != resolutions)
         global_num_changes = self._comm.allreduce(local_num_changes, op=MPI.SUM)
         self._converged = global_num_changes == 0
 

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -65,6 +65,12 @@ class TestModelAdaptivity(TestCase):
         return controller
 
     def test_check_convergence_ignores_invalid_switch_at_finest_resolution(self):
+        """
+        Check that convergence is reached when the switching function requests a
+        finer model while the simulation is already using the finest available
+        resolution. Such an out-of-range request should be clamped to the
+        current resolution and treated as no model change.
+        """
         controller = self._make_controller(lambda resolution, *_: -1)
 
         controller.check_convergence(
@@ -78,6 +84,12 @@ class TestModelAdaptivity(TestCase):
         self.assertTrue(controller._converged)
 
     def test_check_convergence_ignores_invalid_switch_at_coarsest_resolution(self):
+        """
+        Check that convergence is reached when the switching function requests a
+        coarser model while the simulation is already using the coarsest
+        available resolution. This guards against endless iterations caused by
+        repeated out-of-range coarsening requests.
+        """
         controller = self._make_controller(lambda resolution, *_: 1)
 
         controller.check_convergence(
@@ -91,6 +103,12 @@ class TestModelAdaptivity(TestCase):
         self.assertTrue(controller._converged)
 
     def test_check_convergence_detects_valid_switch(self):
+        """
+        Check that convergence is not reported when the switching function
+        requests a valid change to another available model resolution. The
+        adaptivity loop must continue in this case so the requested switch can
+        be applied.
+        """
         controller = self._make_controller(lambda resolution, *_: 1)
 
         controller.check_convergence(
@@ -104,6 +122,14 @@ class TestModelAdaptivity(TestCase):
         self.assertFalse(controller._converged)
 
     def test_manager_loop_switches_once_then_exits_on_invalid_boundary_request(self):
+        """
+        Reproduce the regression scenario where a model is switched once and
+        the switching function then keeps requesting another change beyond the
+        available resolution range. The manager should solve with the new model,
+        avoid reusing output from the previous model, and stop once the repeated
+        boundary request is clamped to a no-op.
+        """
+
         def switching_function(resolution, location, t, input, prev_output):
             if prev_output is None:
                 return 0
@@ -152,6 +178,12 @@ class TestModelAdaptivity(TestCase):
         self.assertTrue(controller._converged)
 
     def test_manager_loop_exits_on_invalid_switch_request(self):
+        """
+        Check the manager loop for the simpler boundary case where the
+        simulation starts at the coarsest model and the switching function keeps
+        requesting an even coarser model. The loop should perform one solve,
+        recognize that no valid model change remains, and return normally.
+        """
         controller = self._make_controller(lambda resolution, *_: 1)
         manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
         manager._model_adaptivity_controller = controller

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -1,0 +1,185 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+import numpy as np
+from mpi4py import MPI
+
+from micro_manager.adaptivity.model_adaptivity import ModelAdaptivity
+from micro_manager.micro_manager import MicroManagerCoupling
+
+
+class DummyModelClass:
+    def __init__(self, name):
+        self.name = name
+
+
+class DummySimulation:
+    def __init__(self, name, global_id=0, late_init=False):
+        self.name = name
+        self._global_id = global_id
+        self._state = {"state": name}
+        self.attachments = {}
+        self.destroyed = False
+        self.late_init = late_init
+
+    def get_global_id(self):
+        return self._global_id
+
+    def get_state(self):
+        return self._state.copy()
+
+    def set_state(self, state):
+        self._state = state.copy()
+
+    def destroy(self):
+        self.destroyed = True
+
+
+class DummyModelManager:
+    def __init__(self):
+        self.created_instances = []
+
+    def get_instance(self, gid, target_class, *, late_init=False):
+        self.created_instances.append(
+            {
+                "gid": gid,
+                "target_class": target_class.name,
+                "late_init": late_init,
+            }
+        )
+        return DummySimulation(target_class.name, gid, late_init=late_init)
+
+
+class TestModelAdaptivity(TestCase):
+    def _make_controller(self, switching_func):
+        controller = ModelAdaptivity.__new__(ModelAdaptivity)
+        controller._switching_func = switching_func
+        controller._model_classes = [
+            DummyModelClass("fine"),
+            DummyModelClass("coarse"),
+        ]
+        controller._model_manager = DummyModelManager()
+        controller._comm = MPI.COMM_SELF
+        controller._logger = MagicMock()
+        controller._converged = False
+        return controller
+
+    def test_check_convergence_ignores_invalid_switch_at_finest_resolution(self):
+        controller = self._make_controller(lambda resolution, *_: -1)
+
+        controller.check_convergence(
+            np.array([[0.0, 0.0, 0.0]]),
+            1.0,
+            [{}],
+            None,
+            [DummySimulation("fine")],
+        )
+
+        self.assertTrue(controller._converged)
+
+    def test_check_convergence_ignores_invalid_switch_at_coarsest_resolution(self):
+        controller = self._make_controller(lambda resolution, *_: 1)
+
+        controller.check_convergence(
+            np.array([[0.0, 0.0, 0.0]]),
+            1.0,
+            [{}],
+            None,
+            [DummySimulation("coarse")],
+        )
+
+        self.assertTrue(controller._converged)
+
+    def test_check_convergence_detects_valid_switch(self):
+        controller = self._make_controller(lambda resolution, *_: 1)
+
+        controller.check_convergence(
+            np.array([[0.0, 0.0, 0.0]]),
+            1.0,
+            [{}],
+            None,
+            [DummySimulation("fine")],
+        )
+
+        self.assertFalse(controller._converged)
+
+    def test_manager_loop_switches_once_then_exits_on_invalid_boundary_request(self):
+        def switching_function(resolution, location, t, input, prev_output):
+            if prev_output is None:
+                return 0
+            return 1
+
+        controller = self._make_controller(switching_function)
+        manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
+        manager._model_adaptivity_controller = controller
+        manager._is_adaptivity_on = False
+        manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
+        manager._global_ids_of_local_sims = [0]
+        manager._t = 1.0
+        manager._micro_sims = [DummySimulation("fine", global_id=0)]
+
+        solve_calls = []
+
+        def solve_variant(micro_sims_input, dt, computed_outputs):
+            solve_calls.append(
+                {
+                    "sim_name": manager._micro_sims[0].name,
+                    "computed_outputs": computed_outputs.copy(),
+                }
+            )
+            return [{"result": len(solve_calls)}]
+
+        result = MicroManagerCoupling._solve_micro_simulations_with_model_adaptivity(
+            manager,
+            [{"input": 1.0}],
+            0.1,
+            solve_variant,
+        )
+
+        self.assertEqual(len(solve_calls), 2)
+        self.assertEqual(solve_calls[0]["sim_name"], "fine")
+        self.assertEqual(solve_calls[0]["computed_outputs"], {})
+
+        self.assertEqual(solve_calls[1]["sim_name"], "coarse")
+        self.assertEqual(
+            solve_calls[1]["computed_outputs"],
+            {},
+            "Output from the previous resolution must not be reused after a model switch.",
+        )
+
+        self.assertEqual(manager._micro_sims[0].name, "coarse")
+        self.assertEqual(result, [{"result": 2}])
+        self.assertTrue(controller._converged)
+
+    def test_manager_loop_exits_on_invalid_switch_request(self):
+        controller = self._make_controller(lambda resolution, *_: 1)
+        manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
+        manager._model_adaptivity_controller = controller
+        manager._is_adaptivity_on = False
+        manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
+        manager._global_ids_of_local_sims = [0]
+        manager._t = 1.0
+        manager._micro_sims = [DummySimulation("coarse")]
+
+        solve_calls = []
+
+        def solve_variant(micro_sims_input, dt, computed_outputs):
+            solve_calls.append(
+                {
+                    "micro_sims_input": micro_sims_input,
+                    "dt": dt,
+                    "computed_outputs": computed_outputs,
+                }
+            )
+            return [{"result": 1.0}]
+
+        result = MicroManagerCoupling._solve_micro_simulations_with_model_adaptivity(
+            manager,
+            [{"input": 1.0}],
+            0.1,
+            solve_variant,
+        )
+
+        self.assertEqual(len(solve_calls), 1)
+        self.assertEqual(solve_calls[0]["computed_outputs"], {})
+        self.assertEqual(result, [{"result": 1.0}])


### PR DESCRIPTION
<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->
Fixes #251

This pr prevents the model-adaptivity loop from running forever when a switching function repeatedly requests a resolution change beyond the available model range

The convergence check now compares the current resolution against the clamped target resolution, so invalid boundary requests are treated as no-op changes.

This also fixes `switch_models()` to return a flat list of switched local ids. Previously, `np.argwhere(...).tolist()` returned nested lists such as [[0]], which could cause switched simulations to be missed when filtering cached outputs.

 added regression tests covering:

 - invalid switch request at finest/coarsest boundary,
 - valid switch detection,
 - manager loop exiting on invalid boundary requests,
 - actual model switch followed by repeated invalid request,
 - no stale output reuse after a model switch.

Also documented the boundary behavior in the model-adaptivity docs and added the new regression test to CI.
Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
