### PR TITLE
Fix parameter inspection for dynamic MicroSimulation class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Micro Manager changelog
 
+## latest
+
+- Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
+
 ## v0.9.0
 
 - Refactored `DomainDecomposer` class and added a new variant of non-uniform decomposition [#243](https://github.com/precice/micro-manager/pull/243)

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -555,9 +555,19 @@ def __getattr__(self, name):
     # Only add initialize override if the wrapped class actually has it,
     # so that requires_initialize() returns True for those classes.
     if has_initialize:
-        class_body += """
-def initialize(self, *args, **kwargs):
-    return self._wrapped.initialize(*args, **kwargs)
+        argspec = inspect.getfullargspec(cls.initialize)
+        # build args
+        init_args = f"{', '.join(argspec.args)}"
+        params = f"{', '.join(argspec.args[1::])}"
+        if argspec.varargs is not None:
+            init_args += f", *args"
+            params += f", *args"
+        if argspec.varkw is not None:
+            init_args += f", **kwargs"
+            params += f", **kwargs"
+        class_body += f"""
+def initialize({init_args}):
+    return self._wrapped.initialize({params})
 """
 
     # Only add output override if the wrapped class actually has it,


### PR DESCRIPTION
As encountered in issue [#248](https://github.com/precice/micro-manager/issues/248), the initialize method
of the dynamically created `CompatibilityWrapper` class passes parameters as `*args, **kwargs`.
Subsequent inspection using `inspect.getfullargspec` does not recognize that positional parameters are required.
This results in no input data being provided to the initialize method.

The provided implementation remedies that by exposing positional parameters.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
