### PR TITLE
Fix parameter inspection of initialize() when micro simulation is pybind11 wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed parameter inspection of the `initialize()` routine when micro simulation is pybind11 wrapped [#281](https://github.com/precice/micro-manager/pull/281)
 - Fixed passing of macro mesh coordinates when model adaptivity is run in parallel [#282](https://github.com/precice/micro-manager/pull/282)
 
 ## v0.10.0

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -555,16 +555,21 @@ def __getattr__(self, name):
     # Only add initialize override if the wrapped class actually has it,
     # so that requires_initialize() returns True for those classes.
     if has_initialize:
-        argspec = inspect.getfullargspec(cls.initialize)
-        # build args
-        init_args = f"{', '.join(argspec.args)}"
-        params = f"{', '.join(argspec.args[1::])}"
-        if argspec.varargs is not None:
-            init_args += f", *args"
-            params += f", *args"
-        if argspec.varkw is not None:
-            init_args += f", **kwargs"
-            params += f", **kwargs"
+        try:
+            argspec = inspect.getfullargspec(cls.initialize)
+            # build args
+            init_args = f"{', '.join(argspec.args)}"
+            params = f"{', '.join(argspec.args[1:])}"
+            if argspec.varargs is not None:
+                init_args += f", *args"
+                params += f", *args"
+            if argspec.varkw is not None:
+                init_args += f", **kwargs"
+                params += f", **kwargs"
+        except TypeError:
+            # pybind11 methods do not expose Python-style argument specs
+            init_args = "self, *args, **kwargs"
+            params = "*args, **kwargs"
         class_body += f"""
 def initialize({init_args}):
     return self._wrapped.initialize({params})

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -572,7 +572,7 @@ def __getattr__(self, name):
             except TypeError:
                 # calling without args failed, need to provide one
                 has_param = True
-            
+
             pos_arg = "input_data, " if has_param else ""
             params = f"{pos_arg}*args, **kwargs"
         init_args = f"self, {params}"

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -558,18 +558,24 @@ def __getattr__(self, name):
         try:
             argspec = inspect.getfullargspec(cls.initialize)
             # build args
-            init_args = f"{', '.join(argspec.args)}"
             params = f"{', '.join(argspec.args[1:])}"
             if argspec.varargs is not None:
-                init_args += f", *args"
                 params += f", *args"
             if argspec.varkw is not None:
-                init_args += f", **kwargs"
                 params += f", **kwargs"
         except TypeError:
             # pybind11 methods do not expose Python-style argument specs
-            init_args = "self, *args, **kwargs"
-            params = "*args, **kwargs"
+            has_param = False
+            try:
+                test_instance = cls(-1)
+                test_instance.initialize()
+            except TypeError:
+                # calling without args failed, need to provide one
+                has_param = True
+            
+            pos_arg = "input_data, " if has_param else ""
+            params = f"{pos_arg}*args, **kwargs"
+        init_args = f"self, {params}"
         class_body += f"""
 def initialize({init_args}):
     return self._wrapped.initialize({params})


### PR DESCRIPTION
When a pybind11-based micro simulation is provided, `inspect.getfullargspec()` on `initialize()` returns `TypeError: unsupported callable`. This PR now handles this error and, if the' TypeError' is hit, directly passes whatever input arguments are available without inspection. The ideal solution would be to find a way to inspect arguments of a pybind11-based micro simulation. This is a temporary fix.

<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
