### PR TITLE
Fix OpenMPI cache miss in CI workflows

### DIFF
--- a/.github/workflows/build-openmpi-cache.yml
+++ b/.github/workflows/build-openmpi-cache.yml
@@ -1,0 +1,58 @@
+name: Build OpenMPI cache
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  build_cache:
+    name: Build and cache OpenMPI 5
+    runs-on: ubuntu-latest
+    container: precice/precice:nightly
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get -qq update
+          apt-get -qq install wget build-essential
+
+      - name: Load Cache OpenMPI 5
+        id: ompi-cache-load
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/openmpi
+          key: openmpi-5.0.5-${{ runner.os }}-build
+
+      - name: Build OpenMPI 5
+        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
+          tar -xzf openmpi-5.0.5.tar.gz
+          cd openmpi-5.0.5
+          mkdir -p ~/openmpi
+          ./configure --prefix=$HOME/openmpi
+          make -j$(nproc)
+          make install
+
+      - name: Save OpenMPI 5 to cache
+        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/openmpi
+          key: openmpi-5.0.5-${{ runner.os }}-build
+
+      - name: Verify OpenMPI installation
+        run: |
+          if [ ! -d ~/openmpi ]; then
+            echo "::error::OpenMPI cache directory not found"
+            exit 1
+          fi
+          cp -r ~/openmpi/* /usr/local/
+          ldconfig
+          mpiexec --version

--- a/.github/workflows/build-openmpi-cache.yml
+++ b/.github/workflows/build-openmpi-cache.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Build OpenMPI 5
         if: steps.ompi-cache-load.outputs.cache-hit != 'true'
         run: |
-          set -euo pipefail
           wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
           tar -xzf openmpi-5.0.5.tar.gz
           cd openmpi-5.0.5

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -1,17 +1,15 @@
 name: Check test coverage
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - "*"
+  workflow_run:
+    workflows: [Build OpenMPI cache]
+    types:
+      - completed
 
 jobs:
   coverage:
     name: Run test coverage check
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -19,40 +17,26 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: micro-manager
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install dependencies
         run: |
           apt-get -qq update
           apt-get -qq install python3-dev python3-venv git pkg-config
-          apt-get -qq install wget build-essential
 
       - name: Load Cache OpenMPI 5
         id: ompi-cache-load
         uses: actions/cache/restore@v5
         with:
           path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
-
-      - name: Build OpenMPI 5
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        run: |
-          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
-          tar -xzf openmpi-5.0.5.tar.gz
-          cd openmpi-5.0.5
-          mkdir -p ~/openmpi
-          ./configure --prefix=$HOME/openmpi
-          make -j$(nproc)
-          make install
-
-      - name: Save OpenMPI 5 to cache
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
+          key: openmpi-5.0.5-${{ runner.os }}-build
 
       - name: Configure OpenMPI
         run: |
+          if [ ! -d ~/openmpi ]; then
+            echo "::error::OpenMPI cache not found. The cache workflow may have failed."
+            exit 1
+          fi
           cp -r ~/openmpi/* /usr/local/
           ldconfig
           which mpiexec

--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -59,13 +59,34 @@ jobs:
         with:
           path: micro-manager
 
+      - name: Install OpenMPI build dependencies
+        run: |
+          apt-get -qq update
+          apt-get -qq install wget build-essential
+
       - name: Load Cache OpenMPI 5
         id: ompi-cache-load
         uses: actions/cache/restore@v5
         with:
           path: ~/openmpi
           key: openmpi-v5-${{ runner.os }}-build
-          # If this fails, cache gets built in run-unit-tests
+      - name: Build OpenMPI 5
+        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
+        run: |
+          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
+          tar -xzf openmpi-5.0.5.tar.gz
+          cd openmpi-5.0.5
+          mkdir -p ~/openmpi
+          ./configure --prefix=$HOME/openmpi
+          make -j$(nproc)
+          make install
+
+      - name: Save OpenMPI 5 to cache
+        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/openmpi
+          key: openmpi-v5-${{ runner.os }}-build
 
       - name: Configure OpenMPI
         run: |

--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -1,15 +1,13 @@
 name: Test adaptivity functionality in parallel
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - "*"
+  workflow_run:
+    workflows: [Build OpenMPI cache]
+    types:
+      - completed
 jobs:
   integration_tests:
     name: Integration tests
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -17,6 +15,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: micro-manager
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install sudo for MPI
         working-directory: micro-manager
@@ -51,6 +50,7 @@ jobs:
 
   unit_tests:
     name: Unit tests
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -58,38 +58,21 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: micro-manager
-
-      - name: Install OpenMPI build dependencies
-        run: |
-          apt-get -qq update
-          apt-get -qq install wget build-essential
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Load Cache OpenMPI 5
         id: ompi-cache-load
         uses: actions/cache/restore@v5
         with:
           path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
-      - name: Build OpenMPI 5
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        run: |
-          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
-          tar -xzf openmpi-5.0.5.tar.gz
-          cd openmpi-5.0.5
-          mkdir -p ~/openmpi
-          ./configure --prefix=$HOME/openmpi
-          make -j$(nproc)
-          make install
-
-      - name: Save OpenMPI 5 to cache
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
+          key: openmpi-5.0.5-${{ runner.os }}-build
 
       - name: Configure OpenMPI
         run: |
+          if [ ! -d ~/openmpi ]; then
+            echo "::error::OpenMPI cache not found. The cache workflow may have failed."
+            exit 1
+          fi
           cp -r ~/openmpi/* /usr/local/
           ldconfig
           which mpiexec

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,55 +1,38 @@
 name: Run unit tests for user-side functions
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - "*"
+  workflow_run:
+    workflows: [Build OpenMPI cache]
+    types:
+      - completed
 jobs:
   unit_tests:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
       - uses: actions/checkout@v6
         with:
           path: micro-manager
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install dependencies
         run: |
           apt-get -qq update
           apt-get -qq install python3-dev python3-venv git pkg-config
-          apt-get -qq install wget build-essential
 
       - name: Load Cache OpenMPI 5
         id: ompi-cache-load
         uses: actions/cache/restore@v5
         with:
           path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
-
-      - name: Build OpenMPI 5
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        run: |
-          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
-          tar -xzf openmpi-5.0.5.tar.gz
-          cd openmpi-5.0.5
-          mkdir -p ~/openmpi
-          ./configure --prefix=$HOME/openmpi
-          make -j$(nproc)
-          make install
-
-      - name: Save OpenMPI 5 to cache
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        id: ompi-cache-store
-        uses: actions/cache/save@v5
-        with:
-          path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
+          key: openmpi-5.0.5-${{ runner.os }}-build
 
       - name: Configure OpenMPI
         run: |
+          if [ ! -d ~/openmpi ]; then
+            echo "::error::OpenMPI cache not found. The cache workflow may have failed."
+            exit 1
+          fi
           cp -r ~/openmpi/* /usr/local/
           ldconfig
           which mpiexec

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
           make install
 
       - name: Save OpenMPI 5 to cache
-        if: steps.ompi-cache.outputs.cache-hit != 'true'
+        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
         id: ompi-cache-store
         uses: actions/cache/save@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed CI OpenMPI cache miss by centralizing the MPI build into a dedicated workflow [#263](https://github.com/precice/micro-manager/pull/263)
 - Fixed naming of variables tracking active simulations in the `MicroManager` [#273](https://github.com/precice/micro-manager/pull/273)
 - Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)
 - Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)


### PR DESCRIPTION
<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->
This pr fixes CI failures on branch or pr runs by building OpenMPI when the cache is missing, instead of assuming ~/openmpi always exists

closes #259 

Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
