### PR TITLE
Minor fixes in MicroManager regarding Adaptivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed naming of variables tracking active simulations in the `MicroManager` [#273](https://github.com/precice/micro-manager/pull/273)
 - Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)
 - Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)
 - Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -212,8 +212,11 @@ class MicroManagerCoupling(MicroManager):
                     # Write a checkpoint if a simulation is just activated.
                     # This checkpoint will be asynchronous to the checkpoints written at the start of the time window.
                     if self._is_model_adaptivity_on:
+                        active_sim_lids = (
+                            self._adaptivity_controller.get_active_sim_local_ids()
+                        )
                         self._model_adaptivity_controller.update_states(
-                            self._micro_sims, active_sim_gids
+                            self._micro_sims, active_sim_lids
                         )
                     for i in range(self._local_number_of_sims):
                         if sim_states_cp[i] is None and self._micro_sims[i]:
@@ -244,13 +247,13 @@ class MicroManagerCoupling(MicroManager):
             # Write a checkpoint
             if self._participant.requires_writing_checkpoint() or performed_lb:
                 if self._is_model_adaptivity_on:
-                    active_sim_gids = None
+                    active_sim_lids = None
                     if self._is_adaptivity_on:
-                        active_sim_gids = (
+                        active_sim_lids = (
                             self._adaptivity_controller.get_active_sim_local_ids()
                         )
                     self._model_adaptivity_controller.update_states(
-                        self._micro_sims, active_sim_gids
+                        self._micro_sims, active_sim_lids
                     )
                 for i in range(self._local_number_of_sims):
                     sim_states_cp[i] = (
@@ -308,13 +311,13 @@ class MicroManagerCoupling(MicroManager):
                         self.state_setter(self._micro_sims[i], sim_states_cp[i])
 
                 if self._is_model_adaptivity_on:
-                    active_sim_gids = None
+                    active_sim_lids = None
                     if self._is_adaptivity_on:
-                        active_sim_gids = (
+                        active_sim_lids = (
                             self._adaptivity_controller.get_active_sim_local_ids()
                         )
                     self._model_adaptivity_controller.write_back_states(
-                        self._micro_sims, active_sim_gids
+                        self._micro_sims, active_sim_lids
                     )
 
                 first_iteration = False


### PR DESCRIPTION
Some variable in the `MicroManager` were named incorrectly.
Switched `gid` to `lid`.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
