### PR TITLE
Fix Model Adaptivity active simulation mask generation for edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-- Fixed model adaptivity active simulation mask generation for 0 local simulations [#266](https://github.com/precice/micro-manager/pull/266)
+- Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)
 - Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 - Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
 - Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed model adaptivity active simulation mask generation for 0 local simulations [#266](https://github.com/precice/micro-manager/pull/266)
 - Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 - Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
 - Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -453,6 +453,7 @@ class ModelAdaptivity:
             active_sims = np.ones(size)
         else:
             mask = np.zeros(size)
-            mask[active_sim_ids] = 1
+            if len(active_sim_ids) > 0:
+                mask[active_sim_ids] = 1
             active_sims = mask
         return active_sims.astype(bool)


### PR DESCRIPTION
When a MM rank has 0 local simulations, the previous version failed to generate an active mask, leading to a crash.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
