### PR TITLE
Release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Micro Manager changelog
 
+## latest
+
+- Fixed passing of macro mesh coordinates when model adaptivity is run in parallel [#282](https://github.com/precice/micro-manager/pull/282)
+
 ## v0.10.0
 
 - Fixed load balancing for case where number of sims to send and recv are not the same [#276](https://github.com/precice/micro-manager/pull/276)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed parameter inspection of the `initialize()` routine when micro simulation is pybind11 wrapped [#281](https://github.com/precice/micro-manager/pull/281)
 - Fixed passing of macro mesh coordinates when model adaptivity is run in parallel [#282](https://github.com/precice/micro-manager/pull/282)
 
 ## v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Micro Manager changelog
 
-## latest
+## v0.10.1
 
 - Fixed parameter inspection of the `initialize()` routine when micro simulation is pybind11 wrapped [#281](https://github.com/precice/micro-manager/pull/281)
 - Fixed passing of macro mesh coordinates when model adaptivity is run in parallel [#282](https://github.com/precice/micro-manager/pull/282)

--- a/docs/model-adaptivity.md
+++ b/docs/model-adaptivity.md
@@ -170,4 +170,4 @@ The output is expected to be an integer and is interpreted in the following mann
 | -1    | Increase model fidelity by one (go back one in list)  |
 | 1     | Decrease model fidelity by one (go one ahead in list) |
 
-If the switching function requests a change beyond the available resolution range, the request is ignored and does not trigger another model-adaptivity iteration.
+If the switching function requests a change beyond the available resolution range, the request is clamped within the available range. Further requests beyond the range are ignored and do not trigger another model-adaptivity iteration.

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -475,6 +475,7 @@ class MicroManagerCoupling(MicroManager):
             # Gather all vertex coords and IDs from all ranks onto all ranks,
             # filter out coords already claimed by lower-ranked ranks.
             # When load balancing, all ranks receive all coords. No duplicates can arise.
+            # TODO: Avoid the allgather by smartly selecting the relevant coordinates
             all_coords = self._comm.allgather(self._mesh_vertex_coords)
             all_ids = self._comm.allgather(self._mesh_vertex_ids)
 
@@ -484,12 +485,11 @@ class MicroManagerCoupling(MicroManager):
             ) = domain_decomposer.filter_duplicate_coords(all_coords, all_ids)
 
             # Global coordinates that are necessary for model adaptivity
-            # TODO: Avoid the allgather by smartly selecting the relevant coordinates in model adaptivity
-            self._global_mesh_vertex_coords = self._comm.allgather(
-                self._mesh_vertex_coords
-            )
-
-        if not self._is_parallel or self._is_load_balancing:
+            global_mesh_vertex_coords = self._comm.allgather(self._mesh_vertex_coords)
+            self._global_mesh_vertex_coords = np.array(
+                global_mesh_vertex_coords
+            ).reshape((-1, self._mesh_vertex_coords.shape[-1]))
+        else:
             # For a serial run or when load balancing, the local mesh vertex coordinates are the global mesh vertex coordinates
             self._global_mesh_vertex_coords = self._mesh_vertex_coords
 

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -555,16 +555,27 @@ def __getattr__(self, name):
     # Only add initialize override if the wrapped class actually has it,
     # so that requires_initialize() returns True for those classes.
     if has_initialize:
-        argspec = inspect.getfullargspec(cls.initialize)
-        # build args
-        init_args = f"{', '.join(argspec.args)}"
-        params = f"{', '.join(argspec.args[1::])}"
-        if argspec.varargs is not None:
-            init_args += f", *args"
-            params += f", *args"
-        if argspec.varkw is not None:
-            init_args += f", **kwargs"
-            params += f", **kwargs"
+        try:
+            argspec = inspect.getfullargspec(cls.initialize)
+            # build args
+            params = f"{', '.join(argspec.args[1:])}"
+            if argspec.varargs is not None:
+                params += f", *args"
+            if argspec.varkw is not None:
+                params += f", **kwargs"
+        except TypeError:
+            # pybind11 methods do not expose Python-style argument specs
+            has_param = False
+            try:
+                test_instance = cls(-1)
+                test_instance.initialize()
+            except TypeError:
+                # calling without args failed, need to provide one
+                has_param = True
+
+            pos_arg = "input_data, " if has_param else ""
+            params = f"{pos_arg}*args, **kwargs"
+        init_args = f"self, {params}"
         class_body += f"""
 def initialize({init_args}):
     return self._wrapped.initialize({params})


### PR DESCRIPTION
This release is necessary due to the following bugfixes:

- Fixed parameter inspection of the `initialize()` routine when micro simulation is pybind11 wrapped [#281](https://github.com/precice/micro-manager/pull/281)
- Fixed passing of macro mesh coordinates when model adaptivity is run in parallel [#282](https://github.com/precice/micro-manager/pull/282)
