### PR TITLE
Cleanup the import logic and improve errors

### DIFF
--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -610,7 +610,7 @@ def load_backend_class(path_to_micro_file: str) -> type:
             )
         else:
             raise RuntimeError(
-                f"Counldn't load dependency of python module '{path_to_micro_file}' containing the micro simulation: {ie}"
+                f"Counld not load a dependency of the python module '{path_to_micro_file}' containing the micro simulation: {ie}"
             )
     except Exception as e:
         raise RuntimeError(

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -606,7 +606,7 @@ def load_backend_class(path_to_micro_file: str) -> type:
     except ModuleNotFoundError as ie:
         if ie.name == path_to_micro_file:
             raise RuntimeError(
-                f"Couldn't load python module '{path_to_micro_file}' containing the micro simulation"
+                f"Could not load the python module '{path_to_micro_file}' containing the micro simulation"
             )
         else:
             raise RuntimeError(

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -600,39 +600,46 @@ def load_backend_class(path_to_micro_file: str) -> type:
         A class inheriting from MicroSimulationInterface.
     """
 
-    def try_load(name):
-        try:
-            return getattr(ipl.import_module(path_to_micro_file, name), name)
-        except ImportError as ie:
-            return None
-        except AttributeError as ae:
-            return None
+    # try to load the module
+    try:
+        mod = ipl.import_module(path_to_micro_file)
+    except ModuleNotFoundError as ie:
+        if ie.name == path_to_micro_file:
+            raise RuntimeError(
+                f"Couldn't load python module '{path_to_micro_file}' containing the micro simulation"
+            )
+        else:
+            raise RuntimeError(
+                f"Counldn't load dependency of python module '{path_to_micro_file}' containing the micro simulation: {ie}"
+            )
+    except Exception as e:
+        raise RuntimeError(
+            f"Error loading python module '{path_to_micro_file}' containing the micro simulation: {e}"
+        )
 
-    def check_cls(cls):
-        try:
-            inherits = issubclass(cls, MicroSimulationInterface)
-        except TypeError:
-            # pybind11 extension types may not support issubclass — wrap them
-            inherits = False
-
-        if not inherits:
-            cls = _wrap_non_interface_class(cls, path_to_micro_file)
-        return cls
-
+    # try to load the class
     CLS_NAME = "MicroSimulation"
-    # attempt to load with base name
-    result = try_load(CLS_NAME)
-    if result is not None:
-        return check_cls(result)
+    suffixes = [""] + [str(i) for i in range(10)]
+    micro_cls = None
+    for suffix in suffixes:
+        if cls := getattr(mod, f"{CLS_NAME}{suffix}", None):
+            micro_cls = cls
+    if micro_cls is None:
+        raise RuntimeError(
+            f"Loaded module '{path_to_micro_file}' does not contain a MicroSimulation class"
+        )
 
-    # attempt to load with appended indices
-    for i in range(10):
-        result = try_load(f"{CLS_NAME}{i}")
-        if result is not None:
-            return check_cls(result)
+    # check loaded class
+    try:
+        inherits = issubclass(micro_cls, MicroSimulationInterface)
+    except TypeError:
+        # pybind11 extension types may not support issubclass — wrap them
+        inherits = False
 
-    # failed to load any class
-    raise RuntimeError(f"Could not load micro simulation from {path_to_micro_file}")
+    if inherits:
+        return micro_cls
+    else:
+        return _wrap_non_interface_class(micro_cls, path_to_micro_file)
 
 
 def create_simulation_class(

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -624,6 +624,7 @@ def load_backend_class(path_to_micro_file: str) -> type:
     for suffix in suffixes:
         if cls := getattr(mod, f"{CLS_NAME}{suffix}", None):
             micro_cls = cls
+            break
     if micro_cls is None:
         raise RuntimeError(
             f"Loaded module '{path_to_micro_file}' does not contain a MicroSimulation class"


### PR DESCRIPTION
This PR cleans up the import logic and improves import error message.

- The [import_module](https://docs.python.org/3/library/importlib.html#importlib.import_module) function was used incorrectly. This is now fixed. ~~I am still unsure why it works when passing a file with a `.py` suffix as it expects a module.~~ The location gets converted to a python module path after reading the config. So all good.
- The import module step is now a separate step and errors are split into 3 groups:
  - The configured module cannot be found
  - The configured module has dependencies that cannot be found
  - Something else went wrong
- Then the class is detected with a potential suffix of 0-9
- Finally the class is wrapped

Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
