### PR TITLE
Export model resolution when using Model Adaptivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)
 - Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)
 - Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 - Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -566,6 +566,7 @@ class Config:
             )
 
         if self._m_adap:
+            self._write_data_names.append("model_resolution")
             self._m_adap_micro_file_names = [
                 name.replace("/", ".").replace("\\", ".").replace(".py", "")
                 for name in self._data["simulation_params"][

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -1162,6 +1162,12 @@ class MicroManagerCoupling(MicroManager):
             )
 
         self._model_adaptivity_controller.finalise_solve()
+
+        for lid, sim in enumerate(self._micro_sims):
+            res = -1
+            if sim is not None:
+                res = self._model_adaptivity_controller.get_sim_class_resolution(sim)
+            output[lid]["model_resolution"] = res
         return output
 
     def _get_solve_variant(self) -> Callable[[list, float], list]:

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -174,7 +174,7 @@ class TestModelAdaptivity(TestCase):
         )
 
         self.assertEqual(manager._micro_sims[0].name, "coarse")
-        self.assertEqual(result, [{"result": 2}])
+        self.assertEqual(result, [{"result": 2, "model_resolution": 1}])
         self.assertTrue(controller._converged)
 
     def test_manager_loop_exits_on_invalid_switch_request(self):
@@ -214,4 +214,4 @@ class TestModelAdaptivity(TestCase):
 
         self.assertEqual(len(solve_calls), 1)
         self.assertEqual(solve_calls[0]["computed_outputs"], {})
-        self.assertEqual(result, [{"result": 1.0}])
+        self.assertEqual(result, [{"result": 1.0, "model_resolution": 1}])


### PR DESCRIPTION
Export `model_resolution` when Model Adaptivity is enabled.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
