### PR TITLE
Fix the adaptivity data check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## latest
 
+- Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 - Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
 - Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)
 - Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)
-- Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 
 ## v0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
 - Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)
 - Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)
+- Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 
 ## v0.9.0
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -742,6 +742,20 @@ class MicroManagerCoupling(MicroManager):
                         self._micro_sims[i].initialize()
             else:  # Case where the initialize() method returns data
                 if self._is_adaptivity_on:
+                    # Check for missing data
+                    expected, provided = set(self._data_for_adaptivity.keys()), set(
+                        initial_micro_output.keys()
+                    )
+                    if missing := expected - provided:
+                        raise Exception(
+                            "The initialize() method needs to return data which is required for the adaptivity calculation. "
+                            f'Of the expected data {", ".join(expected)}, the following is missing: {", ".join(missing)}'
+                        )
+                    elif extra := provided - expected:
+                        self._logger.log_warning_rank_zero(
+                            f'The initialize() method of the Micro simulation returns extra initial data which isn\'t used by the adaptivity: {", ".join(extra)}'
+                        )
+
                     for name in initial_micro_output.keys():
                         initial_micro_data[name] = [0] * self._local_number_of_sims
                         # Save initial data from first micro simulation as we anyway have it
@@ -753,10 +767,6 @@ class MicroManagerCoupling(MicroManager):
                             self._data_for_adaptivity[name][
                                 first_id
                             ] = initial_micro_output[name]
-                        else:
-                            raise Exception(
-                                "The initialize() method needs to return data which is required for the adaptivity calculation."
-                            )
 
                     # Gather initial data from the rest of the micro simulations
                     if sim_requires_init_data:

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -743,7 +743,7 @@ class MicroManagerCoupling(MicroManager):
             else:  # Case where the initialize() method returns data
                 if self._is_adaptivity_on:
                     # Check for missing data
-                    expected, provided = set(self._data_for_adaptivity.keys()), set(
+                    expected, provided = set(self._adaptivity_micro_data_names), set(
                         initial_micro_output.keys()
                     )
                     if missing := expected - provided:
@@ -751,7 +751,7 @@ class MicroManagerCoupling(MicroManager):
                             "The initialize() method needs to return data which is required for the adaptivity calculation. "
                             f'Of the expected data {", ".join(expected)}, the following is missing: {", ".join(missing)}'
                         )
-                    elif extra := provided - expected:
+                    elif extra := provided - set(self._adaptivity_macro_data_names + self._adaptivity_micro_data_names):
                         self._logger.log_warning_rank_zero(
                             f'The initialize() method of the Micro simulation returns extra initial data which isn\'t used by the adaptivity: {", ".join(extra)}'
                         )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -751,7 +751,10 @@ class MicroManagerCoupling(MicroManager):
                             "The initialize() method needs to return data which is required for the adaptivity calculation. "
                             f'Of the expected data {", ".join(expected)}, the following is missing: {", ".join(missing)}'
                         )
-                    elif extra := provided - set(self._adaptivity_macro_data_names + self._adaptivity_micro_data_names):
+                    elif extra := provided - set(
+                        self._adaptivity_macro_data_names
+                        + self._adaptivity_micro_data_names
+                    ):
                         self._logger.log_warning_rank_zero(
                             f'The initialize() method of the Micro simulation returns extra initial data which isn\'t used by the adaptivity: {", ".join(extra)}'
                         )


### PR DESCRIPTION
This PR changes the error message when the initialize() function of the Micro Simulations doesn't exactly return the data expected for adaptivity.

It now only errors when data is missing.
Having extra data leads to a warning.

Closes #260

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
