### PR TITLE
Release v0.10.0

### DIFF
--- a/.github/workflows/build-openmpi-cache.yml
+++ b/.github/workflows/build-openmpi-cache.yml
@@ -1,0 +1,57 @@
+name: Build OpenMPI cache
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  build_cache:
+    name: Build and cache OpenMPI 5
+    runs-on: ubuntu-latest
+    container: precice/precice:nightly
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get -qq update
+          apt-get -qq install wget build-essential
+
+      - name: Load Cache OpenMPI 5
+        id: ompi-cache-load
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/openmpi
+          key: openmpi-5.0.5-${{ runner.os }}-build
+
+      - name: Build OpenMPI 5
+        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
+        run: |
+          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
+          tar -xzf openmpi-5.0.5.tar.gz
+          cd openmpi-5.0.5
+          mkdir -p ~/openmpi
+          ./configure --prefix=$HOME/openmpi
+          make -j$(nproc)
+          make install
+
+      - name: Save OpenMPI 5 to cache
+        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ~/openmpi
+          key: openmpi-5.0.5-${{ runner.os }}-build
+
+      - name: Verify OpenMPI installation
+        run: |
+          if [ ! -d ~/openmpi ]; then
+            echo "::error::OpenMPI cache directory not found"
+            exit 1
+          fi
+          cp -r ~/openmpi/* /usr/local/
+          ldconfig
+          mpiexec --version

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -1,17 +1,15 @@
 name: Check test coverage
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - "*"
+  workflow_run:
+    workflows: [Build OpenMPI cache]
+    types:
+      - completed
 
 jobs:
   coverage:
     name: Run test coverage check
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -19,40 +17,26 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: micro-manager
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install dependencies
         run: |
           apt-get -qq update
           apt-get -qq install python3-dev python3-venv git pkg-config
-          apt-get -qq install wget build-essential
 
       - name: Load Cache OpenMPI 5
         id: ompi-cache-load
         uses: actions/cache/restore@v5
         with:
           path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
-
-      - name: Build OpenMPI 5
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        run: |
-          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
-          tar -xzf openmpi-5.0.5.tar.gz
-          cd openmpi-5.0.5
-          mkdir -p ~/openmpi
-          ./configure --prefix=$HOME/openmpi
-          make -j$(nproc)
-          make install
-
-      - name: Save OpenMPI 5 to cache
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
+          key: openmpi-5.0.5-${{ runner.os }}-build
 
       - name: Configure OpenMPI
         run: |
+          if [ ! -d ~/openmpi ]; then
+            echo "::error::OpenMPI cache not found. The cache workflow may have failed."
+            exit 1
+          fi
           cp -r ~/openmpi/* /usr/local/
           ldconfig
           which mpiexec

--- a/.github/workflows/run-adaptivity-tests-parallel.yml
+++ b/.github/workflows/run-adaptivity-tests-parallel.yml
@@ -1,15 +1,13 @@
 name: Test adaptivity functionality in parallel
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - "*"
+  workflow_run:
+    workflows: [Build OpenMPI cache]
+    types:
+      - completed
 jobs:
   integration_tests:
     name: Integration tests
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -17,6 +15,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: micro-manager
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install sudo for MPI
         working-directory: micro-manager
@@ -51,6 +50,7 @@ jobs:
 
   unit_tests:
     name: Unit tests
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
@@ -58,17 +58,21 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: micro-manager
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Load Cache OpenMPI 5
         id: ompi-cache-load
         uses: actions/cache/restore@v5
         with:
           path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
-          # If this fails, cache gets built in run-unit-tests
+          key: openmpi-5.0.5-${{ runner.os }}-build
 
       - name: Configure OpenMPI
         run: |
+          if [ ! -d ~/openmpi ]; then
+            echo "::error::OpenMPI cache not found. The cache workflow may have failed."
+            exit 1
+          fi
           cp -r ~/openmpi/* /usr/local/
           ldconfig
           which mpiexec

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,55 +1,38 @@
 name: Run unit tests for user-side functions
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - "*"
+  workflow_run:
+    workflows: [Build OpenMPI cache]
+    types:
+      - completed
 jobs:
   unit_tests:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     container: precice/precice:nightly
     steps:
       - uses: actions/checkout@v6
         with:
           path: micro-manager
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install dependencies
         run: |
           apt-get -qq update
           apt-get -qq install python3-dev python3-venv git pkg-config
-          apt-get -qq install wget build-essential
 
       - name: Load Cache OpenMPI 5
         id: ompi-cache-load
         uses: actions/cache/restore@v5
         with:
           path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
-
-      - name: Build OpenMPI 5
-        if: steps.ompi-cache-load.outputs.cache-hit != 'true'
-        run: |
-          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.5.tar.gz
-          tar -xzf openmpi-5.0.5.tar.gz
-          cd openmpi-5.0.5
-          mkdir -p ~/openmpi
-          ./configure --prefix=$HOME/openmpi
-          make -j$(nproc)
-          make install
-
-      - name: Save OpenMPI 5 to cache
-        if: steps.ompi-cache.outputs.cache-hit != 'true'
-        id: ompi-cache-store
-        uses: actions/cache/save@v5
-        with:
-          path: ~/openmpi
-          key: openmpi-v5-${{ runner.os }}-build
+          key: openmpi-5.0.5-${{ runner.os }}-build
 
       - name: Configure OpenMPI
         run: |
+          if [ ! -d ~/openmpi ]; then
+            echo "::error::OpenMPI cache not found. The cache workflow may have failed."
+            exit 1
+          fi
           cp -r ~/openmpi/* /usr/local/
           ldconfig
           which mpiexec

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -71,6 +71,13 @@ jobs:
           cd tests/unit
           python3 -m unittest test_micro_manager.py
 
+      - name: Run model adaptivity unit tests
+        working-directory: micro-manager
+        run: |
+          . .venv/bin/activate
+          cd tests/unit
+          python3 -m unittest test_model_adaptivity.py
+
       - name: Install Micro Manager and run tasking unit test
         working-directory: micro-manager
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Micro Manager changelog
 
+## latest
+
+- Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)
+
 ## v0.9.0
 
 - Refactored `DomainDecomposer` class and added a new variant of non-uniform decomposition [#243](https://github.com/precice/micro-manager/pull/243)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed naming of variables tracking active simulations in the `MicroManager` [#273](https://github.com/precice/micro-manager/pull/273)
 - Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)
 - Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)
 - Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
 - Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)
 - Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)
 - Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)
 
 ## v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Micro Manager changelog
 
-## latest
+## v0.10.0
 
 - Fixed load balancing for case where number of sims to send and recv are not the same [#276](https://github.com/precice/micro-manager/pull/276)
 - Fixed CI OpenMPI cache miss by centralizing the MPI build into a dedicated workflow [#263](https://github.com/precice/micro-manager/pull/263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)
 - Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 - Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
 - Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed CI OpenMPI cache miss by centralizing the MPI build into a dedicated workflow [#263](https://github.com/precice/micro-manager/pull/263)
 - Fixed naming of variables tracking active simulations in the `MicroManager` [#273](https://github.com/precice/micro-manager/pull/273)
 - Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)
 - Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)
 - Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)
 - Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 - Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed load balancing for case where number of sims to send and recv are not the same [#276](https://github.com/precice/micro-manager/pull/276)
 - Fixed CI OpenMPI cache miss by centralizing the MPI build into a dedicated workflow [#263](https://github.com/precice/micro-manager/pull/263)
 - Fixed naming of variables tracking active simulations in the `MicroManager` [#273](https://github.com/precice/micro-manager/pull/273)
 - Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)
 - Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)
 - Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)
 - Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
 - Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
 - Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)
 - Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,9 +7,27 @@ summary: Provide a JSON file to configure the Micro Manager.
 
 {% note %} In the preCICE XML configuration the Micro Manager is a participant with the name `Micro-Manager`. {% endnote %}
 
-The Micro Manager is configured with a JSON file. Several parameters can be set.
+The Micro Manager is configured with a [JSON](https://en.wikipedia.org/wiki/JSON#Syntax) file. Several parameters can be set, in different sections. For example:
+
+```json
+{
+    "micro_file_name": "python/micro.py",
+    "coupling_params": {
+        "precice_config_file_name": "precice-config.xml",
+        "macro_mesh_name": "Macro-Mesh",
+        "read_data_names": ["Macro-Scalar", "Macro-Vector"],
+        "write_data_names": ["Micro-Scalar", "Micro-Vector"]
+    },
+    "simulation_params": {
+        "micro_dt": 1.0,
+        "macro_domain_bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+    }
+}
+```
 
 ## Micro Manager Configuration
+
+These parameters are in the outer section.
 
 | Parameter                  | Description                                                                                                                                                                                           | Default       |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
@@ -25,6 +43,8 @@ Apart from the base settings, there are three main sections in the configuration
 
 ## Coupling Parameters
 
+These parameters are in the section `coupling_params`.
+
 | Parameter                  | Description                                                                    |
 |----------------------------|--------------------------------------------------------------------------------|
 | `precice_config_file_name` | Path to the preCICE XML configuration file from the current working directory. |
@@ -33,6 +53,8 @@ Apart from the base settings, there are three main sections in the configuration
 | `write_data_names`         | List with the names of the data to be written to preCICE.                      |
 
 ## Simulation Parameters
+
+These parameters are in the section `simulation_params`.
 
 | Parameter | Description | Default |
 | --- | --- | --- |
@@ -49,6 +71,8 @@ The total number of partitions ranks in the `decomposition` list should be the s
 Non-uniform domain decomposition is based on a geometric progression.
 
 ## Diagnostics
+
+These parameters are in the section `diagnostics`.
 
 | Parameter              | Description                                                                                                                                | Default |
 |------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,7 +185,7 @@ The Micro Manager uses the output functionality of preCICE, hence these data set
 ## Load balancing
 
 Load balancing can be activated by setting `load_balancing` to true.
-It balances based on either the elapsed time required to solve the prior iteration `type="time""` or the number of active simulations `type=active`.
+It balances based on either the elapsed time required to solve the prior iteration `type="time"` or the number of active simulations `type="active"`.
 One Initial load balancing step is performed, prior to any computation (assuming equal workload for time based load balancing or the current active counts for `active` load balancing.).
 Subsequently, in the following iteration another load balancing step is performed based. (This is mainly for the time based balancing to use the just acquired timings.)
 Afterwards balancing is performed `every_n_time_windows`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,7 @@ To turn on model adaptivity, set `"model_adaptivity": true` in `simulation_param
 
 | Parameter            | Description                                                                                                                                                                                                                                        |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `micro_file_names`   | List of paths to the files containing the Python importable micro simulation classes. If the files are not in the working directory, give the relative path from the directory where the Micro Manager is executed. Requires a minimum of 2 files. |
+| `micro_file_names`   | List of paths to the files containing the Python importable micro simulation classes, in order of decreasing model fidelity. If the files are not in the working directory, give the relative path from the directory where the Micro Manager is executed. Requires a minimum of 2 files. |
 | `switching_function` | Path to the file containing the Python importable switching function. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.                                                  |
 | `micro_stateless`    | List of boolean values, whether the respective micro simulation model is stateless and can use model instancing.                                                                                                                                   |
 

--- a/docs/micro-simulation-convert-to-library.md
+++ b/docs/micro-simulation-convert-to-library.md
@@ -69,6 +69,21 @@ class MicroSimulation: # Name is fixed
         It will be called with frequency set by configuration option `simulation_params: micro_output_n`
         This function is *optional*.
         """
+
+    def set_global_id(self, sim_id):
+        """
+        Reset the global ID of the micro simulation.
+
+        Parameters
+        ----------
+        sim_id : int
+            New global ID of the simulation instance.
+        """
+
+    def get_global_id(self):
+        """
+        Return the global ID of the simulation.
+        """
 ```
 
 A dummy code of a sample MicroSimulation class can be found in the [examples/python-dummy/micro_dummy.py](https://github.com/precice/micro-manager/blob/develop/examples/python-dummy/micro_dummy.py) directory.

--- a/docs/model-adaptivity.md
+++ b/docs/model-adaptivity.md
@@ -169,3 +169,5 @@ The output is expected to be an integer and is interpreted in the following mann
 | 0     | No resolution change                                  |
 | -1    | Increase model fidelity by one (go back one in list)  |
 | 1     | Decrease model fidelity by one (go one ahead in list) |
+
+If the switching function requests a change beyond the available resolution range, the request is ignored and does not trigger another model-adaptivity iteration.

--- a/examples/cpp-dummy/micro_cpp_dummy.cpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.cpp
@@ -65,6 +65,11 @@ int MicroSimulation::get_global_id() const
     return _sim_id;
 }
 
+void MicroSimulation::set_global_id(int sim_id)
+{
+    _sim_id = sim_id;
+}
+
 PYBIND11_MODULE(micro_dummy, m) {
     // optional docstring
     m.doc() = "pybind11 micro dummy plugin";
@@ -75,6 +80,7 @@ PYBIND11_MODULE(micro_dummy, m) {
         .def("get_state", &MicroSimulation::get_state)
         .def("set_state", &MicroSimulation::set_state)
         .def("get_global_id", &MicroSimulation::get_global_id)
+        .def("set_global_id", &MicroSimulation::set_global_id)
         // Pickling support does not work currently, as there is no way to pass the simulation ID to the new instance ms.
         .def(py::pickle( // https://pybind11.readthedocs.io/en/latest/advanced/classes.html#pickling-support
             [](const MicroSimulation &ms) { // __getstate__

--- a/examples/cpp-dummy/micro_cpp_dummy.hpp
+++ b/examples/cpp-dummy/micro_cpp_dummy.hpp
@@ -21,6 +21,7 @@ public:
     void set_state(py::list state);
     py::list get_state() const;
     int get_global_id() const;
+    void set_global_id(int sim_id);
 
 private:
     int _sim_id;

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -453,6 +453,7 @@ class ModelAdaptivity:
             active_sims = np.ones(size)
         else:
             mask = np.zeros(size)
-            mask[active_sim_ids] = 1
+            if len(active_sim_ids) > 0:
+                mask[active_sim_ids] = 1
             active_sims = mask
         return active_sims.astype(bool)

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -219,7 +219,7 @@ class ModelAdaptivity:
             sims[idx].destroy()
             sims[idx] = sim_new
 
-        return np.argwhere((current_res - target_res) != 0).tolist()
+        return np.flatnonzero(current_res != target_res).tolist()
 
     def update_states(
         self,
@@ -304,15 +304,10 @@ class ModelAdaptivity:
         size = len(sims)
         active_sims = self._create_active_mask(active_sim_ids, size)
         resolutions = self._gather_current_resolutions(sims, active_sims)
-        next_switch = np.zeros_like(resolutions)
-        for idx in range(active_sims.shape[0]):
-            if active_sims[idx] != 1:
-                continue
-            prev_out = prev_output[idx] if prev_output is not None else None
-            next_switch[idx] = self._switching_func(
-                resolutions[idx], locations[idx], t, inputs[idx], prev_out
-            )
-        local_num_changes = np.sum(next_switch != 0)
+        target_resolutions = self._gather_target_resolutions(
+            resolutions, locations, t, inputs, prev_output, active_sims
+        )
+        local_num_changes = np.sum(target_resolutions != resolutions)
         global_num_changes = self._comm.allreduce(local_num_changes, op=MPI.SUM)
         self._converged = global_num_changes == 0
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -566,6 +566,7 @@ class Config:
             )
 
         if self._m_adap:
+            self._write_data_names.append("model_resolution")
             self._m_adap_micro_file_names = [
                 name.replace("/", ".").replace("\\", ".").replace(".py", "")
                 for name in self._data["simulation_params"][

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -674,10 +674,8 @@ class ActiveBalancer(LoadBalancer):
             ) = self._get_active_exchange_counts()
 
             if (
-                n_global_send_sims == 0
-                and n_global_recv_sims == 0
-                and not self._bypass_skip
-            ):
+                n_global_send_sims == 0 or n_global_recv_sims == 0
+            ) and not self._bypass_skip:
                 self._log.log_warning_rank_zero(
                     "It appears that the micro simulations are already fairly balanced. No load balancing will be done. Try changing the threshold value to induce load balancing."
                 )

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -1112,11 +1112,17 @@ class MicroManagerCoupling(MicroManager):
 
         # Resolve micro sim output data for inactive simulations
         for inactive_lid in inactive_sim_lids:
+            self.load_balancing.pre_sim_solve(
+                self._global_ids_of_local_sims[inactive_lid]
+            )
             micro_sims_output[inactive_lid]["Active-State"] = 0
             gid = self._global_ids_of_local_sims[inactive_lid]
             micro_sims_output[inactive_lid][
                 "Active-Steps"
             ] = self._micro_sims_active_steps[gid]
+            self.load_balancing.post_sim_solve(
+                self._global_ids_of_local_sims[inactive_lid]
+            )
 
         # Collect micro sim output for adaptivity calculation
         for i in range(self._local_number_of_sims):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -212,8 +212,11 @@ class MicroManagerCoupling(MicroManager):
                     # Write a checkpoint if a simulation is just activated.
                     # This checkpoint will be asynchronous to the checkpoints written at the start of the time window.
                     if self._is_model_adaptivity_on:
+                        active_sim_lids = (
+                            self._adaptivity_controller.get_active_sim_local_ids()
+                        )
                         self._model_adaptivity_controller.update_states(
-                            self._micro_sims, active_sim_gids
+                            self._micro_sims, active_sim_lids
                         )
                     for i in range(self._local_number_of_sims):
                         if sim_states_cp[i] is None and self._micro_sims[i]:
@@ -244,13 +247,13 @@ class MicroManagerCoupling(MicroManager):
             # Write a checkpoint
             if self._participant.requires_writing_checkpoint() or performed_lb:
                 if self._is_model_adaptivity_on:
-                    active_sim_gids = None
+                    active_sim_lids = None
                     if self._is_adaptivity_on:
-                        active_sim_gids = (
+                        active_sim_lids = (
                             self._adaptivity_controller.get_active_sim_local_ids()
                         )
                     self._model_adaptivity_controller.update_states(
-                        self._micro_sims, active_sim_gids
+                        self._micro_sims, active_sim_lids
                     )
                 for i in range(self._local_number_of_sims):
                     sim_states_cp[i] = (
@@ -308,13 +311,13 @@ class MicroManagerCoupling(MicroManager):
                         self.state_setter(self._micro_sims[i], sim_states_cp[i])
 
                 if self._is_model_adaptivity_on:
-                    active_sim_gids = None
+                    active_sim_lids = None
                     if self._is_adaptivity_on:
-                        active_sim_gids = (
+                        active_sim_lids = (
                             self._adaptivity_controller.get_active_sim_local_ids()
                         )
                     self._model_adaptivity_controller.write_back_states(
-                        self._micro_sims, active_sim_gids
+                        self._micro_sims, active_sim_lids
                     )
 
                 first_iteration = False

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -742,6 +742,23 @@ class MicroManagerCoupling(MicroManager):
                         self._micro_sims[i].initialize()
             else:  # Case where the initialize() method returns data
                 if self._is_adaptivity_on:
+                    # Check for missing data
+                    expected, provided = set(self._adaptivity_micro_data_names), set(
+                        initial_micro_output.keys()
+                    )
+                    if missing := expected - provided:
+                        raise Exception(
+                            "The initialize() method needs to return data which is required for the adaptivity calculation. "
+                            f'Of the expected data {", ".join(expected)}, the following is missing: {", ".join(missing)}'
+                        )
+                    elif extra := provided - set(
+                        self._adaptivity_macro_data_names
+                        + self._adaptivity_micro_data_names
+                    ):
+                        self._logger.log_warning_rank_zero(
+                            f'The initialize() method of the Micro simulation returns extra initial data which isn\'t used by the adaptivity: {", ".join(extra)}'
+                        )
+
                     for name in initial_micro_output.keys():
                         initial_micro_data[name] = [0] * self._local_number_of_sims
                         # Save initial data from first micro simulation as we anyway have it
@@ -753,10 +770,6 @@ class MicroManagerCoupling(MicroManager):
                             self._data_for_adaptivity[name][
                                 first_id
                             ] = initial_micro_output[name]
-                        else:
-                            raise Exception(
-                                "The initialize() method needs to return data which is required for the adaptivity calculation."
-                            )
 
                     # Gather initial data from the rest of the micro simulations
                     if sim_requires_init_data:

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -483,6 +483,16 @@ class MicroManagerCoupling(MicroManager):
                 self._mesh_vertex_ids,
             ) = domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
 
+            # Global coordinates that are necessary for model adaptivity
+            # TODO: Avoid the allgather by smartly selecting the relevant coordinates in model adaptivity
+            self._global_mesh_vertex_coords = self._comm.allgather(
+                self._mesh_vertex_coords
+            )
+
+        if not self._is_parallel or self._is_load_balancing:
+            # For a serial run or when load balancing, the local mesh vertex coordinates are the global mesh vertex coordinates
+            self._global_mesh_vertex_coords = self._mesh_vertex_coords
+
         if self._mesh_vertex_coords.size == 0:
             if self._is_parallel:
                 self._is_rank_empty = True
@@ -1146,7 +1156,7 @@ class MicroManagerCoupling(MicroManager):
 
         while self._model_adaptivity_controller.should_iterate():
             switched_lids = self._model_adaptivity_controller.switch_models(
-                self._mesh_vertex_coords[self._global_ids_of_local_sims],
+                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
                 self._t,
                 micro_sims_input,
                 output,
@@ -1162,7 +1172,7 @@ class MicroManagerCoupling(MicroManager):
                     computed_outputs[gid] = out
             output = solve_variant(micro_sims_input, dt, computed_outputs)
             self._model_adaptivity_controller.check_convergence(
-                self._mesh_vertex_coords[self._global_ids_of_local_sims],
+                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
                 self._t,
                 micro_sims_input,
                 output,

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -1162,6 +1162,12 @@ class MicroManagerCoupling(MicroManager):
             )
 
         self._model_adaptivity_controller.finalise_solve()
+
+        for lid, sim in enumerate(self._micro_sims):
+            res = -1
+            if sim is not None:
+                res = self._model_adaptivity_controller.get_sim_class_resolution(sim)
+            output[lid]["model_resolution"] = res
         return output
 
     def _get_solve_variant(self) -> Callable[[list, float], list]:

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -555,9 +555,19 @@ def __getattr__(self, name):
     # Only add initialize override if the wrapped class actually has it,
     # so that requires_initialize() returns True for those classes.
     if has_initialize:
-        class_body += """
-def initialize(self, *args, **kwargs):
-    return self._wrapped.initialize(*args, **kwargs)
+        argspec = inspect.getfullargspec(cls.initialize)
+        # build args
+        init_args = f"{', '.join(argspec.args)}"
+        params = f"{', '.join(argspec.args[1::])}"
+        if argspec.varargs is not None:
+            init_args += f", *args"
+            params += f", *args"
+        if argspec.varkw is not None:
+            init_args += f", **kwargs"
+            params += f", **kwargs"
+        class_body += f"""
+def initialize({init_args}):
+    return self._wrapped.initialize({params})
 """
 
     # Only add output override if the wrapped class actually has it,

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -610,39 +610,47 @@ def load_backend_class(path_to_micro_file: str) -> type:
         A class inheriting from MicroSimulationInterface.
     """
 
-    def try_load(name):
-        try:
-            return getattr(ipl.import_module(path_to_micro_file, name), name)
-        except ImportError as ie:
-            return None
-        except AttributeError as ae:
-            return None
+    # try to load the module
+    try:
+        mod = ipl.import_module(path_to_micro_file)
+    except ModuleNotFoundError as ie:
+        if ie.name == path_to_micro_file:
+            raise RuntimeError(
+                f"Could not load the python module '{path_to_micro_file}' containing the micro simulation"
+            )
+        else:
+            raise RuntimeError(
+                f"Counld not load a dependency of the python module '{path_to_micro_file}' containing the micro simulation: {ie}"
+            )
+    except Exception as e:
+        raise RuntimeError(
+            f"Error loading python module '{path_to_micro_file}' containing the micro simulation: {e}"
+        )
 
-    def check_cls(cls):
-        try:
-            inherits = issubclass(cls, MicroSimulationInterface)
-        except TypeError:
-            # pybind11 extension types may not support issubclass — wrap them
-            inherits = False
-
-        if not inherits:
-            cls = _wrap_non_interface_class(cls, path_to_micro_file)
-        return cls
-
+    # try to load the class
     CLS_NAME = "MicroSimulation"
-    # attempt to load with base name
-    result = try_load(CLS_NAME)
-    if result is not None:
-        return check_cls(result)
+    suffixes = [""] + [str(i) for i in range(10)]
+    micro_cls = None
+    for suffix in suffixes:
+        if cls := getattr(mod, f"{CLS_NAME}{suffix}", None):
+            micro_cls = cls
+            break
+    if micro_cls is None:
+        raise RuntimeError(
+            f"Loaded module '{path_to_micro_file}' does not contain a MicroSimulation class"
+        )
 
-    # attempt to load with appended indices
-    for i in range(10):
-        result = try_load(f"{CLS_NAME}{i}")
-        if result is not None:
-            return check_cls(result)
+    # check loaded class
+    try:
+        inherits = issubclass(micro_cls, MicroSimulationInterface)
+    except TypeError:
+        # pybind11 extension types may not support issubclass — wrap them
+        inherits = False
 
-    # failed to load any class
-    raise RuntimeError(f"Could not load micro simulation from {path_to_micro_file}")
+    if inherits:
+        return micro_cls
+    else:
+        return _wrap_non_interface_class(micro_cls, path_to_micro_file)
 
 
 def create_simulation_class(

--- a/tests/integration/test_unit_cube/micro_dummy.py
+++ b/tests/integration/test_unit_cube/micro_dummy.py
@@ -56,3 +56,6 @@ class MicroSimulation:
 
     def get_global_id(self):
         return self._sim_id
+
+    def set_global_id(self, sim_id):
+        self._sim_id = sim_id

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -174,7 +174,7 @@ class TestModelAdaptivity(TestCase):
         )
 
         self.assertEqual(manager._micro_sims[0].name, "coarse")
-        self.assertEqual(result, [{"result": 2}])
+        self.assertEqual(result, [{"result": 2, "model_resolution": 1}])
         self.assertTrue(controller._converged)
 
     def test_manager_loop_exits_on_invalid_switch_request(self):
@@ -214,4 +214,4 @@ class TestModelAdaptivity(TestCase):
 
         self.assertEqual(len(solve_calls), 1)
         self.assertEqual(solve_calls[0]["computed_outputs"], {})
-        self.assertEqual(result, [{"result": 1.0}])
+        self.assertEqual(result, [{"result": 1.0, "model_resolution": 1}])

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -1,0 +1,217 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+import numpy as np
+from mpi4py import MPI
+
+from micro_manager.adaptivity.model_adaptivity import ModelAdaptivity
+from micro_manager.micro_manager import MicroManagerCoupling
+
+
+class DummyModelClass:
+    def __init__(self, name):
+        self.name = name
+
+
+class DummySimulation:
+    def __init__(self, name, global_id=0, late_init=False):
+        self.name = name
+        self._global_id = global_id
+        self._state = {"state": name}
+        self.attachments = {}
+        self.destroyed = False
+        self.late_init = late_init
+
+    def get_global_id(self):
+        return self._global_id
+
+    def get_state(self):
+        return self._state.copy()
+
+    def set_state(self, state):
+        self._state = state.copy()
+
+    def destroy(self):
+        self.destroyed = True
+
+
+class DummyModelManager:
+    def __init__(self):
+        self.created_instances = []
+
+    def get_instance(self, gid, target_class, *, late_init=False):
+        self.created_instances.append(
+            {
+                "gid": gid,
+                "target_class": target_class.name,
+                "late_init": late_init,
+            }
+        )
+        return DummySimulation(target_class.name, gid, late_init=late_init)
+
+
+class TestModelAdaptivity(TestCase):
+    def _make_controller(self, switching_func):
+        controller = ModelAdaptivity.__new__(ModelAdaptivity)
+        controller._switching_func = switching_func
+        controller._model_classes = [
+            DummyModelClass("fine"),
+            DummyModelClass("coarse"),
+        ]
+        controller._model_manager = DummyModelManager()
+        controller._comm = MPI.COMM_SELF
+        controller._logger = MagicMock()
+        controller._converged = False
+        return controller
+
+    def test_check_convergence_ignores_invalid_switch_at_finest_resolution(self):
+        """
+        Check that convergence is reached when the switching function requests a
+        finer model while the simulation is already using the finest available
+        resolution. Such an out-of-range request should be clamped to the
+        current resolution and treated as no model change.
+        """
+        controller = self._make_controller(lambda resolution, *_: -1)
+
+        controller.check_convergence(
+            np.array([[0.0, 0.0, 0.0]]),
+            1.0,
+            [{}],
+            None,
+            [DummySimulation("fine")],
+        )
+
+        self.assertTrue(controller._converged)
+
+    def test_check_convergence_ignores_invalid_switch_at_coarsest_resolution(self):
+        """
+        Check that convergence is reached when the switching function requests a
+        coarser model while the simulation is already using the coarsest
+        available resolution. This guards against endless iterations caused by
+        repeated out-of-range coarsening requests.
+        """
+        controller = self._make_controller(lambda resolution, *_: 1)
+
+        controller.check_convergence(
+            np.array([[0.0, 0.0, 0.0]]),
+            1.0,
+            [{}],
+            None,
+            [DummySimulation("coarse")],
+        )
+
+        self.assertTrue(controller._converged)
+
+    def test_check_convergence_detects_valid_switch(self):
+        """
+        Check that convergence is not reported when the switching function
+        requests a valid change to another available model resolution. The
+        adaptivity loop must continue in this case so the requested switch can
+        be applied.
+        """
+        controller = self._make_controller(lambda resolution, *_: 1)
+
+        controller.check_convergence(
+            np.array([[0.0, 0.0, 0.0]]),
+            1.0,
+            [{}],
+            None,
+            [DummySimulation("fine")],
+        )
+
+        self.assertFalse(controller._converged)
+
+    def test_manager_loop_switches_once_then_exits_on_invalid_boundary_request(self):
+        """
+        Reproduce the regression scenario where a model is switched once and
+        the switching function then keeps requesting another change beyond the
+        available resolution range. The manager should solve with the new model,
+        avoid reusing output from the previous model, and stop once the repeated
+        boundary request is clamped to a no-op.
+        """
+
+        def switching_function(resolution, location, t, input, prev_output):
+            if prev_output is None:
+                return 0
+            return 1
+
+        controller = self._make_controller(switching_function)
+        manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
+        manager._model_adaptivity_controller = controller
+        manager._is_adaptivity_on = False
+        manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
+        manager._global_ids_of_local_sims = [0]
+        manager._t = 1.0
+        manager._micro_sims = [DummySimulation("fine", global_id=0)]
+
+        solve_calls = []
+
+        def solve_variant(micro_sims_input, dt, computed_outputs):
+            solve_calls.append(
+                {
+                    "sim_name": manager._micro_sims[0].name,
+                    "computed_outputs": computed_outputs.copy(),
+                }
+            )
+            return [{"result": len(solve_calls)}]
+
+        result = MicroManagerCoupling._solve_micro_simulations_with_model_adaptivity(
+            manager,
+            [{"input": 1.0}],
+            0.1,
+            solve_variant,
+        )
+
+        self.assertEqual(len(solve_calls), 2)
+        self.assertEqual(solve_calls[0]["sim_name"], "fine")
+        self.assertEqual(solve_calls[0]["computed_outputs"], {})
+
+        self.assertEqual(solve_calls[1]["sim_name"], "coarse")
+        self.assertEqual(
+            solve_calls[1]["computed_outputs"],
+            {},
+            "Output from the previous resolution must not be reused after a model switch.",
+        )
+
+        self.assertEqual(manager._micro_sims[0].name, "coarse")
+        self.assertEqual(result, [{"result": 2}])
+        self.assertTrue(controller._converged)
+
+    def test_manager_loop_exits_on_invalid_switch_request(self):
+        """
+        Check the manager loop for the simpler boundary case where the
+        simulation starts at the coarsest model and the switching function keeps
+        requesting an even coarser model. The loop should perform one solve,
+        recognize that no valid model change remains, and return normally.
+        """
+        controller = self._make_controller(lambda resolution, *_: 1)
+        manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
+        manager._model_adaptivity_controller = controller
+        manager._is_adaptivity_on = False
+        manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
+        manager._global_ids_of_local_sims = [0]
+        manager._t = 1.0
+        manager._micro_sims = [DummySimulation("coarse")]
+
+        solve_calls = []
+
+        def solve_variant(micro_sims_input, dt, computed_outputs):
+            solve_calls.append(
+                {
+                    "micro_sims_input": micro_sims_input,
+                    "dt": dt,
+                    "computed_outputs": computed_outputs,
+                }
+            )
+            return [{"result": 1.0}]
+
+        result = MicroManagerCoupling._solve_micro_simulations_with_model_adaptivity(
+            manager,
+            [{"input": 1.0}],
+            0.1,
+            solve_variant,
+        )
+
+        self.assertEqual(len(solve_calls), 1)
+        self.assertEqual(solve_calls[0]["computed_outputs"], {})
+        self.assertEqual(result, [{"result": 1.0}])

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -140,6 +140,7 @@ class TestModelAdaptivity(TestCase):
         manager._model_adaptivity_controller = controller
         manager._is_adaptivity_on = False
         manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
+        manager._global_mesh_vertex_coords = manager._mesh_vertex_coords
         manager._global_ids_of_local_sims = [0]
         manager._t = 1.0
         manager._micro_sims = [DummySimulation("fine", global_id=0)]
@@ -189,6 +190,7 @@ class TestModelAdaptivity(TestCase):
         manager._model_adaptivity_controller = controller
         manager._is_adaptivity_on = False
         manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
+        manager._global_mesh_vertex_coords = manager._mesh_vertex_coords
         manager._global_ids_of_local_sims = [0]
         manager._t = 1.0
         manager._micro_sims = [DummySimulation("coarse")]


### PR DESCRIPTION
This release consists of:

- Fixed load balancing for case where number of sims to send and recv are not the same [#276](https://github.com/precice/micro-manager/pull/276)
- Fixed CI OpenMPI cache miss by centralizing the MPI build into a dedicated workflow [#263](https://github.com/precice/micro-manager/pull/263)
- Fixed naming of variables tracking active simulations in the `MicroManager` [#273](https://github.com/precice/micro-manager/pull/273)
- Improved load balancing of inactive simulations by tracking a small amount of time [#272](https://github.com/precice/micro-manager/pull/272)
- Added the exported field `model_resolution` when using model adaptivity [#271](https://github.com/precice/micro-manager/pull/271)
- Fixed model adaptivity active simulation mask generation for 0 local simulations [#270](https://github.com/precice/micro-manager/pull/270)
- Allow `initialize()` to return data that is not used by the adaptivity [#261](https://github.com/precice/micro-manager/pull/261)
- Fixed `MicroSimulation` initialization requiring positional parameters [#255](https://github.com/precice/micro-manager/pull/255)
- Fixed model adaptivity convergence at resolution boundaries to prevent infinite loops for out-of-range switching requests [#252](https://github.com/precice/micro-manager/pull/252)
- Add function `set_global_id` to the dummies and the example in the integration test [#247](https://github.com/precice/micro-manager/pull/247)
