### PR TITLE
Fix passing of macro mesh coordinates when model adaptivity is run in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Micro Manager changelog
 
+## latest
+
+- Fixed passing of macro mesh coordinates when model adaptivity is run in parallel [#282](https://github.com/precice/micro-manager/pull/282)
+
 ## v0.10.0
 
 - Fixed load balancing for case where number of sims to send and recv are not the same [#276](https://github.com/precice/micro-manager/pull/276)

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -475,6 +475,7 @@ class MicroManagerCoupling(MicroManager):
             # Gather all vertex coords and IDs from all ranks onto all ranks,
             # filter out coords already claimed by lower-ranked ranks.
             # When load balancing, all ranks receive all coords. No duplicates can arise.
+            # TODO: Avoid the allgather by smartly selecting the relevant coordinates
             all_coords = self._comm.allgather(self._mesh_vertex_coords)
             all_ids = self._comm.allgather(self._mesh_vertex_ids)
 
@@ -482,6 +483,15 @@ class MicroManagerCoupling(MicroManager):
                 self._mesh_vertex_coords,
                 self._mesh_vertex_ids,
             ) = domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
+
+            # Global coordinates that are necessary for model adaptivity
+            global_mesh_vertex_coords = self._comm.allgather(self._mesh_vertex_coords)
+            self._global_mesh_vertex_coords = np.array(
+                global_mesh_vertex_coords
+            ).reshape((-1, self._mesh_vertex_coords.shape[-1]))
+        else:
+            # For a serial run or when load balancing, the local mesh vertex coordinates are the global mesh vertex coordinates
+            self._global_mesh_vertex_coords = self._mesh_vertex_coords
 
         if self._mesh_vertex_coords.size == 0:
             if self._is_parallel:
@@ -1146,7 +1156,7 @@ class MicroManagerCoupling(MicroManager):
 
         while self._model_adaptivity_controller.should_iterate():
             switched_lids = self._model_adaptivity_controller.switch_models(
-                self._mesh_vertex_coords,
+                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
                 self._t,
                 micro_sims_input,
                 output,
@@ -1162,7 +1172,7 @@ class MicroManagerCoupling(MicroManager):
                     computed_outputs[gid] = out
             output = solve_variant(micro_sims_input, dt, computed_outputs)
             self._model_adaptivity_controller.check_convergence(
-                self._mesh_vertex_coords,
+                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
                 self._t,
                 micro_sims_input,
                 output,

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -483,16 +483,6 @@ class MicroManagerCoupling(MicroManager):
                 self._mesh_vertex_ids,
             ) = domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
 
-            # Global coordinates that are necessary for model adaptivity
-            # TODO: Avoid the allgather by smartly selecting the relevant coordinates in model adaptivity
-            self._global_mesh_vertex_coords = self._comm.allgather(
-                self._mesh_vertex_coords
-            )
-
-        if not self._is_parallel or self._is_load_balancing:
-            # For a serial run or when load balancing, the local mesh vertex coordinates are the global mesh vertex coordinates
-            self._global_mesh_vertex_coords = self._mesh_vertex_coords
-
         if self._mesh_vertex_coords.size == 0:
             if self._is_parallel:
                 self._is_rank_empty = True

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -1156,7 +1156,7 @@ class MicroManagerCoupling(MicroManager):
 
         while self._model_adaptivity_controller.should_iterate():
             switched_lids = self._model_adaptivity_controller.switch_models(
-                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
+                self._mesh_vertex_coords,
                 self._t,
                 micro_sims_input,
                 output,
@@ -1172,7 +1172,7 @@ class MicroManagerCoupling(MicroManager):
                     computed_outputs[gid] = out
             output = solve_variant(micro_sims_input, dt, computed_outputs)
             self._model_adaptivity_controller.check_convergence(
-                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
+                self._mesh_vertex_coords,
                 self._t,
                 micro_sims_input,
                 output,


### PR DESCRIPTION
When model adaptivity is run, the switching function requires the coordinate location. Even if this is run in parallel, only the local coordinates are required. This PR simplifies passing the coordinates.

<!-- Add a short description of your contribution here. Skip this if the title is self-explanatory -->

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
