### PR TITLE
Improve Load Balancing performace of inactive simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)
 - Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)
 - Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)
 - Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -1112,11 +1112,17 @@ class MicroManagerCoupling(MicroManager):
 
         # Resolve micro sim output data for inactive simulations
         for inactive_lid in inactive_sim_lids:
+            self.load_balancing.pre_sim_solve(
+                self._global_ids_of_local_sims[inactive_lid]
+            )
             micro_sims_output[inactive_lid]["Active-State"] = 0
             gid = self._global_ids_of_local_sims[inactive_lid]
             micro_sims_output[inactive_lid][
                 "Active-Steps"
             ] = self._micro_sims_active_steps[gid]
+            self.load_balancing.post_sim_solve(
+                self._global_ids_of_local_sims[inactive_lid]
+            )
 
         # Collect micro sim output for adaptivity calculation
         for i in range(self._local_number_of_sims):


### PR DESCRIPTION
Added a small time measurement for inactive simulations.
Previously, all inactive simulations were assigned to the same rank.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
