### PR TITLE
Provide global macro mesh coordinates for model adaptivity

### DIFF
--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -484,6 +484,7 @@ class MicroManagerCoupling(MicroManager):
             ) = domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
 
             # Global coordinates that are necessary for model adaptivity
+            # TODO: Avoid the allgather by smartly selecting the relevant coordinates in model adaptivity
             self._global_mesh_vertex_coords = self._comm.allgather(
                 self._mesh_vertex_coords
             )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -483,6 +483,15 @@ class MicroManagerCoupling(MicroManager):
                 self._mesh_vertex_ids,
             ) = domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
 
+            # Global coordinates that are necessary for model adaptivity
+            self._global_mesh_vertex_coords = self._comm.allgather(
+                self._mesh_vertex_coords
+            )
+
+        if not self._is_parallel or self._is_load_balancing:
+            # For a serial run or when load balancing, the local mesh vertex coordinates are the global mesh vertex coordinates
+            self._global_mesh_vertex_coords = self._mesh_vertex_coords
+
         if self._mesh_vertex_coords.size == 0:
             if self._is_parallel:
                 self._is_rank_empty = True
@@ -1146,7 +1155,7 @@ class MicroManagerCoupling(MicroManager):
 
         while self._model_adaptivity_controller.should_iterate():
             switched_lids = self._model_adaptivity_controller.switch_models(
-                self._mesh_vertex_coords[self._global_ids_of_local_sims],
+                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
                 self._t,
                 micro_sims_input,
                 output,
@@ -1162,7 +1171,7 @@ class MicroManagerCoupling(MicroManager):
                     computed_outputs[gid] = out
             output = solve_variant(micro_sims_input, dt, computed_outputs)
             self._model_adaptivity_controller.check_convergence(
-                self._mesh_vertex_coords[self._global_ids_of_local_sims],
+                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
                 self._t,
                 micro_sims_input,
                 output,


### PR DESCRIPTION
Model adaptivity needs to sample macro mesh coordinates using global IDs. To enable this, as it is currently done, this PR gathers global macro mesh coordinates on every rank.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [ ] ~~I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.~~
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
