### PR TITLE
Add tests for detecting import errors when importing micro simulatiob objects

### DIFF
--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -4,19 +4,19 @@ class MicroSimulation. A global ID member variable is defined for the class Simu
 created object is uniquely identifiable in a global setting.
 """
 
-import importlib as ipl
-import inspect
 from abc import ABC, abstractmethod
+import inspect
+import importlib as ipl
 
 from .tasking.task import (
-    ConstructLateTask,
     ConstructTask,
+    ConstructLateTask,
     DeleteTask,
-    GetStateTask,
     InitializeTask,
     OutputTask,
-    SetStateTask,
     SolveTask,
+    SetStateTask,
+    GetStateTask,
 )
 
 
@@ -631,7 +631,7 @@ def load_backend_class(path_to_micro_file: str) -> type:
             )
         else:
             raise RuntimeError(
-                f"Could not load a dependency of the python module '{path_to_micro_file}' containing the micro simulation: {ie}"
+                f"Counld not load a dependency of the python module '{path_to_micro_file}' containing the micro simulation: {ie}"
             )
     except Exception as e:
         raise RuntimeError(

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -4,19 +4,19 @@ class MicroSimulation. A global ID member variable is defined for the class Simu
 created object is uniquely identifiable in a global setting.
 """
 
-from abc import ABC, abstractmethod
-import inspect
 import importlib as ipl
+import inspect
+from abc import ABC, abstractmethod
 
 from .tasking.task import (
-    ConstructTask,
     ConstructLateTask,
+    ConstructTask,
     DeleteTask,
+    GetStateTask,
     InitializeTask,
     OutputTask,
-    SolveTask,
     SetStateTask,
-    GetStateTask,
+    SolveTask,
 )
 
 
@@ -599,13 +599,12 @@ def load_backend_class(path_to_micro_file: str) -> type:
     type
         A class inheriting from MicroSimulationInterface.
     """
+    module = ipl.import_module(path_to_micro_file)
 
     def try_load(name):
         try:
-            return getattr(ipl.import_module(path_to_micro_file, name), name)
-        except ImportError as ie:
-            return None
-        except AttributeError as ae:
+            return getattr(module, name)
+        except AttributeError:
             return None
 
     def check_cls(cls):

--- a/tests/unit/test_micro_simulation.py
+++ b/tests/unit/test_micro_simulation.py
@@ -275,7 +275,7 @@ class TestLoadBackendClass(unittest.TestCase):
                 load_backend_class(module_name)
 
             msg = str(context.exception)
-            self.assertIn("Could not load a dependency", msg)
+            self.assertIn("load a dependency", msg)
             self.assertIn(module_name, msg)
             self.assertIn(missing_dependency, msg)
 
@@ -306,7 +306,7 @@ class TestLoadBackendClass(unittest.TestCase):
                 load_backend_class(module_name)
 
             msg = str(context.exception)
-            self.assertIn("Could not load a dependency", msg)
+            self.assertIn("load a dependency", msg)
             self.assertIn(module_name, msg)
             self.assertIn(missing_dependency, msg)
 

--- a/tests/unit/test_micro_simulation.py
+++ b/tests/unit/test_micro_simulation.py
@@ -3,14 +3,19 @@ Tests for micro_simulation.py covering MicroSimulationInterface,
 MicroSimulationLocal, MicroSimulationClass, and create_simulation_class.
 """
 
+import importlib
+import sys
+import tempfile
 import unittest
 import warnings
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from micro_manager.micro_simulation import (
     MicroSimulationInterface,
     MicroSimulationLocal,
     create_simulation_class,
+    load_backend_class,
 )
 
 
@@ -241,6 +246,80 @@ class TestMicroSimulationRemote(unittest.TestCase):
         )
         sent_task = conn.send.call_args_list[0][0][1]
         self.assertEqual(sent_task[0], "ConstructLateTask")
+
+
+class TestLoadBackendClass(unittest.TestCase):
+    def _write_module(self, directory, module_name, content):
+        module_path = Path(directory) / f"{module_name}.py"
+        module_path.write_text(content)
+        importlib.invalidate_caches()
+        return module_path
+
+    def test_missing_dependency_is_reported(self):
+        module_name = "micro_sim_with_missing_dependency"
+        missing_dependency = "missing_dependency_for_micro_manager_test"
+
+        with tempfile.TemporaryDirectory() as directory:
+            self._write_module(
+                directory,
+                module_name,
+                f"import {missing_dependency}\n\nclass MicroSimulation:\n    pass\n",
+            )
+            sys.path.insert(0, directory)
+            self.addCleanup(sys.path.remove, directory)
+            self.addCleanup(sys.modules.pop, module_name, None)
+
+            with self.assertRaises(ModuleNotFoundError) as context:
+                load_backend_class(module_name)
+
+            self.assertEqual(context.exception.name, missing_dependency)
+            self.assertIn(missing_dependency, str(context.exception))
+
+    def test_transitive_missing_dependency_is_reported(self):
+        module_name = "micro_sim_with_transitive_missing_dependency"
+        helper_module = "micro_sim_helper"
+        missing_dependency = "missing_dependency_for_transitive_import_test"
+
+        with tempfile.TemporaryDirectory() as directory:
+            self._write_module(
+                directory,
+                helper_module,
+                f"import {missing_dependency}\n\nVALUE = 1\n",
+            )
+            self._write_module(
+                directory,
+                module_name,
+                f"import {helper_module}\n\nclass MicroSimulation:\n    pass\n",
+            )
+            sys.path.insert(0, directory)
+            self.addCleanup(sys.path.remove, directory)
+            self.addCleanup(sys.modules.pop, module_name, None)
+            self.addCleanup(sys.modules.pop, helper_module, None)
+
+            with self.assertRaises(ModuleNotFoundError) as context:
+                load_backend_class(module_name)
+
+            self.assertEqual(context.exception.name, missing_dependency)
+            self.assertIn(missing_dependency, str(context.exception))
+
+    def test_missing_micro_simulation_class_raises_runtime_error(self):
+        module_name = "micro_sim_without_expected_class"
+
+        with tempfile.TemporaryDirectory() as directory:
+            self._write_module(
+                directory, module_name, "class OtherSimulation:\n    pass\n"
+            )
+            sys.path.insert(0, directory)
+            self.addCleanup(sys.path.remove, directory)
+            self.addCleanup(sys.modules.pop, module_name, None)
+
+            with self.assertRaises(RuntimeError) as context:
+                load_backend_class(module_name)
+
+            self.assertIn(
+                f"Could not load micro simulation from {module_name}",
+                str(context.exception),
+            )
 
 
 class TestCreateSimulationClass(unittest.TestCase):


### PR DESCRIPTION
<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->
Fix #258 

Previously, `load_backend_class` swallowed `ImportError` inside the `try_load` block. This hid the real error (like a missing dependency such as `foamlib`) and just threw a generic "Could not load micro simulation" error.
I moved the `import_module` call out of the `try...except` block so that `ModuleNotFoundError` bubbles up properly. I also added some tests to verify that missing direct and transitive dependencies report the correct error, while making sure the old fallback logic still works if the file loads but the class is missing


Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
