### PR TITLE
Fix load balancing case when there is a mismatch in send and receive problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed load balancing for case where number of sims to send and recv are not the same [#276](https://github.com/precice/micro-manager/pull/276)
 - Fixed CI OpenMPI cache miss by centralizing the MPI build into a dedicated workflow [#263](https://github.com/precice/micro-manager/pull/263)
 - Fixed naming of variables tracking active simulations in the `MicroManager` [#273](https://github.com/precice/micro-manager/pull/273)
 - Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -674,10 +674,8 @@ class ActiveBalancer(LoadBalancer):
             ) = self._get_active_exchange_counts()
 
             if (
-                n_global_send_sims == 0
-                and n_global_recv_sims == 0
-                and not self._bypass_skip
-            ):
+                n_global_send_sims == 0 or n_global_recv_sims == 0
+            ) and not self._bypass_skip:
                 self._log.log_warning_rank_zero(
                     "It appears that the micro simulations are already fairly balanced. No load balancing will be done. Try changing the threshold value to induce load balancing."
                 )


### PR DESCRIPTION
When a non-zero threshold value is used, the number of micro simulations to send and receive may differ. In such cases, the load balancing should simply check whether either the number of simulations to send or receive is zero, and if so, not perform balancing. The condition to check this was incorrect, leading to a failure. This PR fixes that.

<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
