### PR TITLE
Model adaptivity configuration docs: Clarify micro_file_names

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,7 @@ To turn on model adaptivity, set `"model_adaptivity": true` in `simulation_param
 
 | Parameter            | Description                                                                                                                                                                                                                                        |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `micro_file_names`   | List of paths to the files containing the Python importable micro simulation classes. If the files are not in the working directory, give the relative path from the directory where the Micro Manager is executed. Requires a minimum of 2 files. |
+| `micro_file_names`   | List of paths to the files containing the Python importable micro simulation classes, in order of decreasing model fidelity. If the files are not in the working directory, give the relative path from the directory where the Micro Manager is executed. Requires a minimum of 2 files. |
 | `switching_function` | Path to the file containing the Python importable switching function. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.                                                  |
 | `micro_stateless`    | List of boolean values, whether the respective micro simulation model is stateless and can use model instancing.                                                                                                                                   |
 


### PR DESCRIPTION
Looking first at the `micro_file_names` configuration option, I was confused on whether the order plays any role, since this is a list (not a dictionary). I understand that this is always supposed to be in the order of decreasing model fidelity, considering the return values of the `switching_function` at the bottom of https://precice.org/tooling-micro-manager-model-adaptivity.html

Also: is `fidelity` meant as a synonym for `resolution` here? Because the `switching_function` seems to take a `resolution` argument.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] If necessary, I made changes to the documentation and/or added new content.
