### PR TITLE
Switch to dedicated simulation container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Added simulation container for more encapsulation [#284](https://github.com/precice/micro-manager/pull/284)
 - Redesigned configuration loading for enhanced clarity and standardization [#264](https://github.com/precice/micro-manager/pull/264)
 - Added RBF interpolation, currently used within adaptivity for output interpolation [#242](https://github.com/precice/micro-manager/pull/242)
 

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -8,6 +8,7 @@ from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.config import Config
 from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.model_manager import ModelManager
+from micro_manager.simulation_container import SimulationContainer
 
 import numpy as np
 
@@ -17,6 +18,7 @@ class AdaptivityCalculator:
         self,
         config: Config,
         nsims: int,
+        sim_container: SimulationContainer,
         micro_problem_cls: MicroSimulationClass,
         model_manager: ModelManager,
         base_logger: Logger,
@@ -31,6 +33,8 @@ class AdaptivityCalculator:
             Object which has getter functions to get parameters defined in the configuration file.
         nsims : int
             Number of micro simulations.
+        sim_container : SimulationContainer
+            Simulation container object.
         micro_problem_cls : callable
             Class of micro problem.
         model_manager : object
@@ -49,6 +53,7 @@ class AdaptivityCalculator:
 
         self._micro_problem_cls = micro_problem_cls
         self._model_manager = model_manager
+        self._sim_container: SimulationContainer = sim_container
 
         self._coarse_tol = 0.0
         self._ref_tol = 0.0

--- a/micro_manager/adaptivity/adaptivity_selection.py
+++ b/micro_manager/adaptivity/adaptivity_selection.py
@@ -5,9 +5,7 @@ from .adaptivity import AdaptivityCalculator
 
 def create_adaptivity_calculator(
     config,
-    local_number_of_sims,
-    global_number_of_sims,
-    global_ids_of_local_sims,
+    sim_container,
     participant,
     logger,
     rank,
@@ -20,7 +18,7 @@ def create_adaptivity_calculator(
     if adaptivity_type == "local":
         return LocalAdaptivityCalculator(
             config,
-            local_number_of_sims,
+            sim_container,
             logger,
             rank,
             comm,
@@ -31,8 +29,7 @@ def create_adaptivity_calculator(
     if adaptivity_type == "global":
         return GlobalAdaptivityCalculator(
             config,
-            global_number_of_sims,
-            global_ids_of_local_sims,
+            sim_container,
             participant,
             logger,
             rank,

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -16,6 +16,7 @@ from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.model_manager import ModelManager
 from micro_manager.interpolation import RBF_PU
+from micro_manager.simulation_container import SimulationContainer
 
 from micro_manager.tools.p2p import p2p_comm, get_ranks_of_sims
 
@@ -24,8 +25,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
     def __init__(
         self,
         config: Config,
-        global_number_of_sims: int,
-        global_ids: list,
+        sim_container: SimulationContainer,
         participant,
         base_logger: Logger,
         rank: int,
@@ -40,10 +40,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         config : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
-        global_number_of_sims : int
-            Total number of simulations in the macro-micro coupled problem.
-        global_ids : list
-            List of global IDs of simulations living on this rank.
+        sim_container : SimulationContainer
+            Simulation container object.
         participant : object of class Participant
             Object of the class Participant using which the preCICE API is called.
         base_logger : object of class Logger
@@ -59,26 +57,18 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         """
         super().__init__(
             config,
-            global_number_of_sims,
+            sim_container.global_num_sims,
+            sim_container,
             micro_problem_cls,
             model_manager,
             base_logger,
             rank,
         )
-        self._global_number_of_sims = global_number_of_sims
-        self._global_ids = global_ids
         self._comm = comm
 
         self._interpolation = RBF_PU(
             base_logger, comm, self._rank, self._comm.Get_size()
         )
-        rank_of_sim = get_ranks_of_sims(global_ids, rank, comm, global_number_of_sims)
-
-        self._is_sim_on_this_rank = [False] * global_number_of_sims  # DECLARATION
-        for gid in range(global_number_of_sims):
-            if rank_of_sim[gid] == self._rank:
-                self._is_sim_on_this_rank[gid] = True
-
         self._precice_participant = participant
 
         self._comm_node = comm.Split_type(MPI.COMM_TYPE_SHARED)
@@ -92,7 +82,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             self._MPI_local_rank == 0
         ):  # Only the first rank in the node allocates the shared memory
             nbytes = (
-                self._global_number_of_sims * self._global_number_of_sims * itemsize
+                self._sim_container.global_num_sims * self._sim_container.global_num_sims * itemsize
             )
         else:
             nbytes = 0
@@ -113,7 +103,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         self._similarity_dists: np.ndarray = np.ndarray(
             buffer=array_buffer,
             dtype="f",
-            shape=(self._global_number_of_sims, self._global_number_of_sims),
+            shape=(self._sim_container.global_num_sims, self._sim_container.global_num_sims),
         )
 
         if self._MPI_local_rank == 0:
@@ -123,7 +113,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
     def compute_adaptivity(
         self,
         dt: float,
-        micro_sims: list,
         data_for_adaptivity: dict,
     ) -> None:
         """
@@ -150,8 +139,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         global_data_for_adaptivity = dict()
         for name in data_for_adaptivity.keys():
             data_as_list = self._comm.allgather(data_for_adaptivity[name])
-            global_ids_as_list = self._comm.allgather(self._global_ids)
-            global_data_for_adaptivity[name] = [0] * self._global_number_of_sims
+            global_ids_as_list = self._comm.allgather(self._sim_container.local_gids)
+            global_data_for_adaptivity[name] = [0] * self._sim_container.global_num_sims
             for i, gids_list in enumerate(global_ids_as_list):
                 count = 0
                 for gid in gids_list:
@@ -176,7 +165,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         self._update_active_sims()
 
-        self._update_inactive_sims(micro_sims)
+        self._update_inactive_sims()
 
         self._associate_inactive_to_active()
 
@@ -190,9 +179,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             1D array of active simulation ids
         """
         active_sim_ids = []
-        for gid in self._global_ids:
+        for gid in self._sim_container.local_gids:
             if self._is_sim_active[gid]:
-                active_sim_ids.append(self._global_ids.index(gid))
+                active_sim_ids.append(self._sim_container.local_gids.index(gid))
 
         return np.array(active_sim_ids)
 
@@ -206,9 +195,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             1D array of inactive simulation ids
         """
         inactive_sim_ids = []
-        for gid in self._global_ids:
+        for gid in self._sim_container.local_gids:
             if not self._is_sim_active[gid]:
-                inactive_sim_ids.append(self._global_ids.index(gid))
+                inactive_sim_ids.append(self._sim_container.local_gids.index(gid))
 
         return np.array(inactive_sim_ids)
 
@@ -222,7 +211,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             1D array of active simulation ids
         """
         active_sim_ids = []
-        for gid in self._global_ids:
+        for gid in self._sim_container.local_gids:
             if self._is_sim_active[gid]:
                 active_sim_ids.append(gid)
 
@@ -238,7 +227,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             1D array of inactive simulation ids
         """
         inactive_sim_ids = []
-        for gid in self._global_ids:
+        for gid in self._sim_container.local_gids:
             if not self._is_sim_active[gid]:
                 inactive_sim_ids.append(gid)
 
@@ -283,12 +272,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         return micro_sims_output
 
-    def set_is_on_rank(self, gid, val):
-        """
-        Marks whether the simulation gid is as on local rank or not.
-        """
-        self._is_sim_on_this_rank[gid] = val
-
     def log_metrics(self, n: int) -> None:
         """
         Log the following metrics:
@@ -315,7 +298,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         """
         active_sims_on_this_rank = 0
         inactive_sims_on_this_rank = 0
-        for gid in self._global_ids:
+        for gid in self._sim_container.local_gids:
             if self._is_sim_active[gid]:
                 active_sims_on_this_rank += 1
             else:
@@ -326,11 +309,11 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             or self._adaptivity_output_type == "local"
         ):
             ranks_of_sims = get_ranks_of_sims(
-                self._global_ids, self._rank, self._comm, self._global_number_of_sims
+                self._sim_container.local_gids, self._rank, self._comm, self._sim_container.global_num_sims
             )
 
             assoc_ranks = []  # Ranks to which inactive sims on this rank are associated
-            for gid in self._global_ids:
+            for gid in self._sim_container.local_gids:
                 if not self._is_sim_active[gid]:
                     assoc_rank = int(ranks_of_sims[self._sim_is_associated_to[gid]])
                     if not assoc_rank in assoc_ranks:
@@ -426,24 +409,23 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         for gid in inactive_gids:
             assoc_active_gid = self._sim_is_associated_to[gid]
             # Gather global IDs of associated active simulations not on this rank
-            if not self._is_sim_on_this_rank[assoc_active_gid]:
+            if not self._sim_container.is_sim_on_rank(assoc_active_gid):
                 if assoc_active_gid in active_to_inactive_map:
                     active_to_inactive_map[assoc_active_gid].append(gid)
                 else:
                     active_to_inactive_map[assoc_active_gid] = [gid]
             else:  # If associated active simulation is on this rank, copy the output directly
-                lid = self._global_ids.index(gid)
-                assoc_active_lid = self._global_ids.index(assoc_active_gid)
+                lid = self._sim_container.local_gids.index(gid)
+                assoc_active_lid = self._sim_container.local_gids.index(assoc_active_gid)
                 micro_output[lid] = deepcopy(micro_output[assoc_active_lid])
 
         assoc_active_gids = list(active_to_inactive_map.keys())
 
         recv_reqs = p2p_comm(
-            self._global_ids,
+            self._sim_container.local_gids,
             self._rank,
             self._comm,
-            self._global_number_of_sims,
-            self._is_sim_on_this_rank,
+            self._sim_container.global_num_sims,
             assoc_active_gids,
             micro_output,
         )
@@ -452,20 +434,15 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         for count, req in enumerate(recv_reqs):
             output = req.wait()
             for gid in active_to_inactive_map[assoc_active_gids[count]]:
-                lid = self._global_ids.index(gid)
+                lid = self._sim_container.local_gids.index(gid)
                 micro_output[lid] = deepcopy(output)
 
-    def _update_inactive_sims(self, micro_sims: list) -> None:
+    def _update_inactive_sims(self) -> None:
         """
         Update set of inactive micro simulations. Each inactive micro simulation is compared to all active ones and if it is not similar to any of them, it is activated.
 
         If a micro simulation which has been inactive since the start of the simulation is activated for the
         first time, the simulation object is created and initialized.
-
-        Parameters
-        ----------
-        micro_sims : list
-            List of objects of class MicroProblem, which are the micro simulations
         """
         self._ref_tol = self._refine_const * self._max_similarity_dist
 
@@ -486,7 +463,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                     # Add the newly activated gid to active_gids_all_ranks for further checks
                     active_gids_all_ranks = np.append(active_gids_all_ranks, gid)
                     # Collect the global IDs to be activated on this rank
-                    if self._is_sim_on_this_rank[gid]:
+                    if self._sim_container.is_sim_on_rank(gid):
                         to_be_activated_gids.append(gid)
         # ----------------------------------------------------------------------------------
 
@@ -498,19 +475,17 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         # Only handle activation of simulations on this rank
         for gid in to_be_activated_gids:
-            to_be_activated_lid = self._global_ids.index(gid)
-            micro_sims[to_be_activated_lid] = self._model_manager.get_instance(
+            to_be_activated_lid = self._sim_container.local_gids.index(gid)
+            self._sim_container[to_be_activated_lid] = self._model_manager.get_instance(
                 gid, self._micro_problem_cls
             )
             assoc_active_gid = self._sim_is_associated_to[gid]
 
-            if self._is_sim_on_this_rank[
-                assoc_active_gid
-            ]:  # Associated active simulation is on the same rank
-                assoc_active_lid = self._global_ids.index(assoc_active_gid)
-                micro_sims[to_be_activated_lid].set_state(
-                    micro_sims[assoc_active_lid].get_state()
-                )
+            # Associated active simulation is on the same rank
+            if self._sim_container.is_sim_on_rank(assoc_active_gid):
+                assoc_active_lid = self._sim_container.local_gids.index(assoc_active_gid)
+                state = self._sim_container.get_state(assoc_active_lid)
+                self._sim_container.set_state(to_be_activated_lid, state)
             else:  # Associated active simulation is not on this rank
                 if assoc_active_gid in to_be_activated_map:
                     to_be_activated_map[assoc_active_gid].append(to_be_activated_lid)
@@ -522,18 +497,19 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         )
 
         sim_states_and_global_ids = []
-        for lid, sim in enumerate(micro_sims):
+        for lid in self._sim_container.range_lid:
+            sim = self._sim_container[lid]
+            gid = self._sim_container.local_gids[lid]
             if sim == 0 or sim is None:
-                sim_states_and_global_ids.append((None, self._global_ids[lid]))
+                sim_states_and_global_ids.append((None, gid))
             else:
-                sim_states_and_global_ids.append((sim.get_state(), sim.get_global_id()))
+                sim_states_and_global_ids.append((self._sim_container.get_state(lid), gid))
 
         recv_reqs = p2p_comm(
-            self._global_ids,
+            self._sim_container.local_gids,
             self._rank,
             self._comm,
-            self._global_number_of_sims,
-            self._is_sim_on_this_rank,
+            self._sim_container.global_num_sims,
             list(to_be_activated_map.keys()),
             sim_states_and_global_ids,
         )
@@ -544,22 +520,21 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             local_ids = to_be_activated_map[gid]
             for lid in local_ids:
                 # Create the micro simulation object and set its state
-                micro_sims[lid] = self._model_manager.get_instance(
-                    self._global_ids[lid], self._micro_problem_cls
+                self._sim_container[lid] = self._model_manager.get_instance(
+                    self._sim_container.local_gids[lid], self._micro_problem_cls
                 )
-                micro_sims[lid].set_state(state)
+                self._sim_container.set_state(lid, state)
 
         # Delete the micro simulation object if it is inactive
-        for gid in self._global_ids:
+        for gid in self._sim_container.local_gids:
             if not self._is_sim_active[gid]:
-                lid = self._global_ids.index(gid)
+                lid = self._sim_container.local_gids.index(gid)
                 # Release resources now, especially for remote simulation instance.
                 # If left to garbage collector this might lead to a race condition.
                 # Releasing with call to sim.destroy(), afterwards reference in sim
                 # sim list can be removed.
-                if type(micro_sims[lid]).__name__ == "MicroSimulationWrapper":
-                    micro_sims[lid].destroy()
-                micro_sims[lid] = None
+                self._sim_container[lid].destroy()
+                self._sim_container[lid] = None
 
         self._precice_participant.stop_last_profiling_section()
 

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -543,6 +543,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         for gid in self._sim_container.local_gids:
             if not self._is_sim_active[gid]:
                 lid = self._sim_container.local_gids.index(gid)
+                if self._sim_container[lid] is None:
+                    continue
                 # Release resources now, especially for remote simulation instance.
                 # If left to garbage collector this might lead to a race condition.
                 # Releasing with call to sim.destroy(), afterwards reference in sim

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -496,8 +496,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 assoc_active_lid = self._sim_container.local_gids.index(
                     assoc_active_gid
                 )
-                state = self._sim_container.get_state(assoc_active_lid)
-                self._sim_container.set_state(to_be_activated_lid, state)
+                state = self._sim_container.get_sim_state(assoc_active_lid)
+                self._sim_container.set_sim_state(to_be_activated_lid, state)
             else:  # Associated active simulation is not on this rank
                 if assoc_active_gid in to_be_activated_map:
                     to_be_activated_map[assoc_active_gid].append(to_be_activated_lid)
@@ -516,7 +516,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 sim_states_and_global_ids.append((None, gid))
             else:
                 sim_states_and_global_ids.append(
-                    (self._sim_container.get_state(lid), gid)
+                    (self._sim_container.get_sim_state(lid), gid)
                 )
 
         recv_reqs = p2p_comm(
@@ -537,7 +537,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 self._sim_container[lid] = self._model_manager.get_instance(
                     self._sim_container.local_gids[lid], self._micro_problem_cls
                 )
-                self._sim_container.set_state(lid, state)
+                self._sim_container.set_sim_state(lid, state)
 
         # Delete the micro simulation object if it is inactive
         for gid in self._sim_container.local_gids:

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -82,7 +82,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             self._MPI_local_rank == 0
         ):  # Only the first rank in the node allocates the shared memory
             nbytes = (
-                self._sim_container.global_num_sims * self._sim_container.global_num_sims * itemsize
+                self._sim_container.global_num_sims
+                * self._sim_container.global_num_sims
+                * itemsize
             )
         else:
             nbytes = 0
@@ -103,7 +105,10 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         self._similarity_dists: np.ndarray = np.ndarray(
             buffer=array_buffer,
             dtype="f",
-            shape=(self._sim_container.global_num_sims, self._sim_container.global_num_sims),
+            shape=(
+                self._sim_container.global_num_sims,
+                self._sim_container.global_num_sims,
+            ),
         )
 
         if self._MPI_local_rank == 0:
@@ -309,7 +314,10 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             or self._adaptivity_output_type == "local"
         ):
             ranks_of_sims = get_ranks_of_sims(
-                self._sim_container.local_gids, self._rank, self._comm, self._sim_container.global_num_sims
+                self._sim_container.local_gids,
+                self._rank,
+                self._comm,
+                self._sim_container.global_num_sims,
             )
 
             assoc_ranks = []  # Ranks to which inactive sims on this rank are associated
@@ -416,7 +424,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                     active_to_inactive_map[assoc_active_gid] = [gid]
             else:  # If associated active simulation is on this rank, copy the output directly
                 lid = self._sim_container.local_gids.index(gid)
-                assoc_active_lid = self._sim_container.local_gids.index(assoc_active_gid)
+                assoc_active_lid = self._sim_container.local_gids.index(
+                    assoc_active_gid
+                )
                 micro_output[lid] = deepcopy(micro_output[assoc_active_lid])
 
         assoc_active_gids = list(active_to_inactive_map.keys())
@@ -483,7 +493,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
             # Associated active simulation is on the same rank
             if self._sim_container.is_sim_on_rank(assoc_active_gid):
-                assoc_active_lid = self._sim_container.local_gids.index(assoc_active_gid)
+                assoc_active_lid = self._sim_container.local_gids.index(
+                    assoc_active_gid
+                )
                 state = self._sim_container.get_state(assoc_active_lid)
                 self._sim_container.set_state(to_be_activated_lid, state)
             else:  # Associated active simulation is not on this rank
@@ -503,7 +515,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             if sim == 0 or sim is None:
                 sim_states_and_global_ids.append((None, gid))
             else:
-                sim_states_and_global_ids.append((self._sim_container.get_state(lid), gid))
+                sim_states_and_global_ids.append(
+                    (self._sim_container.get_state(lid), gid)
+                )
 
         recv_reqs = p2p_comm(
             self._sim_container.local_gids,

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -48,7 +48,13 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             Handles instantiation of micro simulation.
         """
         super().__init__(
-            config, sim_container.local_num_sims, sim_container, micro_problem_cls, model_manager, base_logger, rank
+            config,
+            sim_container.local_num_sims,
+            sim_container,
+            micro_problem_cls,
+            model_manager,
+            base_logger,
+            rank,
         )
         self._comm = comm
         self._interpolation = RBF_PU(
@@ -60,7 +66,9 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         # similarity_dists: 2D array having similarity distances between each micro simulation pair
         # This matrix is modified in place via the function update_similarity_dists
-        self._similarity_dists = np.zeros((sim_container.local_num_sims, sim_container.local_num_sims))
+        self._similarity_dists = np.zeros(
+            (sim_container.local_num_sims, sim_container.local_num_sims)
+        )
 
     def compute_adaptivity(
         self,
@@ -299,7 +307,9 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         # Update the set of inactive micro sims
         for lid in to_be_activated_ids:
             associated_active_id = self._sim_is_associated_to[lid]
-            self._sim_container[lid] = self._model_manager.get_instance(lid, self._micro_problem_cls)
+            self._sim_container[lid] = self._model_manager.get_instance(
+                lid, self._micro_problem_cls
+            )
             state = self._sim_container.get_state(associated_active_id)
             self._sim_container.set_state(lid, state)
             # Active sim cannot have an associated sim

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -310,8 +310,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             self._sim_container[lid] = self._model_manager.get_instance(
                 lid, self._micro_problem_cls
             )
-            state = self._sim_container.get_state(associated_active_id)
-            self._sim_container.set_state(lid, state)
+            state = self._sim_container.get_sim_state(associated_active_id)
+            self._sim_container.set_sim_state(lid, state)
             # Active sim cannot have an associated sim
             self._sim_is_associated_to[lid] = -2
 

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -317,7 +317,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         # Delete the inactive micro simulations which have not been activated
         for lid in range(self._is_sim_active.size):
-            if not self._is_sim_active[lid]:
+            if not self._is_sim_active[lid] and self._sim_container[lid] is not None:
                 # Release resources now, especially for remote simulation instance.
                 # If left to garbage collector this might lead to a race condition.
                 # Releasing with call to sim.destroy(), afterwards reference in sim

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -13,13 +13,14 @@ from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.model_manager import ModelManager
 from micro_manager.interpolation import RBF_PU
+from micro_manager.simulation_container import SimulationContainer
 
 
 class LocalAdaptivityCalculator(AdaptivityCalculator):
     def __init__(
         self,
         config: Config,
-        num_sims: int,
+        sim_container: SimulationContainer,
         base_logger: Logger,
         rank: int,
         comm: MPI.Comm,
@@ -33,8 +34,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         config : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
-        num_sims : int
-            Number of micro simulations.
+        sim_container : SimulationContainer
+            Simulation container object.
         base_logger : object of class Logger
             Logger object to log messages.
         rank : int
@@ -47,7 +48,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             Handles instantiation of micro simulation.
         """
         super().__init__(
-            config, num_sims, micro_problem_cls, model_manager, base_logger, rank
+            config, sim_container.local_num_sims, sim_container, micro_problem_cls, model_manager, base_logger, rank
         )
         self._comm = comm
         self._interpolation = RBF_PU(
@@ -59,12 +60,11 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         # similarity_dists: 2D array having similarity distances between each micro simulation pair
         # This matrix is modified in place via the function update_similarity_dists
-        self._similarity_dists = np.zeros((num_sims, num_sims))
+        self._similarity_dists = np.zeros((sim_container.local_num_sims, sim_container.local_num_sims))
 
     def compute_adaptivity(
         self,
         dt: float,
-        micro_sims: list,
         data_for_adaptivity: dict,
     ) -> None:
         """
@@ -74,8 +74,6 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         dt : float
             Current time step
-        micro_sims : list
-            List containing simulation objects
         data_for_adaptivity : dict
             A dictionary containing the names of the data to be used in adaptivity as keys and information on whether
             the data are scalar or vector as values.
@@ -99,7 +97,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         self._update_active_sims()
 
-        self._update_inactive_sims(micro_sims)
+        self._update_inactive_sims()
 
         self._associate_inactive_to_active()
 
@@ -273,18 +271,13 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
                 # Remove deactivated gid from further checks
                 active_gids_to_check.remove(gid)
 
-    def _update_inactive_sims(self, micro_sims: list) -> None:
+    def _update_inactive_sims(self) -> None:
         """
         Update set of inactive micro simulations. Each inactive micro simulation is compared to all active ones
         and if it is not similar to any of them, it is activated.
 
         If a micro simulation which has been inactive since the start of the simulation is activated for the
         first time, the simulation object is created and initialized.
-
-        Parameters
-        ----------
-        micro_sims : list
-            List containing micro simulation objects.
         """
         self._ref_tol = self._refine_const * self._max_similarity_dist
 
@@ -304,21 +297,20 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         self._just_deactivated.clear()  # Clear the list of sims deactivated in this step
 
         # Update the set of inactive micro sims
-        for i in to_be_activated_ids:
-            associated_active_id = self._sim_is_associated_to[i]
-            micro_sims[i] = self._model_manager.get_instance(i, self._micro_problem_cls)
-            micro_sims[i].set_state(micro_sims[associated_active_id].get_state())
-            self._sim_is_associated_to[
-                i
-            ] = -2  # Active sim cannot have an associated sim
+        for lid in to_be_activated_ids:
+            associated_active_id = self._sim_is_associated_to[lid]
+            self._sim_container[lid] = self._model_manager.get_instance(lid, self._micro_problem_cls)
+            state = self._sim_container.get_state(associated_active_id)
+            self._sim_container.set_state(lid, state)
+            # Active sim cannot have an associated sim
+            self._sim_is_associated_to[lid] = -2
 
         # Delete the inactive micro simulations which have not been activated
-        for i in range(self._is_sim_active.size):
-            if not self._is_sim_active[i]:
+        for lid in range(self._is_sim_active.size):
+            if not self._is_sim_active[lid]:
                 # Release resources now, especially for remote simulation instance.
                 # If left to garbage collector this might lead to a race condition.
                 # Releasing with call to sim.destroy(), afterwards reference in sim
                 # sim list can be removed.
-                if type(micro_sims[i]).__name__ == "MicroSimulationWrapper":
-                    micro_sims[i].destroy()
-                micro_sims[i] = None
+                self._sim_container[lid].destroy()
+                self._sim_container[lid] = None

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -200,7 +200,7 @@ class ModelAdaptivity:
 
             # check if a state of the target resolution exists
             # then update state buffer with current state
-            state_dict = self._sim_container.get_state(lid)
+            state_dict = self._sim_container.get_sim_state(lid)
             new_state_exists = key_new in state_dict
 
             # construct new sim and delay initialization if possible

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -176,7 +176,9 @@ class ModelAdaptivity:
             List of lids of simulations that were switched.
         """
         locations = self._sim_container.local_coords
-        active_sims = self._create_active_mask(active_sim_ids, self._sim_container.local_num_sims)
+        active_sims = self._create_active_mask(
+            active_sim_ids, self._sim_container.local_num_sims
+        )
         current_res = self._gather_current_resolutions(active_sims)
         target_res = self._gather_target_resolutions(
             current_res, locations, t, inputs, prev_output, active_sims
@@ -243,7 +245,9 @@ class ModelAdaptivity:
             List of all active simulation ids.
         """
         locations = self._sim_container.local_coords
-        active_sims = self._create_active_mask(active_sim_ids, self._sim_container.local_num_sims)
+        active_sims = self._create_active_mask(
+            active_sim_ids, self._sim_container.local_num_sims
+        )
         resolutions = self._gather_current_resolutions(active_sims)
         target_resolutions = self._gather_target_resolutions(
             resolutions, locations, t, inputs, prev_output, active_sims
@@ -301,9 +305,7 @@ class ModelAdaptivity:
             (idx for idx, cls in enumerate(self._model_classes) if cls.name == sim.name)
         )
 
-    def _gather_current_resolutions(
-        self, active_sims: np.ndarray
-    ) -> np.ndarray:
+    def _gather_current_resolutions(self, active_sims: np.ndarray) -> np.ndarray:
         """
         Gathers current resolutions. Inactive sims have resolution -1.
 
@@ -319,7 +321,9 @@ class ModelAdaptivity:
         """
         return np.array(
             [
-                self.get_sim_class_resolution(self._sim_container[lid]) if active_sims[lid] == 1 else -1
+                self.get_sim_class_resolution(self._sim_container[lid])
+                if active_sims[lid] == 1
+                else -1
                 for lid in self._sim_container.range_lid
             ]
         )

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -13,6 +13,7 @@ from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.misc import clamp_in_range
 from micro_manager.model_manager import ModelManager
 from micro_manager.tasking.connection import Connection
+from micro_manager.simulation_container import SimulationContainer
 
 from mpi4py import MPI
 import numpy as np
@@ -23,6 +24,7 @@ class ModelAdaptivity:
     def __init__(
         self,
         model_manager: ModelManager,
+        sim_container: SimulationContainer,
         config: Config,
         comm: MPI.Comm,
         rank: int,
@@ -37,6 +39,8 @@ class ModelAdaptivity:
         ----------
         model_manager: ModelManager
             ModelManager instance
+        sim_container: SimulationContainer
+            SimulationContainer instance
         config : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
         comm: MPI.Comm
@@ -54,6 +58,7 @@ class ModelAdaptivity:
 
         self._comm = comm
         self._model_manager = model_manager
+        self._sim_container = sim_container
         self._model_files = config.model_adaptivity_file_names()
         self._switching_func_name = config.model_adaptivity_switching_function()
 
@@ -142,11 +147,9 @@ class ModelAdaptivity:
 
     def switch_models(
         self,
-        locations: np.ndarray,
         t: float,
         inputs: list[dict],
         prev_output: Optional[list[dict]],
-        sims: list,
         active_sim_ids: Optional[list] = None,
     ) -> list[int]:
         """
@@ -172,112 +175,56 @@ class ModelAdaptivity:
         switched_lids : list[int]
             List of lids of simulations that were switched.
         """
-        size = len(sims)
-        active_sims = self._create_active_mask(active_sim_ids, size)
-        current_res = self._gather_current_resolutions(sims, active_sims)
+        locations = self._sim_container.local_coords
+        active_sims = self._create_active_mask(active_sim_ids, self._sim_container.local_num_sims)
+        current_res = self._gather_current_resolutions(active_sims)
         target_res = self._gather_target_resolutions(
             current_res, locations, t, inputs, prev_output, active_sims
         )
 
         self._logger.log_info(f"New resolutions for t={t}: {target_res}")
 
-        for idx in range(size):
-            if current_res[idx] == target_res[idx]:
+        for lid in self._sim_container.range_lid:
+            if current_res[lid] == target_res[lid]:
                 continue
 
-            sim = sims[idx]
-            gid = sim.get_global_id()
-            target_class = self.get_resolution_sim_class(target_res[idx])
+            sim = self._sim_container[lid]
+            gid = self._sim_container.local_gids[lid]
+            target_class = self.get_resolution_sim_class(target_res[lid])
 
             # we store state for each resolution separately
             # keys are sim names of respective resolution
-            key = f"{sim.name}-state"
             key_new = f"{target_class.name}-state"
 
             # check if a state of the target resolution exists
             # then update state buffer with current state
-            new_state_exists = key_new in sim.attachments
-            sim.attachments[key] = sim.get_state()
+            state_dict = self._sim_container.get_state(lid)
+            new_state_exists = key_new in state_dict
 
             # construct new sim and delay initialization if possible
             sim_new = self._model_manager.get_instance(
                 gid, target_class, late_init=new_state_exists
             )
-            # need to copy over the multi-state buffer to new sim object
-            sim_new.attachments = sim.attachments
-            sim_new.attachments[key_new] = sim_new.get_state()
 
             # if state of target resolution exists
             # use it to initialize
             if new_state_exists:
-                sim_new_state = sim.attachments[key_new]
+                sim_new_state = state_dict[key_new]
                 sim_new.set_state(sim_new_state)
+            else:
+                state_dict[key_new] = sim_new.get_state()
 
             # release resources of previous sim and set to new sim
-            sims[idx].destroy()
-            sims[idx] = sim_new
+            sim.destroy()
+            self._sim_container[lid] = sim_new
 
         return np.flatnonzero(current_res != target_res).tolist()
 
-    def update_states(
-        self,
-        sims: list,
-        active_sim_ids: Optional[list] = None,
-    ):
-        """
-        Updates the current state of the current model in the local buffers.
-
-        Parameters
-        ----------
-        sims : list
-            List of all simulation objects.
-        active_sim_ids : [list, None]
-            List of all active simulation ids.
-        """
-        size = len(sims)
-        active_sims = self._create_active_mask(active_sim_ids, size)
-
-        for idx in range(size):
-            if not active_sims[idx]:
-                continue
-
-            sim = sims[idx]
-            key = f"{sim.name}-state"
-            sim.attachments[key] = sim.get_state()
-
-    def write_back_states(
-        self,
-        sims: list,
-        active_sim_ids: Optional[list] = None,
-    ):
-        """
-        Loads the current state of the current model into local buffers.
-
-        Parameters
-        ----------
-        sims : list
-            List of all simulation objects.
-        active_sim_ids : [list, None]
-            List of all active simulation ids.
-        """
-        size = len(sims)
-        active_sims = self._create_active_mask(active_sim_ids, size)
-
-        for idx in range(size):
-            if not active_sims[idx]:
-                continue
-
-            sim = sims[idx]
-            key = f"{sim.name}-state"
-            sim.set_state(sim.attachments[key])
-
     def check_convergence(
         self,
-        locations: np.ndarray,
         t: float,
         inputs: list,
         prev_output: Optional[list[dict]],
-        sims: list,
         active_sim_ids: Optional[list] = None,
     ) -> None:
         """
@@ -286,22 +233,18 @@ class ModelAdaptivity:
 
         Parameters
         ----------
-        locations : np.array - shape(N,D)
-            Array with gaussian points for all sims. D is the mesh dimension.
         t : float
             Current time in simulation.
         inputs : list[dict]
             List of all input objects.
         prev_output : [None, list[dict]]
             Contains the outputs of the previous model evaluation.
-        sims : list
-            List of all simulation objects.
         active_sim_ids : [list, None]
             List of all active simulation ids.
         """
-        size = len(sims)
-        active_sims = self._create_active_mask(active_sim_ids, size)
-        resolutions = self._gather_current_resolutions(sims, active_sims)
+        locations = self._sim_container.local_coords
+        active_sims = self._create_active_mask(active_sim_ids, self._sim_container.local_num_sims)
+        resolutions = self._gather_current_resolutions(active_sims)
         target_resolutions = self._gather_target_resolutions(
             resolutions, locations, t, inputs, prev_output, active_sims
         )
@@ -359,15 +302,13 @@ class ModelAdaptivity:
         )
 
     def _gather_current_resolutions(
-        self, sims: list, active_sims: np.ndarray
+        self, active_sims: np.ndarray
     ) -> np.ndarray:
         """
         Gathers current resolutions. Inactive sims have resolution -1.
 
         Parameters
         ----------
-        sims : list
-            List of all simulation objects.
         active_sims : np.array
             Boolean array indicating whether the model is active or not.
 
@@ -378,8 +319,8 @@ class ModelAdaptivity:
         """
         return np.array(
             [
-                self.get_sim_class_resolution(sim) if active_sims[idx] == 1 else -1
-                for idx, sim in enumerate(sims)
+                self.get_sim_class_resolution(self._sim_container[lid]) if active_sims[lid] == 1 else -1
+                for lid in self._sim_container.range_lid
             ]
         )
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -709,7 +709,7 @@ class Config:
                 "Adaptivity settings are provided but adaptivity is turned off."
             )
 
-        if self.enable_adaptivity():
+        with self.show_log_if(self.enable_adaptivity()):
             self.adaptivity_type.set = self.json["simulation_params"][
                 "adaptivity_settings"
             ]["type"].get_with_default(

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -709,7 +709,7 @@ class Config:
                 "Adaptivity settings are provided but adaptivity is turned off."
             )
 
-        with self.show_log_if(self.enable_adaptivity()):
+        if self.enable_adaptivity():
             self.adaptivity_type.set = self.json["simulation_params"][
                 "adaptivity_settings"
             ]["type"].get_with_default(

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -210,7 +210,10 @@ class LoadBalancer:
             "micro_manager.solve.load_balancing.init"
         )
         current_partitioning = get_ranks_of_sims(
-            self._sim_container.local_gids, self._rank, self._comm, self._sim_container.global_num_sims
+            self._sim_container.local_gids,
+            self._rank,
+            self._comm,
+            self._sim_container.global_num_sims,
         )
         # self._precice_participant.start_profiling_section("micro_manager.solve.load_balancing.init.partition")
         target_partitioning, work_loads = self._partition_impl(
@@ -305,9 +308,9 @@ class LoadBalancer:
             list of global inactive gids
         """
         global_active_gids = set(self._get_global_active_gids())
-        global_inactive_gids = set(np.arange(self._sim_container.global_num_sims)).difference(
-            global_active_gids
-        )
+        global_inactive_gids = set(
+            np.arange(self._sim_container.global_num_sims)
+        ).difference(global_active_gids)
         return list(global_inactive_gids)
 
     def _exchange_sims(self, send_map, recv_map, inactive_map={}):
@@ -586,7 +589,10 @@ class ActiveBalancer(LoadBalancer):
         send_map: dict[int, int] = dict()
         recv_map: dict[int, int] = dict()
         ranks_of_sims = get_ranks_of_sims(
-            self._sim_container.local_gids, self._rank, self._comm, self._sim_container.global_num_sims
+            self._sim_container.local_gids,
+            self._rank,
+            self._comm,
+            self._sim_container.global_num_sims,
         )
         global_ids_of_inactive_sims = self._get_global_inactive_gids()
 

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -11,6 +11,7 @@ from micro_manager.adaptivity.adaptivity import AdaptivityCalculator
 from micro_manager.model_manager import ModelManager
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.p2p import create_tag, get_ranks_of_sims
+from micro_manager.simulation_container import SimulationContainer
 
 
 class LoadBalancer:
@@ -19,13 +20,9 @@ class LoadBalancer:
         precice_participant: Participant,
         model_manager: ModelManager,
         adaptivity_controller: Optional[AdaptivityCalculator],
-        state_loader: callable,
-        state_setter: callable,
+        sim_container: SimulationContainer,
         log: Logger,
         config: Config,
-        sim_list: list,
-        global_ids: list,
-        global_number_of_sims: int,
         comm: MPI.Comm,
         rank: int,
     ):
@@ -41,20 +38,10 @@ class LoadBalancer:
             model manager object to construct instances
         adaptivity_controller: Optional[AdaptivityCalculator]
             handles adaptivity calculation if provided
-        state_loader: callable
-            loads state from micro simulation
-        state_setter: callable
-            sets state of micro simulation
         log: Logger
             logger object
         config: Config
             configuration object
-        sim_list: list
-            list of simulation objects
-        global_ids: list
-            list of global ids on this rank
-        global_number_of_sims: int
-            total number of simulations in this run
         comm: MPI.Comm
             used MPI communicator
         rank: int
@@ -64,19 +51,15 @@ class LoadBalancer:
         self._precice_participant = precice_participant
         self._model_manager = model_manager
         self._adaptivity_controller = adaptivity_controller
-        self._state_loader = state_loader
-        self._state_setter = state_setter
+        self._sim_container = sim_container
         self._log = log
         self._config = config
-        self._sim_list = sim_list
-        self._global_ids = global_ids
-        self._global_number_of_sims = global_number_of_sims
         self._comm = comm
         self._rank = rank
 
         self._threshold = None  # provided by sub-cls
         self._balance_metric_local = dict()
-        self._balance_metric_global = np.zeros(global_number_of_sims)
+        self._balance_metric_global = np.zeros(self._sim_container.global_num_sims)
         self._partition_impl = self.get_partition_impl(
             config.load_balancing_partitioning()
         )
@@ -176,7 +159,7 @@ class LoadBalancer:
             ::-1
         ]  # descending
         workload_per_partition = np.zeros(n_parts)
-        assignment = np.zeros(self._global_number_of_sims, dtype=np.int32)
+        assignment = np.zeros(self._sim_container.global_num_sims, dtype=np.int32)
 
         for idx in sorted_workload_indices:
             # get current smallest partition
@@ -211,7 +194,7 @@ class LoadBalancer:
         workload_per_partition = np.zeros(n_parts)
         workload_per_partition[0] = np.sum(self._balance_metric_global)
         return (
-            np.zeros(self._global_number_of_sims, dtype=np.int32),
+            np.zeros(self._sim_container.global_num_sims, dtype=np.int32),
             workload_per_partition,
         )
 
@@ -227,7 +210,7 @@ class LoadBalancer:
             "micro_manager.solve.load_balancing.init"
         )
         current_partitioning = get_ranks_of_sims(
-            self._global_ids, self._rank, self._comm, self._global_number_of_sims
+            self._sim_container.local_gids, self._rank, self._comm, self._sim_container.global_num_sims
         )
         # self._precice_participant.start_profiling_section("micro_manager.solve.load_balancing.init.partition")
         target_partitioning, work_loads = self._partition_impl(
@@ -246,7 +229,7 @@ class LoadBalancer:
         self._exchange_sims(send_map, recv_map, {gid: True for gid in inactive_gids})
         self._precice_participant.stop_last_profiling_section()
 
-        sims_per_rank = self._comm.gather(len(self._sim_list), 0)
+        sims_per_rank = self._comm.gather(len(self._sim_container), 0)
         self._log.log_info_rank_zero(
             f"Load Balancing Number of Simulations per Rank: {sims_per_rank}"
         )
@@ -299,11 +282,11 @@ class LoadBalancer:
         active_gid_arr = None
         if self._adaptivity_controller is not None:
             active_gid_arr = [
-                self._global_ids[i]
+                self._sim_container.local_gids[i]
                 for i in self._adaptivity_controller.get_active_sim_local_ids()
             ]
         else:
-            active_gid_arr = self._global_ids
+            active_gid_arr = self._sim_container.local_gids
 
         # bcast to all and merge
         tmp = self._comm.allgather(active_gid_arr)
@@ -322,7 +305,7 @@ class LoadBalancer:
             list of global inactive gids
         """
         global_active_gids = set(self._get_global_active_gids())
-        global_inactive_gids = set(np.arange(self._global_number_of_sims)).difference(
+        global_inactive_gids = set(np.arange(self._sim_container.global_num_sims)).difference(
             global_active_gids
         )
         return list(global_inactive_gids)
@@ -345,11 +328,12 @@ class LoadBalancer:
         send_reqs = []
         for gid, send_rank in send_map.items():
             tag = create_tag(gid, self._rank, send_rank)
-            lid = self._global_ids.index(gid)
+            lid = self._sim_container.local_gids.index(gid)
 
             # prepare send data
             is_inactive = inactive_map[gid] if gid in inactive_map else False
-            cls_name = None if is_inactive else self._sim_list[lid].name
+            cls_name = None if is_inactive else self._sim_container[lid].name
+            coord = self._sim_container.local_coords[lid]
             is_stateless = (
                 None if is_inactive else self._model_manager.is_stateless(cls_name)
             )
@@ -358,9 +342,10 @@ class LoadBalancer:
                 is_stateless,
                 None
                 if is_stateless or is_inactive
-                else self._state_loader(self._sim_list[lid]),
+                else self._sim_container.get_state(lid),
                 cls_name,
                 gid,
+                coord,
             )
 
             req = self._comm.isend(send_data, dest=send_rank, tag=tag)
@@ -381,28 +366,19 @@ class LoadBalancer:
 
         # Delete the simulations which no longer exist on this rank
         for gid in send_map.keys():
-            lid = self._global_ids.index(gid)
-            is_active = gid not in inactive_map
-            if is_active:
-                self._sim_list[lid].destroy()
-            del self._sim_list[lid]
-            self._global_ids.remove(gid)
-            if self._adaptivity_controller is not None:
-                self._adaptivity_controller.set_is_on_rank(gid, False)
+            lid = self._sim_container.local_gids.index(gid)
+            self._sim_container.remove_sim(lid)
 
         # Create simulations and set them to the received states
         for req in recv_reqs:
-            is_inactive, is_stateless, state, cls_name, gid = req.wait()
-            self._sim_list.append(
-                None
-                if is_inactive
-                else self._model_manager.get_instance_by_name(gid, cls_name)
-            )
+            is_inactive, is_stateless, state, cls_name, gid, coord = req.wait()
+            sim = None
+            if not is_inactive:
+                sim = self._model_manager.get_instance_by_name(gid, cls_name)
+            lid = self._sim_container.add_sim(gid, sim, coord)
+
             if not is_stateless and state is not None:
-                self._state_setter(self._sim_list[-1], state)
-            self._global_ids.append(gid)
-            if self._adaptivity_controller is not None:
-                self._adaptivity_controller.set_is_on_rank(gid, True)
+                self._sim_container.set_state(lid, state)
 
 
 class ActiveBalancer(LoadBalancer):
@@ -415,13 +391,9 @@ class ActiveBalancer(LoadBalancer):
         precice_participant: Participant,
         model_manager: ModelManager,
         adaptivity_controller: Optional[AdaptivityCalculator],
-        state_loader: callable,
-        state_setter: callable,
+        sim_container: SimulationContainer,
         log: Logger,
         config: Config,
-        sim_list: list,
-        global_ids: list,
-        global_number_of_sims: int,
         comm: MPI.Comm,
         rank: int,
     ):
@@ -429,13 +401,9 @@ class ActiveBalancer(LoadBalancer):
             precice_participant,
             model_manager,
             adaptivity_controller,
-            state_loader,
-            state_setter,
+            sim_container,
             log,
             config,
-            sim_list,
-            global_ids,
-            global_number_of_sims,
             comm,
             rank,
         )
@@ -618,7 +586,7 @@ class ActiveBalancer(LoadBalancer):
         send_map: dict[int, int] = dict()
         recv_map: dict[int, int] = dict()
         ranks_of_sims = get_ranks_of_sims(
-            self._global_ids, self._rank, self._comm, self._global_number_of_sims
+            self._sim_container.local_gids, self._rank, self._comm, self._sim_container.global_num_sims
         )
         global_ids_of_inactive_sims = self._get_global_inactive_gids()
 
@@ -706,13 +674,9 @@ def create_load_balancer(
     precice_participant: Participant,
     model_manager: ModelManager,
     adaptivity_controller: Optional[AdaptivityCalculator],
-    state_loader: callable,
-    state_setter: callable,
+    sim_container: SimulationContainer,
     log: Logger,
     config: Config,
-    sim_list: list,
-    global_ids: list,
-    global_number_of_sims: int,
     comm: MPI.Comm,
     rank: int,
 ) -> LoadBalancer:
@@ -729,13 +693,9 @@ def create_load_balancer(
         precice_participant,
         model_manager,
         adaptivity_controller,
-        state_loader,
-        state_setter,
+        sim_container,
         log,
         config,
-        sim_list,
-        global_ids,
-        global_number_of_sims,
         comm,
         rank,
     )

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -345,7 +345,7 @@ class LoadBalancer:
                 is_stateless,
                 None
                 if is_stateless or is_inactive
-                else self._sim_container.get_state(lid),
+                else self._sim_container.get_sim_state(lid),
                 cls_name,
                 gid,
                 coord,
@@ -381,7 +381,7 @@ class LoadBalancer:
             lid = self._sim_container.add_sim(gid, sim, coord)
 
             if not is_stateless and state is not None:
-                self._sim_container.set_state(lid, state)
+                self._sim_container.set_sim_state(lid, state)
 
 
 class ActiveBalancer(LoadBalancer):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -23,6 +23,7 @@ from functools import partial
 
 import precice
 
+from .simulation_container import SimulationContainer
 from .model_manager import ModelManager
 from .micro_manager_base import MicroManager
 
@@ -143,16 +144,13 @@ class MicroManagerCoupling(MicroManager):
 
         self._model_manager = ModelManager()
         self._conn = None
-        self.state_loader = lambda sim: sim.get_state()
-        self.state_setter = lambda sim, state: sim.set_state(state)
-        if self._is_model_adaptivity_on:
-            self.state_loader = lambda sim: sim.attachments
-            self.state_setter = lambda sim, state: sim.attachments.update(state)
         self._is_load_balancing = (
             self._config.enable_load_balancing() and self._is_parallel
         )
         self._load_balancing_n = self._config.load_balancing_n()
         self.load_balancing = None
+
+        self._sim_container = SimulationContainer()
 
     # **************
     # Public methods
@@ -166,14 +164,12 @@ class MicroManagerCoupling(MicroManager):
         - If adaptivity is on, compute micro simulations adaptively.
         """
         self._t = self._n = 0
-        sim_states_cp = [None] * self._local_number_of_sims
         mem_usage: list = []
         mem_usage_n = []
 
         process = Process()
 
         micro_sim_solve = self._get_solve_variant()
-        # TODO adapt variant to also use special mada case, iterates in itself and will prob
         # call _solve_micro_simulations or _solve_micro_simulations_with_adaptivity internally
         # should use ModelAdaptivity methods to coordinate
 
@@ -200,7 +196,6 @@ class MicroManagerCoupling(MicroManager):
 
                     self._adaptivity_controller.compute_adaptivity(
                         dt,
-                        self._micro_sims,
                         self._data_for_adaptivity,
                     )
                     active_sim_gids = (
@@ -211,16 +206,7 @@ class MicroManagerCoupling(MicroManager):
 
                     # Write a checkpoint if a simulation is just activated.
                     # This checkpoint will be asynchronous to the checkpoints written at the start of the time window.
-                    if self._is_model_adaptivity_on:
-                        active_sim_lids = (
-                            self._adaptivity_controller.get_active_sim_local_ids()
-                        )
-                        self._model_adaptivity_controller.update_states(
-                            self._micro_sims, active_sim_lids
-                        )
-                    for i in range(self._local_number_of_sims):
-                        if sim_states_cp[i] is None and self._micro_sims[i]:
-                            sim_states_cp[i] = self.state_loader(self._micro_sims[i])
+                    self._sim_container.write_checkpoints(only_none=True)
 
                     self._participant.stop_last_profiling_section()
 
@@ -229,38 +215,23 @@ class MicroManagerCoupling(MicroManager):
             if lb_counter % self._load_balancing_n == 0 or first_iteration:
                 # self._participant.start_profiling_section("micro_manager.solve.load_balancing")
                 self.load_balancing.balance()
-                self._local_number_of_sims = len(self._global_ids_of_local_sims)
-                self._is_rank_empty = self._local_number_of_sims == 0
+
                 # Reset simulation state checkpoints after load balancing
-                sim_states_cp = [None] * self._local_number_of_sims
+                self._sim_container.clear_checkpoints()
                 if self._is_adaptivity_on:
                     for name in self._adaptivity_data_names:
                         self._data_for_adaptivity[name] = [
                             0
-                        ] * self._local_number_of_sims
+                        ] * self._sim_container.local_num_sims
                 # Reset simulation crash state information after load balancing
-                self._has_sim_crashed = [False] * self._local_number_of_sims
+                self._has_sim_crashed = [False] * self._sim_container.local_num_sims
                 # self._participant.stop_last_profiling_section()
                 performed_lb = True
             lb_counter += 1
 
             # Write a checkpoint
             if self._participant.requires_writing_checkpoint() or performed_lb:
-                if self._is_model_adaptivity_on:
-                    active_sim_lids = None
-                    if self._is_adaptivity_on:
-                        active_sim_lids = (
-                            self._adaptivity_controller.get_active_sim_local_ids()
-                        )
-                    self._model_adaptivity_controller.update_states(
-                        self._micro_sims, active_sim_lids
-                    )
-                for i in range(self._local_number_of_sims):
-                    sim_states_cp[i] = (
-                        self.state_loader(self._micro_sims[i])
-                        if self._micro_sims[i]
-                        else None
-                    )
+                self._sim_container.write_checkpoints()
 
             micro_sims_input = self._read_data_from_precice(dt)
 
@@ -274,7 +245,7 @@ class MicroManagerCoupling(MicroManager):
             self._participant.stop_last_profiling_section()
 
             if self._is_load_balancing:
-                for i in range(self._local_number_of_sims):
+                for i in range(self._sim_container.local_num_sims):
                     micro_sims_output[i]["rank_of_sim"] = self._rank
 
             # Check if more than a certain percentage of the micro simulations have crashed and terminate if threshold is exceeded
@@ -286,7 +257,7 @@ class MicroManagerCoupling(MicroManager):
 
                 if self._is_parallel:
                     crash_ratio = (
-                        np.sum(crashed_sims_on_all_ranks) / self._global_number_of_sims
+                        np.sum(crashed_sims_on_all_ranks) / self._sim_container.global_num_sims
                     )
                 else:
                     crash_ratio = np.sum(self._has_sim_crashed) / len(
@@ -306,20 +277,7 @@ class MicroManagerCoupling(MicroManager):
 
             # Revert micro simulations to their last checkpoints if required
             if self._participant.requires_reading_checkpoint():
-                for i in range(self._local_number_of_sims):
-                    if self._micro_sims[i]:
-                        self.state_setter(self._micro_sims[i], sim_states_cp[i])
-
-                if self._is_model_adaptivity_on:
-                    active_sim_lids = None
-                    if self._is_adaptivity_on:
-                        active_sim_lids = (
-                            self._adaptivity_controller.get_active_sim_local_ids()
-                        )
-                    self._model_adaptivity_controller.write_back_states(
-                        self._micro_sims, active_sim_lids
-                    )
-
+                self._sim_container.load_checkpoints()
                 first_iteration = False
 
             # Time window has converged, now micro output can be generated
@@ -329,8 +287,9 @@ class MicroManagerCoupling(MicroManager):
 
                 if self._micro_sims_have_output:
                     if self._n % self._micro_n_out == 0:
-                        for sim in self._micro_sims:
-                            if sim:
+                        for lid in self._sim_container.range_lid:
+                            sim = self._sim_container[lid]
+                            if sim is not None:
                                 sim.output()
 
                 if (
@@ -495,7 +454,6 @@ class MicroManagerCoupling(MicroManager):
 
         if self._mesh_vertex_coords.size == 0:
             if self._is_parallel:
-                self._is_rank_empty = True
                 self._logger.log_warning(
                     "The access region of this rank has no macro-scale vertices. This rank will not have any micro simulations. To avoid this, change the domain decomposition"
                 )
@@ -510,19 +468,20 @@ class MicroManagerCoupling(MicroManager):
 
         if self._is_load_balancing and self._is_parallel:
             (
-                self._local_number_of_sims,
+                local_number_of_sims,
                 local_macro_coords,
             ) = domain_decomposer.get_local_sims_and_macro_coords(
                 self._mesh_vertex_coords
             )
         else:
-            self._local_number_of_sims, _ = self._mesh_vertex_coords.shape
+            local_number_of_sims, _ = self._mesh_vertex_coords.shape
+            local_macro_coords = self._mesh_vertex_coords
 
         nms_all_ranks = np.zeros(self._size, dtype=np.int64)
         # Gather number of micro simulations that each rank has, because this rank needs to know how many micro
         # simulations have been created by previous ranks, so that it can set
         # the correct global IDs
-        self._comm.Allgatherv(np.array(self._local_number_of_sims), nms_all_ranks)
+        self._comm.Allgatherv(np.array(local_number_of_sims), nms_all_ranks)
 
         max_nms = np.max(nms_all_ranks)
         min_nms = np.min(nms_all_ranks)
@@ -548,18 +507,18 @@ class MicroManagerCoupling(MicroManager):
             )
 
         # Get global number of micro simulations
-        self._global_number_of_sims: int = np.sum(nms_all_ranks)
+        global_number_of_sims = np.sum(nms_all_ranks)
 
         self._logger.log_info_rank_zero(
-            "Total number of micro simulations: {}".format(self._global_number_of_sims)
+            "Total number of micro simulations: {}".format(global_number_of_sims)
         )
 
         if self._is_adaptivity_on:
             for name in self._adaptivity_data_names:
-                self._data_for_adaptivity[name] = [0] * self._local_number_of_sims
+                self._data_for_adaptivity[name] = [0] * local_number_of_sims
 
         # Create lists of global IDs
-        self._global_ids_of_local_sims = []  # DECLARATION
+        global_ids_of_local_sims = []  # DECLARATION
 
         if self._is_load_balancing:
             # Create a set of global coordinate indices for faster lookup
@@ -570,15 +529,22 @@ class MicroManagerCoupling(MicroManager):
             # Set global IDs based on the coordinate ordering in preCICE to be consistent with the scenario without load balancing
             for coords in local_macro_coords:
                 coord_tuple = tuple(coords)
-                self._global_ids_of_local_sims.append(coord_to_index[coord_tuple])
+                global_ids_of_local_sims.append(coord_to_index[coord_tuple])
         else:
             sim_id = np.sum(nms_all_ranks[: self._rank])
-            for i in range(self._local_number_of_sims):
-                self._global_ids_of_local_sims.append(sim_id)
+            for i in range(local_number_of_sims):
+                global_ids_of_local_sims.append(sim_id)
                 sim_id += 1
 
+        self._sim_container.initialize(
+            glob_num_sims=global_number_of_sims,
+            local_num_sims=local_number_of_sims,
+            local_gids=global_ids_of_local_sims,
+            local_coords=local_macro_coords,
+        )
+
         # Setup for simulation crashes
-        self._has_sim_crashed = [False] * self._local_number_of_sims
+        self._has_sim_crashed = [False] * self._sim_container.local_num_sims
         if self._interpolate_crashed_sims:
             self._interpolant = Interpolation(self._logger)
 
@@ -600,6 +566,7 @@ class MicroManagerCoupling(MicroManager):
         if self._is_model_adaptivity_on:
             self._model_adaptivity_controller: ModelAdaptivity = ModelAdaptivity(
                 self._model_manager,
+                self._sim_container,
                 self._config,
                 self._comm,
                 self._rank,
@@ -625,19 +592,16 @@ class MicroManagerCoupling(MicroManager):
             )
 
         # Create micro simulation objects
-        self._micro_sims = [None] * self._local_number_of_sims
         if not self._lazy_init:
-            for i in range(self._local_number_of_sims):
-                self._micro_sims[i] = self._model_manager.get_instance(
-                    self._global_ids_of_local_sims[i], micro_problem_cls
+            for lid in self._sim_container.range_lid:
+                self._sim_container[lid] = self._model_manager.get_instance(
+                    self._sim_container.local_gids[lid], micro_problem_cls
                 )
 
         if self._is_adaptivity_on:
             self._adaptivity_controller = create_adaptivity_calculator(
                 self._config,
-                self._local_number_of_sims,
-                self._global_number_of_sims,
-                self._global_ids_of_local_sims,
+                self._sim_container,
                 self._participant,
                 self._logger,
                 self._rank,
@@ -647,7 +611,7 @@ class MicroManagerCoupling(MicroManager):
             )
 
             self._micro_sims_active_steps = np.zeros(
-                self._global_number_of_sims
+                self._sim_container.global_num_sims
             )  # DECLARATION
 
         self._micro_sims_init = False  # DECLARATION
@@ -657,7 +621,7 @@ class MicroManagerCoupling(MicroManager):
 
         first_id = 0  # 0 if lazy initialization is off, otherwise the first active simulation ID
         micro_sims_to_init = range(
-            1, self._local_number_of_sims
+            1, self._sim_container.local_num_sims
         )  # All sims if lazy init is off, otherwise all active simulations
 
         # Additional bool to check if there are sims to init
@@ -675,12 +639,12 @@ class MicroManagerCoupling(MicroManager):
 
             # For lazy initialization, compute adaptivity with the initial macro data
             if self._lazy_init:
-                for i in range(self._local_number_of_sims):
+                for i in self._sim_container.range_lid:
                     for name in self._adaptivity_macro_data_names:
                         self._data_for_adaptivity[name][i] = initial_macro_data[i][name]
 
                 self._adaptivity_controller.compute_adaptivity(
-                    self._micro_dt, self._micro_sims, self._data_for_adaptivity
+                    self._micro_dt, self._data_for_adaptivity
                 )
 
                 active_sim_lids = self._adaptivity_controller.get_active_sim_local_ids()
@@ -693,13 +657,8 @@ class MicroManagerCoupling(MicroManager):
                     are_there_sims_to_init = False
                 else:
                     for i in active_sim_lids:
-                        self._micro_sims[i] = micro_problem_cls(
-                            self._global_ids_of_local_sims[i]
-                        )
-
-                    for i in active_sim_lids:
-                        self._micro_sims[i] = self._model_manager.get_instance(
-                            self._global_ids_of_local_sims[i], micro_problem_cls
+                        self._sim_container[i] = self._model_manager.get_instance(
+                            self._sim_container.local_gids[i], micro_problem_cls
                         )
 
                     first_id = active_sim_lids[0]  # First active simulation ID
@@ -709,7 +668,7 @@ class MicroManagerCoupling(MicroManager):
                     are_there_sims_to_init = True
 
         test_instance = self._model_manager.get_instance(
-            self._global_number_of_sims + 1, micro_problem_cls
+            self._sim_container.global_num_sims + 1, micro_problem_cls
         )
         test_data = None
         if is_initial_data_available:
@@ -734,11 +693,11 @@ class MicroManagerCoupling(MicroManager):
         if are_there_sims_to_init and self._micro_sims_init:
             # Call initialize() method of the micro simulation to check if it returns any initial data
             if sim_requires_init_data:
-                initial_micro_output = self._micro_sims[first_id].initialize(
+                initial_micro_output = self._sim_container[first_id].initialize(
                     initial_macro_data[first_id]
                 )
             else:
-                initial_micro_output = self._micro_sims[first_id].initialize()
+                initial_micro_output = self._sim_container[first_id].initialize()
 
             if initial_micro_output is None:
                 self._logger.log_warning_rank_zero(
@@ -749,10 +708,10 @@ class MicroManagerCoupling(MicroManager):
 
                 if sim_requires_init_data:
                     for i in micro_sims_to_init:
-                        self._micro_sims[i].initialize(initial_macro_data[i])
+                        self._sim_container[i].initialize(initial_macro_data[i])
                 else:
                     for i in micro_sims_to_init:
-                        self._micro_sims[i].initialize()
+                        self._sim_container[i].initialize()
             else:  # Case where the initialize() method returns data
                 if self._is_adaptivity_on:
                     # Check for missing data
@@ -773,7 +732,7 @@ class MicroManagerCoupling(MicroManager):
                         )
 
                     for name in initial_micro_output.keys():
-                        initial_micro_data[name] = [0] * self._local_number_of_sims
+                        initial_micro_data[name] = [0] * self._sim_container.local_num_sims
                         # Save initial data from first micro simulation as we anyway have it
                         initial_micro_data[name][first_id] = initial_micro_output[name]
 
@@ -787,7 +746,7 @@ class MicroManagerCoupling(MicroManager):
                     # Gather initial data from the rest of the micro simulations
                     if sim_requires_init_data:
                         for i in micro_sims_to_init:
-                            initial_micro_output = self._micro_sims[i].initialize(
+                            initial_micro_output = self._sim_container[i].initialize(
                                 initial_macro_data[i]
                             )
                             for name in self._adaptivity_micro_data_names:
@@ -797,7 +756,7 @@ class MicroManagerCoupling(MicroManager):
                                 initial_micro_data[name][i] = initial_micro_output[name]
                     else:
                         for i in micro_sims_to_init:
-                            initial_micro_output = self._micro_sims[i].initialize()
+                            initial_micro_output = self._sim_container[i].initialize()
                             for name in self._adaptivity_micro_data_names:
                                 self._data_for_adaptivity[name][
                                     i
@@ -808,11 +767,11 @@ class MicroManagerCoupling(MicroManager):
                         "The initialize() method of the Micro simulation returns initial data, but adaptivity is turned off. The returned data will be ignored. The initialize method will nevertheless still be called."
                     )
                     if sim_requires_init_data:
-                        for i in range(1, self._local_number_of_sims):
-                            self._micro_sims[i].initialize(initial_macro_data[i])
+                        for i in range(1, self._sim_container.local_num_sims):
+                            self._sim_container[i].initialize(initial_macro_data[i])
                     else:
-                        for i in range(1, self._local_number_of_sims):
-                            self._micro_sims[i].initialize()
+                        for i in range(1, self._sim_container.local_num_sims):
+                            self._sim_container[i].initialize()
 
         self._micro_sims_have_output = micro_problem_cls.check_output()
 
@@ -820,13 +779,9 @@ class MicroManagerCoupling(MicroManager):
             self._participant,
             self._model_manager,
             self._adaptivity_controller if self._is_adaptivity_on else None,
-            self.state_loader,
-            self.state_setter,
+            self._sim_container,
             self._logger,
             self._config,
-            self._micro_sims,
-            self._global_ids_of_local_sims,
-            self._global_number_of_sims,
             self._comm,
             self._rank,
         )
@@ -842,7 +797,7 @@ class MicroManagerCoupling(MicroManager):
             else:
                 # Ranks without active simulations provide empty dicts
                 initial_micro_data_list: list[dict] = [
-                    dict() for _ in range(self._local_number_of_sims)
+                    dict() for _ in range(self._sim_container.local_num_sims)
                 ]
 
             initial_micro_data_list = (
@@ -851,7 +806,7 @@ class MicroManagerCoupling(MicroManager):
                 )
             )
 
-            for i in range(self._local_number_of_sims):
+            for i in range(self._sim_container.local_num_sims):
                 for name in self._adaptivity_micro_data_names:
                     self._data_for_adaptivity[name][i] = initial_micro_data_list[i][
                         name
@@ -880,7 +835,7 @@ class MicroManagerCoupling(MicroManager):
         read_data: dict[str, list] = dict()
 
         if self._is_load_balancing:
-            read_vertex_ids = self._global_ids_of_local_sims
+            read_vertex_ids = self._sim_container.local_gids
         else:
             read_vertex_ids = self._mesh_vertex_ids
 
@@ -912,12 +867,12 @@ class MicroManagerCoupling(MicroManager):
             List of dicts in which keys are names of data and the values are the data to be written to preCICE.
         """
         if self._is_load_balancing:
-            write_vertex_ids = self._global_ids_of_local_sims
+            write_vertex_ids = self._sim_container.local_gids
         else:
             write_vertex_ids = self._mesh_vertex_ids
 
         data_dict: dict[str, list] = dict()
-        if not self._is_rank_empty:
+        if not self._sim_container.empty():
             for name in data[0]:
                 data_dict[name] = []
 
@@ -959,37 +914,34 @@ class MicroManagerCoupling(MicroManager):
         micro_sims_output : list
             List of dicts in which keys are names of data and the values are the data which are required outputs of
         """
-        micro_sims_output: list[dict] = [None] * self._local_number_of_sims
+        micro_sims_output: list[dict] = [None] * self._sim_container.local_num_sims
 
-        for count, sim in enumerate(self._micro_sims):
+        for lid in self._sim_container.range_lid:
+            sim = self._sim_container[lid]
             # skip already computed outputs
-            gid = self._global_ids_of_local_sims[count]
+            gid = self._sim_container.local_gids[lid]
             if gid in computed_outputs:
-                micro_sims_output[count] = computed_outputs[gid]
+                micro_sims_output[lid] = computed_outputs[gid]
                 continue
 
             # If micro simulation has not crashed in a previous iteration, attempt to solve it
-            if not self._has_sim_crashed[count]:
+            if not self._has_sim_crashed[lid]:
                 # Attempt to solve the micro simulation
                 try:
-                    self.load_balancing.pre_sim_solve(
-                        self._global_ids_of_local_sims[count]
-                    )
-                    micro_sims_output[count] = sim.solve(micro_sims_input[count], dt)
-                    self.load_balancing.post_sim_solve(
-                        self._global_ids_of_local_sims[count]
-                    )
+                    self.load_balancing.pre_sim_solve(gid)
+                    micro_sims_output[lid] = sim.solve(micro_sims_input[lid], dt)
+                    self.load_balancing.post_sim_solve(gid)
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
                     self._logger.log_error(
                         "Micro simulation at macro coordinates {} with input {} has experienced an error. "
                         "See next entry on this rank for error message.".format(
-                            self._mesh_vertex_coords[count], micro_sims_input[count]
+                            self._sim_container.local_coords[lid], micro_sims_input[lid]
                         )
                     )
                     self._logger.log_error(error_message)
-                    self._has_sim_crashed[count] = True
+                    self._has_sim_crashed[lid] = True
 
         # If interpolate is off, terminate after crash
         if not self._interpolate_crashed_sims:
@@ -1005,19 +957,19 @@ class MicroManagerCoupling(MicroManager):
 
         # Interpolate result for crashed simulation
         unset_sims = [
-            count for count, value in enumerate(micro_sims_output) if value is None
+            lid for lid, value in enumerate(micro_sims_output) if value is None
         ]
 
         # Iterate over all crashed simulations to interpolate output
         if self._interpolate_crashed_sims:
-            for unset_sim in unset_sims:
+            for lid in unset_sims:
                 self._logger.log_info(
                     "Interpolating output for crashed simulation at macro vertex {}.".format(
-                        self._mesh_vertex_coords[unset_sim]
+                        self._sim_container.local_coords[lid]
                     )
                 )
-                micro_sims_output[unset_sim] = self._interpolate_output_for_crashed_sim(
-                    micro_sims_input, micro_sims_output, unset_sim
+                micro_sims_output[lid] = self._interpolate_output_for_crashed_sim(
+                    micro_sims_input, micro_sims_output, lid
                 )
 
         return micro_sims_output
@@ -1045,12 +997,12 @@ class MicroManagerCoupling(MicroManager):
         """
         active_sim_lids = self._adaptivity_controller.get_active_sim_local_ids()
 
-        micro_sims_output = [0] * self._local_number_of_sims
+        micro_sims_output = [0] * self._sim_container.local_num_sims
 
         # Solve all active micro simulations
         for lid in active_sim_lids:
             # skip already computed outputs
-            gid = self._global_ids_of_local_sims[lid]
+            gid = self._sim_container.local_gids[lid]
             if gid in computed_outputs:
                 micro_sims_output[lid] = computed_outputs[gid]
                 continue
@@ -1058,19 +1010,14 @@ class MicroManagerCoupling(MicroManager):
             # If micro simulation has not crashed in a previous iteration, attempt to solve it
             if not self._has_sim_crashed[lid]:
                 try:
-                    self.load_balancing.pre_sim_solve(
-                        self._global_ids_of_local_sims[lid]
-                    )
-                    micro_sims_output[lid] = self._micro_sims[lid].solve(
+                    self.load_balancing.pre_sim_solve(gid)
+                    micro_sims_output[lid] = self._sim_container[lid].solve(
                         micro_sims_input[lid], dt
                     )
-                    self.load_balancing.post_sim_solve(
-                        self._global_ids_of_local_sims[lid]
-                    )
+                    self.load_balancing.post_sim_solve(gid)
 
                     # Mark the micro sim as active for export
                     micro_sims_output[lid]["Active-State"] = 1
-                    gid = self._global_ids_of_local_sims[lid]
                     micro_sims_output[lid][
                         "Active-Steps"
                     ] = self._micro_sims_active_steps[gid]
@@ -1080,7 +1027,7 @@ class MicroManagerCoupling(MicroManager):
                     self._logger.log_error(
                         "Micro simulation at macro coordinates {} has experienced an error. "
                         "See next entry on this rank for error message.".format(
-                            self._mesh_vertex_coords[lid]
+                            self._sim_container.local_coords[lid]
                         )
                     )
                     self._logger.log_error(error_message)
@@ -1106,15 +1053,15 @@ class MicroManagerCoupling(MicroManager):
 
         # Iterate over all crashed simulations to interpolate output
         if self._interpolate_crashed_sims:
-            for unset_sim in unset_sims:
+            for lid in unset_sims:
                 self._logger.log_info(
                     "Interpolating output for crashed simulation at macro vertex {}.".format(
-                        self._mesh_vertex_coords[unset_sim]
+                        self._sim_container.local_coords[lid]
                     )
                 )
 
-                micro_sims_output[unset_sim] = self._interpolate_output_for_crashed_sim(
-                    micro_sims_input, micro_sims_output, unset_sim, active_sim_lids
+                micro_sims_output[lid] = self._interpolate_output_for_crashed_sim(
+                    micro_sims_input, micro_sims_output, lid, active_sim_lids
                 )
 
         micro_sims_output = self._adaptivity_controller.get_full_field_micro_output(
@@ -1126,21 +1073,21 @@ class MicroManagerCoupling(MicroManager):
         # Resolve micro sim output data for inactive simulations
         for inactive_lid in inactive_sim_lids:
             self.load_balancing.pre_sim_solve(
-                self._global_ids_of_local_sims[inactive_lid]
+                self._sim_container.local_gids[inactive_lid]
             )
             micro_sims_output[inactive_lid]["Active-State"] = 0
-            gid = self._global_ids_of_local_sims[inactive_lid]
+            gid = self._sim_container.local_gids[inactive_lid]
             micro_sims_output[inactive_lid][
                 "Active-Steps"
             ] = self._micro_sims_active_steps[gid]
             self.load_balancing.post_sim_solve(
-                self._global_ids_of_local_sims[inactive_lid]
+                self._sim_container.local_gids[inactive_lid]
             )
 
         # Collect micro sim output for adaptivity calculation
-        for i in range(self._local_number_of_sims):
+        for lid in self._sim_container.range_lid:
             for name in self._adaptivity_micro_data_names:
-                self._data_for_adaptivity[name][i] = micro_sims_output[i][name]
+                self._data_for_adaptivity[name][lid] = micro_sims_output[lid][name]
 
         return micro_sims_output
 
@@ -1156,11 +1103,9 @@ class MicroManagerCoupling(MicroManager):
 
         while self._model_adaptivity_controller.should_iterate():
             switched_lids = self._model_adaptivity_controller.switch_models(
-                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
                 self._t,
                 micro_sims_input,
                 output,
-                self._micro_sims,
                 active_sim_ids,
             )
             computed_outputs = {}
@@ -1168,21 +1113,20 @@ class MicroManagerCoupling(MicroManager):
                 for lid, out in enumerate(output):
                     if lid in switched_lids:
                         continue
-                    gid = self._global_ids_of_local_sims[lid]
+                    gid = self._sim_container.local_gids[lid]
                     computed_outputs[gid] = out
             output = solve_variant(micro_sims_input, dt, computed_outputs)
             self._model_adaptivity_controller.check_convergence(
-                self._global_mesh_vertex_coords[self._global_ids_of_local_sims],
                 self._t,
                 micro_sims_input,
                 output,
-                self._micro_sims,
                 active_sim_ids,
             )
 
         self._model_adaptivity_controller.finalise_solve()
 
-        for lid, sim in enumerate(self._micro_sims):
+        for lid in self._sim_container.range_lid:
+            sim = self._sim_container[lid]
             res = -1
             if sim is not None:
                 res = self._model_adaptivity_controller.get_sim_class_resolution(sim)
@@ -1215,7 +1159,7 @@ class MicroManagerCoupling(MicroManager):
         self,
         micro_sims_input: list,
         micro_sims_output: list,
-        unset_sim: int,
+        unset_sim_lid: int,
         active_sim_ids: np.ndarray = None,
     ) -> dict:
         """
@@ -1228,7 +1172,7 @@ class MicroManagerCoupling(MicroManager):
             solve a micro simulation.
         micro_sims_output : list
             List dicts containing output of local micro simulations.
-        unset_sim : int
+        unset_sim_lid : int
             Index of the crashed simulation in the list of all local simulations currently interpolating.
         active_sim_ids : numpy.ndarray, optional
             Array of active simulation IDs.
@@ -1248,7 +1192,7 @@ class MicroManagerCoupling(MicroManager):
         micro_sims_active_values = []
         # Turn crashed simulation macro parameters into list to use as coordinate for interpolation
         crashed_position = []
-        for value in micro_sims_input[unset_sim].values():
+        for value in micro_sims_input[unset_sim_lid].values():
             if isinstance(value, np.ndarray) or isinstance(value, list):
                 crashed_position.extend(value)
             else:
@@ -1270,7 +1214,7 @@ class MicroManagerCoupling(MicroManager):
         if len(micro_sims_active_input_lists) == 0:
             self._logger.log_error(
                 "No active neighbors available for interpolation at macro vertex {}. Value cannot be interpolated".format(
-                    self._mesh_vertex_coords[unset_sim]
+                    self._sim_container.local_coords[unset_sim_lid]
                 )
             )
             return None
@@ -1308,5 +1252,5 @@ class MicroManagerCoupling(MicroManager):
         # Reintroduce removed information
         if self._is_adaptivity_on:
             output_interpol["Active-State"] = 1
-            output_interpol["Active-Steps"] = self._micro_sims_active_steps[unset_sim]
+            output_interpol["Active-Steps"] = self._micro_sims_active_steps[unset_sim_lid]
         return output_interpol

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -257,7 +257,8 @@ class MicroManagerCoupling(MicroManager):
 
                 if self._is_parallel:
                     crash_ratio = (
-                        np.sum(crashed_sims_on_all_ranks) / self._sim_container.global_num_sims
+                        np.sum(crashed_sims_on_all_ranks)
+                        / self._sim_container.global_num_sims
                     )
                 else:
                     crash_ratio = np.sum(self._has_sim_crashed) / len(
@@ -732,7 +733,9 @@ class MicroManagerCoupling(MicroManager):
                         )
 
                     for name in initial_micro_output.keys():
-                        initial_micro_data[name] = [0] * self._sim_container.local_num_sims
+                        initial_micro_data[name] = [
+                            0
+                        ] * self._sim_container.local_num_sims
                         # Save initial data from first micro simulation as we anyway have it
                         initial_micro_data[name][first_id] = initial_micro_output[name]
 
@@ -1252,5 +1255,7 @@ class MicroManagerCoupling(MicroManager):
         # Reintroduce removed information
         if self._is_adaptivity_on:
             output_interpol["Active-State"] = 1
-            output_interpol["Active-Steps"] = self._micro_sims_active_steps[unset_sim_lid]
+            output_interpol["Active-Steps"] = self._micro_sims_active_steps[
+                unset_sim_lid
+            ]
         return output_interpol

--- a/micro_manager/micro_manager_base.py
+++ b/micro_manager/micro_manager_base.py
@@ -54,10 +54,6 @@ class MicroManager(MicroManagerInterface):
         self._is_parallel = self._size > 1
         self._micro_sims_have_output = False
 
-        self._local_number_of_sims = 0
-        self._global_number_of_sims = 0
-        self._is_rank_empty = False
-
         self._config = Config(config_file)
 
     def initialize(self):

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -183,10 +183,19 @@ class MicroSimulationInterface(ABC):
         """
         pass
 
+    @property
+    def name(self) -> str:
+        """
+        For normal operation, this does not need to be overridden.
+        The method should return a unique name for the model type.
+        """
+        return type(self).__name__
+
 
 class MicroSimulationLocal(MicroSimulationInterface):
-    def __init__(self, gid, late_init, sim_cls):
+    def __init__(self, gid, name, late_init, sim_cls):
         self._gid = gid
+        self._name = name
         self._instance = sim_cls(-1 if late_init else gid)
 
     def solve(self, micro_sim_input, dt):
@@ -222,11 +231,16 @@ class MicroSimulationLocal(MicroSimulationInterface):
     def destroy(self):
         self._instance = None
 
+    @property
+    def name(self):
+        return self._name
+
 
 class MicroSimulationRemote(MicroSimulationInterface):
-    def __init__(self, gid, late_init, num_ranks, conn, cls_path, sim_cls):
+    def __init__(self, gid, name, late_init, num_ranks, conn, cls_path, sim_cls):
         self._cls_path = cls_path
         self._gid = gid
+        self._name = name
         self._num_ranks = num_ranks
         self._conn = conn
         self._sim_cls = sim_cls
@@ -319,67 +333,6 @@ class MicroSimulationRemote(MicroSimulationInterface):
         for worker_id in range(self._num_ranks):
             self._conn.recv(worker_id)
 
-
-class MicroSimulationWrapper(MicroSimulationInterface):
-    """
-    If only a single rank is in use: will contain the micro sim instance.
-    Otherwise, it will delegate method calls to workers and not contain state.
-    """
-
-    def __init__(self, name, sim_cls, cls_path, global_id, late_init, num_ranks, conn):
-        self._impl = None
-
-        if num_ranks > 1 and conn is not None:
-            self._impl = MicroSimulationRemote(
-                global_id, late_init, num_ranks, conn, cls_path, sim_cls
-            )
-        else:
-            self._impl = MicroSimulationLocal(global_id, late_init, sim_cls)
-
-        self._external_data = dict()
-        self._name = name
-
-    def solve(self, micro_sim_input, dt):
-        return self._impl.solve(micro_sim_input, dt)
-
-    def get_state(self):
-        return self._impl.get_state()
-
-    def set_state(self, state):
-        return self._impl.set_state(state)
-
-    def get_global_id(self):
-        return self._impl.get_global_id()
-
-    def set_global_id(self, global_id):
-        return self._impl.set_global_id(global_id)
-
-    def initialize(self, *args, **kwargs):
-        return self._impl.initialize(*args, **kwargs)
-
-    def output(self):
-        return self._impl.output()
-
-    def requires_initialize(self) -> bool:
-        return self._impl.requires_initialize()
-
-    def requires_output(self) -> bool:
-        return self._impl.requires_output()
-
-    def destroy(self):
-        return self._impl.destroy()
-
-    def __getattr__(self, name):
-        return getattr(self._impl, name)
-
-    @property
-    def attachments(self):
-        return self._external_data
-
-    @attachments.setter
-    def attachments(self, value):
-        self._external_data = value
-
     @property
     def name(self):
         return self._name
@@ -399,15 +352,12 @@ class MicroSimulationClass:
         return self._name
 
     def __call__(self, gid, *, late_init=False):
-        return MicroSimulationWrapper(
-            self._name,
-            self._sim_cls,
-            self._cls_path,
-            gid,
-            late_init,
-            self._num_ranks,
-            self._conn,
-        )
+        if self._num_ranks > 1 and self._conn is not None:
+            return MicroSimulationRemote(
+                gid, self._name, late_init, self._num_ranks, self._conn, self._cls_path, self._sim_cls
+            )
+        else:
+            return MicroSimulationLocal(gid, self._name, late_init, self._sim_cls)
 
     @property
     def backend_cls(self):

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -354,7 +354,13 @@ class MicroSimulationClass:
     def __call__(self, gid, *, late_init=False):
         if self._num_ranks > 1 and self._conn is not None:
             return MicroSimulationRemote(
-                gid, self._name, late_init, self._num_ranks, self._conn, self._cls_path, self._sim_cls
+                gid,
+                self._name,
+                late_init,
+                self._num_ranks,
+                self._conn,
+                self._cls_path,
+                self._sim_cls,
             )
         else:
             return MicroSimulationLocal(gid, self._name, late_init, self._sim_cls)

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -1,6 +1,5 @@
 from micro_manager.micro_simulation import (
     MicroSimulationClass,
-    MicroSimulationWrapper,
     MicroSimulationInterface,
 )
 
@@ -45,14 +44,6 @@ class ModelWrapper(MicroSimulationInterface):
         return self._backend.__class__
 
     @property
-    def attachments(self):
-        return self._backend.attachments
-
-    @attachments.setter
-    def attachments(self, value):
-        self._backend.attachments = value
-
-    @property
     def name(self):
         return self._backend.name
 
@@ -67,7 +58,7 @@ class ModelManager:
     def __init__(self):
         self._registered_classes: list[MicroSimulationClass] = []
         self._stateless_map: dict[MicroSimulationClass, bool] = dict()
-        self._backend_map: dict[MicroSimulationClass, MicroSimulationWrapper] = dict()
+        self._backend_map: dict[MicroSimulationClass, MicroSimulationInterface] = dict()
 
     def register(self, micro_sim_cls: MicroSimulationClass, stateless: bool):
         """

--- a/micro_manager/simulation_container.py
+++ b/micro_manager/simulation_container.py
@@ -5,6 +5,14 @@ import numpy as np
 
 
 class SimulationContainer:
+    """
+    The simulation container stores all simulation instances of this rank alongside
+    the corresponding GIDs and macro-scale coordinates. Further, this container manages
+    checkpointing by providing methods to store and load simulation states. Lastly, it
+    provides functionality to insert and remove simulation instances as well as further
+    utility methods and properties.
+    """
+
     EntryType = Tuple[
         Optional[MicroSimulationInterface],
         Dict[str, Optional[Any]],
@@ -14,7 +22,8 @@ class SimulationContainer:
 
     def __init__(self):
         """
-        Constructs SimContainer. When model adaptivity is active, state storage needs to capture states of all models.
+        Constructs SimulationContainer.
+        When model adaptivity is active, state storage must capture the states of all models.
 
         Parameters
         ----------
@@ -192,7 +201,7 @@ class SimulationContainer:
         for lid in self.range_lid:
             self._sim_checkpoints[lid].clear()
 
-    def get_state(self, lid: int) -> Dict[str, Any]:
+    def get_sim_state(self, lid: int) -> Dict[str, Any]:
         """
         Gets the state of the simulation at the given local id.
 
@@ -215,7 +224,7 @@ class SimulationContainer:
 
         return state_dict
 
-    def set_state(self, lid: int, state: Dict[str, Any]) -> None:
+    def set_sim_state(self, lid: int, state: Dict[str, Any]) -> None:
         """
         Sets the state of the simulation at the given local id to the provided state.
 
@@ -237,7 +246,7 @@ class SimulationContainer:
 
     def __len__(self) -> int:
         """
-        Returns the number of local simulations.
+        Returns the number of simulations on this rank (local).
 
         Returns
         -------
@@ -249,7 +258,7 @@ class SimulationContainer:
     def __iter__(self) -> Iterable[EntryType]:
         """
         Iterates over all entries in this container. Each entry is a tuple of a potential
-        simulation instance, its checkpoint data, the GID and spatial coordinate.
+        simulation instance, its checkpoint data, the GID, and the macro-scale coordinate.
 
         Returns
         -------

--- a/micro_manager/simulation_container.py
+++ b/micro_manager/simulation_container.py
@@ -1,4 +1,4 @@
-from micro_simulation import MicroSimulationInterface
+from .micro_simulation import MicroSimulationInterface
 
 from typing import Optional, Any, List, Dict, Set, Iterable, Tuple
 import numpy as np
@@ -6,11 +6,11 @@ import numpy as np
 
 class SimulationContainer:
     EntryType = Tuple[
-            Optional[MicroSimulationInterface],
-            Dict[str, Optional[Any]],
-            int,
-            np.ndarray,
-        ]
+        Optional[MicroSimulationInterface],
+        Dict[str, Optional[Any]],
+        int,
+        np.ndarray,
+    ]
 
     def __init__(self):
         """
@@ -20,15 +20,21 @@ class SimulationContainer:
         ----------
 
         """
-        self._sims : List[Optional[MicroSimulationInterface]] = []
+        self._sims: List[Optional[MicroSimulationInterface]] = []
         # we store one state for each potential model, associated by its name
-        self._sim_checkpoints : List[Dict[str, Optional[Any]]] = []
-        self._sim_gids : List[int] = []
-        self._sim_gids_set : Set[int] = set()
-        self._sim_coords : List[np.ndarray] = []
-        self._global_num_sims : int = 0
+        self._sim_checkpoints: List[Dict[str, Optional[Any]]] = []
+        self._sim_gids: List[int] = []
+        self._sim_gids_set: Set[int] = set()
+        self._sim_coords: List[np.ndarray] = []
+        self._global_num_sims: int = 0
 
-    def initialize(self, glob_num_sims: int, local_num_sims: int, local_gids: List[int], local_coords: List[np.ndarray]) -> None:
+    def initialize(
+        self,
+        glob_num_sims: int,
+        local_num_sims: int,
+        local_gids: List[int],
+        local_coords: List[np.ndarray],
+    ) -> None:
         """
         Initializes buffers to appropriate sizes.
 
@@ -308,7 +314,9 @@ class SimulationContainer:
         del self._sim_coords[lid]
         self._sim_gids_set.remove(gid)
 
-    def add_sim(self, gid: int, sim: Optional[MicroSimulationInterface], coord: np.ndarray) -> int:
+    def add_sim(
+        self, gid: int, sim: Optional[MicroSimulationInterface], coord: np.ndarray
+    ) -> int:
         """
         Adds the provided simulation to this container.
 

--- a/micro_manager/simulation_container.py
+++ b/micro_manager/simulation_container.py
@@ -1,0 +1,347 @@
+from micro_simulation import MicroSimulationInterface
+
+from typing import Optional, Any, List, Dict, Set, Iterable, Tuple
+import numpy as np
+
+
+class SimulationContainer:
+    EntryType = Tuple[
+            Optional[MicroSimulationInterface],
+            Dict[str, Optional[Any]],
+            int,
+            np.ndarray,
+        ]
+
+    def __init__(self):
+        """
+        Constructs SimContainer. When model adaptivity is active, state storage needs to capture states of all models.
+
+        Parameters
+        ----------
+
+        """
+        self._sims : List[Optional[MicroSimulationInterface]] = []
+        # we store one state for each potential model, associated by its name
+        self._sim_checkpoints : List[Dict[str, Optional[Any]]] = []
+        self._sim_gids : List[int] = []
+        self._sim_gids_set : Set[int] = set()
+        self._sim_coords : List[np.ndarray] = []
+        self._global_num_sims : int = 0
+
+    def initialize(self, glob_num_sims: int, local_num_sims: int, local_gids: List[int], local_coords: List[np.ndarray]) -> None:
+        """
+        Initializes buffers to appropriate sizes.
+
+        Parameters
+        ----------
+        glob_num_sims : int
+            global number of simulations
+        local_num_sims : int
+            number of local simulations on this rank
+        local_gids : List[int]
+            gids on this rank
+        local_coords : List[np.ndarray]
+            coords of simulation on this rank
+        """
+        self._global_num_sims = glob_num_sims
+        self._sims = [None] * local_num_sims
+        self._sim_checkpoints = [{} for _ in range(local_num_sims)]
+        self._sim_gids = local_gids.copy()
+        self._sim_gids_set = set(self._sim_gids)
+        self._sim_coords = local_coords.copy()
+
+    def is_sim_on_rank(self, gid: int) -> bool:
+        """
+        Checks if a simulation given by its gid is on this rank.
+
+        Parameters
+        ----------
+        gid : int
+           simulation gid
+
+        Returns
+        -------
+        is_on_rank : bool
+            True if simulation on this rank
+        """
+        return gid in self._sim_gids_set
+
+    @property
+    def global_num_sims(self) -> int:
+        """
+        Returns the global number of simulations.
+
+        Returns
+        -------
+        global_num_sims : int
+            global number of simulations
+        """
+        return self._global_num_sims
+
+    @property
+    def local_num_sims(self) -> int:
+        """
+        Returns the local number of simulations.
+
+        Returns
+        -------
+        local_num_sims : int
+            local number of simulations
+        """
+        return len(self._sims)
+
+    @property
+    def local_gids(self) -> List[int]:
+        """
+        Returns a reference to the local list of gids on this rank.
+        Has the same order as the simulations stored in this container.
+
+        Returns
+        -------
+        local_gids : List[int]
+            gids on this rank
+        """
+        return self._sim_gids
+
+    @property
+    def local_coords(self) -> List[np.ndarray]:
+        """
+        Returns a reference to the local list of simulation coordinates on this rank.
+        Has the same order as the simulations stored in this container.
+
+        Returns
+        -------
+        local_coords : List[np.ndarray]
+            coords on this rank
+        """
+        return self._sim_coords
+
+    @property
+    def range_lid(self) -> Iterable[int]:
+        """
+        Returns an iterator that yields all current local IDs.
+
+        Returns
+        -------
+        lid_range : Iterable[int]
+            lid iterator
+        """
+        return range(self.local_num_sims)
+
+    @property
+    def range_gid(self) -> Iterable[int]:
+        """
+        Returns an iterator that yields all global IDs.
+
+        Returns
+        -------
+        gid_range : Iterable[int]
+            gid iterator
+        """
+        return range(self.global_num_sims)
+
+    def write_checkpoints(self, only_none: bool = False) -> None:
+        """
+        Writes checkpoints for respective simulations. If only_none is True, only checkpoints are written for
+        simulations that do not have checkpoints yet.
+
+        Parameters
+        ----------
+        only_none : bool
+            Should only checkpoints be written for simulations without checkpoints.
+        """
+        for lid in self.range_lid:
+            if self._sims[lid] is None:
+                continue
+
+            sim = self._sims[lid]
+            state_dict = self._sim_checkpoints[lid]
+            key = f"{sim.name}-state"
+
+            if only_none and key in state_dict:
+                continue
+
+            state_dict[key] = sim.get_state()
+
+    def load_checkpoints(self) -> None:
+        """
+        Resets the state of all simulations to the state stored in checkpoints.
+        """
+        for lid in self.range_lid:
+            if self._sims[lid] is None:
+                continue
+
+            sim = self._sims[lid]
+            state_dict = self._sim_checkpoints[lid]
+            key = f"{sim.name}-state"
+            if key not in state_dict:
+                continue
+
+            sim.set_state(state_dict[key])
+
+    def clear_checkpoints(self) -> None:
+        """
+        Deletes all stored checkpoints.
+        """
+        for lid in self.range_lid:
+            self._sim_checkpoints[lid].clear()
+
+    def get_state(self, lid: int) -> Dict[str, Any]:
+        """
+        Gets the state of the simulation at the given local id.
+
+        Parameters
+        ----------
+        lid : int
+            Local id of the simulation.
+
+        Returns
+        -------
+        state : Dict[str, Any]
+            State of the simulation across all models.
+        """
+        sim = self._sims[lid]
+        assert sim is not None
+
+        state_dict = self._sim_checkpoints[lid]
+        key = f"{sim.name}-state"
+        state_dict[key] = sim.get_state()
+
+        return state_dict
+
+    def set_state(self, lid: int, state: Dict[str, Any]) -> None:
+        """
+        Sets the state of the simulation at the given local id to the provided state.
+
+        Parameters
+        ----------
+        lid : int
+            Local id of the simulation.
+        state : Dict[str, Any]
+            State of the simulation across all models.
+        """
+        state_dict = self._sim_checkpoints[lid]
+        state_dict.update(state)
+
+        sim = self._sims[lid]
+        assert sim is not None
+        key = f"{sim.name}-state"
+
+        sim.set_state(state_dict[key])
+
+    def __len__(self) -> int:
+        """
+        Returns the number of local simulations.
+
+        Returns
+        -------
+        num_sims : int
+            Number of local simulations.
+        """
+        return len(self._sims)
+
+    def __iter__(self) -> Iterable[EntryType]:
+        """
+        Iterates over all entries in this container. Each entry is a tuple of a potential
+        simulation instance, its checkpoint data, the GID and spatial coordinate.
+
+        Returns
+        -------
+        iterator : Iterable[Tuple[
+            Optional[MicroSimulationInterface],
+            Dict[str, Optional[Any]],
+            int,
+            np.ndarray,
+        ]]
+        """
+        return zip(
+            self._sims,
+            self._sim_checkpoints,
+            self._sim_gids,
+            self._sim_coords,
+        )
+
+    def __getitem__(self, lid: int) -> Optional[MicroSimulationInterface]:
+        """
+        Returns the simulation instance specified by its LID.
+
+        Parameters
+        ----------
+        lid : int
+           Local id of the simulation.
+
+        Returns
+        -------
+        sim : Optional[MicroSimulationInterface]
+        """
+        return self._sims[lid]
+
+    def __setitem__(self, lid: int, sim: Optional[MicroSimulationInterface]) -> None:
+        """
+        Writes access to simulation storage.
+        This method can only access the simulation list.
+
+        Parameters
+        ----------
+        lid : int
+            Local id of the simulation.
+        sim : Optional[MicroSimulationInterface]
+            Simulation instance to be stored at lid
+        """
+        self._sims[lid] = sim
+
+    def remove_sim(self, lid: int) -> None:
+        """
+        Removes the simulation at the given local id.
+
+        Parameters
+        ----------
+        lid : int
+            Local id of the simulation.
+        """
+        if self._sims[lid] is not None:
+            self._sims[lid].destroy()
+        del self._sims[lid]
+        del self._sim_checkpoints[lid]
+        gid = self._sim_gids[lid]
+        del self._sim_gids[lid]
+        del self._sim_coords[lid]
+        self._sim_gids_set.remove(gid)
+
+    def add_sim(self, gid: int, sim: Optional[MicroSimulationInterface], coord: np.ndarray) -> int:
+        """
+        Adds the provided simulation to this container.
+
+        Parameters
+        ----------
+        gid : int
+            gid of the simulation
+        sim : Optional[MicroSimulationInterface]
+            Simulation to add.
+        coord : np.ndarray
+            Coordinate of the simulation.
+
+        Returns
+        -------
+        lid : int
+            local id of the added simulation.
+        """
+        self._sims.append(sim)
+        self._sim_gids.append(gid)
+        self._sim_gids_set.add(gid)
+        self._sim_checkpoints.append({})
+        self._sim_coords.append(coord)
+
+        # return lid of sim
+        return len(self._sims) - 1
+
+    def empty(self) -> bool:
+        """
+        Checks if the container is empty.
+
+        Returns
+        -------
+        empty : bool
+            True if the container is empty, False otherwise.
+        """
+        return len(self._sims) == 0

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -243,7 +243,6 @@ class MicroManagerSnapshot(MicroManager):
                         self._rank
                     )
                 )
-                self._is_rank_empty = True
             else:
                 raise Exception("Snapshot has no micro simulations.")
 

--- a/micro_manager/tools/p2p.py
+++ b/micro_manager/tools/p2p.py
@@ -66,7 +66,6 @@ def p2p_comm(
     rank: int,
     comm: MPI.Comm,
     global_number_of_sims: int,
-    is_sim_on_this_rank: list[bool],
     assoc_active_ids: list[int],
     data: list,
 ) -> list:
@@ -83,8 +82,6 @@ def p2p_comm(
         MPI communicator.
     global_number_of_sims : int
         Global number of sims.
-    is_sim_on_this_rank: list[bool]
-        Bool flags of whether a simulation given its gid is on this rank or not.
     assoc_active_ids : list[int]
         Global IDs of active simulations which are not on this rank and are associated to
         the inactive simulations on this rank.
@@ -117,7 +114,7 @@ def p2p_comm(
 
     for d in send_map_list:
         for i, r in d.items():
-            if is_sim_on_this_rank[i]:
+            if rank_of_sim[i] == rank:
                 if i in send_map:
                     send_map[i].append(r)
                 else:

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -30,6 +30,9 @@ class MicroSimulation:
     def solve(self, micro_input, dt):
         pass
 
+    def destroy(self):
+        pass
+
 
 class ModelManager:
     def get_instance(self, gid, micro_problem_cls):

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -7,6 +7,7 @@ from mpi4py import MPI
 
 from micro_manager.adaptivity.adaptivity import AdaptivityCalculator
 from micro_manager.adaptivity.local_adaptivity import LocalAdaptivityCalculator
+from micro_manager.simulation_container import SimulationContainer
 
 
 class MicroSimulation:
@@ -96,9 +97,13 @@ class TestLocalAdaptivity(TestCase):
         configurator.output_dir = MagicMock(return_value="output_dir")
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
+        container = SimulationContainer()
+        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+
         adaptivity_controller = AdaptivityCalculator(
             configurator,
             nsims=self._number_of_sims,
+            sim_container=container,
             micro_problem_cls=MicroSimulation,
             model_manager=ModelManager(),
             base_logger=MagicMock(),
@@ -144,9 +149,13 @@ class TestLocalAdaptivity(TestCase):
         configurator.output_dir = MagicMock(return_value="output_dir")
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
+        container = SimulationContainer()
+        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+
         adaptivity_controller = LocalAdaptivityCalculator(
             configurator,
             self._number_of_sims,
+            sim_container=container,
             base_logger=MagicMock(),
             rank=0,
             comm=MagicMock(),
@@ -180,9 +189,13 @@ class TestLocalAdaptivity(TestCase):
         configurator.output_dir = MagicMock(return_value="output_dir")
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
+        container = SimulationContainer()
+        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+
         adaptivity_controller = AdaptivityCalculator(
             configurator,
             nsims=self._number_of_sims,
+            sim_container=container,
             base_logger=MagicMock(),
             rank=0,
             micro_problem_cls=MicroSimulation,
@@ -275,6 +288,9 @@ class TestLocalAdaptivity(TestCase):
         """
         import warnings
 
+        container = SimulationContainer()
+        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+
         configurator = MagicMock()
         configurator.adaptivity_similarity_measure = MagicMock(return_value="L2rel")
         configurator.output_dir = MagicMock(return_value="output_dir")
@@ -282,6 +298,7 @@ class TestLocalAdaptivity(TestCase):
         adaptivity_l2rel = AdaptivityCalculator(
             configurator,
             nsims=3,
+            sim_container=container,
             base_logger=MagicMock(),
             rank=0,
             micro_problem_cls=MicroSimulation,
@@ -297,6 +314,7 @@ class TestLocalAdaptivity(TestCase):
         adaptivity_l1rel = AdaptivityCalculator(
             configurator_l1,
             nsims=3,
+            sim_container=container,
             base_logger=MagicMock(),
             rank=0,
             micro_problem_cls=MicroSimulation,
@@ -332,9 +350,13 @@ class TestLocalAdaptivity(TestCase):
         configurator.output_dir = MagicMock(return_value="output_dir")
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
+        container = SimulationContainer()
+        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+
         adaptivity_controller = AdaptivityCalculator(
             configurator,
             nsims=self._number_of_sims,
+            sim_container=container,
             base_logger=MagicMock(),
             rank=0,
             micro_problem_cls=MicroSimulation,
@@ -373,9 +395,12 @@ class TestLocalAdaptivity(TestCase):
         configurator.output_dir = MagicMock(return_value="output_dir")
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
+        container = SimulationContainer()
+        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+
         adaptivity_controller = LocalAdaptivityCalculator(
             configurator,
-            self._number_of_sims,
+            sim_container=container,
             base_logger=MagicMock(),
             rank=0,
             comm=MPI.COMM_WORLD,
@@ -399,11 +424,10 @@ class TestLocalAdaptivity(TestCase):
         )
         adaptivity_controller._sim_is_associated_to = np.array([-2, 0, 0, 0, 3])
 
-        dummy_micro_sims = []
         for i in range(self._number_of_sims):
-            dummy_micro_sims.append(MicroSimulation(i))
+            container[i] = MicroSimulation(i)
 
-        adaptivity_controller._update_inactive_sims(dummy_micro_sims)
+        adaptivity_controller._update_inactive_sims()
 
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -98,7 +98,12 @@ class TestLocalAdaptivity(TestCase):
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
         container = SimulationContainer()
-        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+        container.initialize(
+            self._number_of_sims,
+            self._number_of_sims,
+            list(range(self._number_of_sims)),
+            [np.zeros(3) for _ in range(self._number_of_sims)],
+        )
 
         adaptivity_controller = AdaptivityCalculator(
             configurator,
@@ -150,7 +155,12 @@ class TestLocalAdaptivity(TestCase):
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
         container = SimulationContainer()
-        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+        container.initialize(
+            self._number_of_sims,
+            self._number_of_sims,
+            list(range(self._number_of_sims)),
+            [np.zeros(3) for _ in range(self._number_of_sims)],
+        )
 
         adaptivity_controller = LocalAdaptivityCalculator(
             configurator,
@@ -190,7 +200,12 @@ class TestLocalAdaptivity(TestCase):
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
         container = SimulationContainer()
-        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+        container.initialize(
+            self._number_of_sims,
+            self._number_of_sims,
+            list(range(self._number_of_sims)),
+            [np.zeros(3) for _ in range(self._number_of_sims)],
+        )
 
         adaptivity_controller = AdaptivityCalculator(
             configurator,
@@ -289,7 +304,12 @@ class TestLocalAdaptivity(TestCase):
         import warnings
 
         container = SimulationContainer()
-        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+        container.initialize(
+            self._number_of_sims,
+            self._number_of_sims,
+            list(range(self._number_of_sims)),
+            [np.zeros(3) for _ in range(self._number_of_sims)],
+        )
 
         configurator = MagicMock()
         configurator.adaptivity_similarity_measure = MagicMock(return_value="L2rel")
@@ -351,7 +371,12 @@ class TestLocalAdaptivity(TestCase):
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
         container = SimulationContainer()
-        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+        container.initialize(
+            self._number_of_sims,
+            self._number_of_sims,
+            list(range(self._number_of_sims)),
+            [np.zeros(3) for _ in range(self._number_of_sims)],
+        )
 
         adaptivity_controller = AdaptivityCalculator(
             configurator,
@@ -396,7 +421,12 @@ class TestLocalAdaptivity(TestCase):
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
 
         container = SimulationContainer()
-        container.initialize(self._number_of_sims, self._number_of_sims, list(range(self._number_of_sims)), [np.zeros(3) for _ in range(self._number_of_sims)])
+        container.initialize(
+            self._number_of_sims,
+            self._number_of_sims,
+            list(range(self._number_of_sims)),
+            [np.zeros(3) for _ in range(self._number_of_sims)],
+        )
 
         adaptivity_controller = LocalAdaptivityCalculator(
             configurator,

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -13,6 +13,7 @@ from micro_manager.simulation_container import SimulationContainer
 class MicroSimulation:
     def __init__(self, global_id):
         self._global_id = global_id
+        self.name = MicroSimulation.__name__
 
     def get_global_id(self):
         return self._global_id
@@ -164,7 +165,6 @@ class TestLocalAdaptivity(TestCase):
 
         adaptivity_controller = LocalAdaptivityCalculator(
             configurator,
-            self._number_of_sims,
             sim_container=container,
             base_logger=MagicMock(),
             rank=0,

--- a/tests/unit/test_load_balancing.py
+++ b/tests/unit/test_load_balancing.py
@@ -78,7 +78,12 @@ class TestLBTime(TestCase):
         )
 
         container = SimulationContainer()
-        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        container.initialize(
+            global_number_of_sims,
+            len(global_ids),
+            global_ids,
+            [np.zeros(3) for _ in global_ids],
+        )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
@@ -149,7 +154,12 @@ class TestLBTime(TestCase):
         )
 
         container = SimulationContainer()
-        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        container.initialize(
+            global_number_of_sims,
+            len(global_ids),
+            global_ids,
+            [np.zeros(3) for _ in global_ids],
+        )
         for lid, gid in enumerate(container.local_gids):
             sim = None
             if gid not in [0, 2]:
@@ -244,7 +254,12 @@ class TestLBActive(TestCase):
         )
 
         container = SimulationContainer()
-        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        container.initialize(
+            global_number_of_sims,
+            len(global_ids),
+            global_ids,
+            [np.zeros(3) for _ in global_ids],
+        )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
@@ -261,7 +276,7 @@ class TestLBActive(TestCase):
 
         load_balancer.balance()
 
-        actual_global_ids = []#
+        actual_global_ids = []  #
         for lid in container.local_gids:
             sim = container[lid]
             actual_global_ids.append(sim.get_global_id())
@@ -315,7 +330,12 @@ class TestLBActive(TestCase):
         )
 
         container = SimulationContainer()
-        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        container.initialize(
+            global_number_of_sims,
+            len(global_ids),
+            global_ids,
+            [np.zeros(3) for _ in global_ids],
+        )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
@@ -414,7 +434,12 @@ class TestLBActive(TestCase):
         )
 
         container = SimulationContainer()
-        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        container.initialize(
+            global_number_of_sims,
+            len(global_ids),
+            global_ids,
+            [np.zeros(3) for _ in global_ids],
+        )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
@@ -514,7 +539,12 @@ class TestLBActive(TestCase):
         )
 
         container = SimulationContainer()
-        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        container.initialize(
+            global_number_of_sims,
+            len(global_ids),
+            global_ids,
+            [np.zeros(3) for _ in global_ids],
+        )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 

--- a/tests/unit/test_load_balancing.py
+++ b/tests/unit/test_load_balancing.py
@@ -8,6 +8,7 @@ from mpi4py import MPI
 from micro_manager.load_balancing import LoadBalancer, ActiveBalancer
 from micro_manager.micro_simulation import create_simulation_class
 from micro_manager.tools.p2p import get_ranks_of_sims
+from micro_manager.simulation_container import SimulationContainer
 
 
 class MicroSimulation:
@@ -76,9 +77,10 @@ class TestLBTime(TestCase):
             None,
         )
 
-        micro_sims = []
-        for i in global_ids:
-            micro_sims.append(sim_cls(i))
+        container = SimulationContainer()
+        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        for lid, gid in enumerate(container.local_gids):
+            container[lid] = sim_cls(gid)
 
         config = MagicMock()
         config.enable_load_balancing = MagicMock(return_value=True)
@@ -87,13 +89,9 @@ class TestLBTime(TestCase):
             MagicMock(),
             ModelManager(sim_cls),
             None,
-            lambda sim: sim.get_state(),
-            lambda sim, state: sim.set_state(state),
+            container,
             MagicMock(),
             config,
-            micro_sims,
-            global_ids,
-            global_number_of_sims,
             self._comm,
             self._rank,
         )
@@ -101,12 +99,13 @@ class TestLBTime(TestCase):
         load_balancer.balance()
 
         actual_global_ids = []
-        for sim in micro_sims:
+        for lid in container.range_lid:
+            sim = container[lid]
             actual_global_ids.append(sim.get_global_id())
         self.assertListEqual(sorted(actual_global_ids), expected_global_ids)
 
         actual_ranks_of_sims = get_ranks_of_sims(
-            global_ids, self._rank, self._comm, global_number_of_sims
+            container.local_gids, self._rank, self._comm, container.global_num_sims
         )
         self.assertListEqual(list(expected_ranks_of_sims), list(actual_ranks_of_sims))
 
@@ -149,12 +148,13 @@ class TestLBTime(TestCase):
             None,
         )
 
-        micro_sims = []
-        for i in global_ids:
-            if i in [0, 2]:
-                micro_sims.append(None)
-            else:
-                micro_sims.append(sim_cls(i))
+        container = SimulationContainer()
+        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        for lid, gid in enumerate(container.local_gids):
+            sim = None
+            if gid not in [0, 2]:
+                sim = sim_cls(gid)
+            container[lid] = sim
 
         config = MagicMock()
         config.enable_load_balancing = MagicMock(return_value=True)
@@ -163,43 +163,35 @@ class TestLBTime(TestCase):
             MagicMock(),
             ModelManager(sim_cls),
             adaptivity,
-            lambda sim: sim.get_state(),
-            lambda sim, state: sim.set_state(state),
+            container,
             MagicMock(),
             config,
-            micro_sims,
-            global_ids,
-            global_number_of_sims,
             self._comm,
             self._rank,
         )
 
         load_balancer.balance()
 
-        self.assertListEqual(sorted(global_ids), expected_global_ids)
+        self.assertListEqual(sorted(container.local_gids), expected_global_ids)
 
         actual_ranks_of_sims = get_ranks_of_sims(
-            global_ids, self._rank, self._comm, global_number_of_sims
+            container.local_gids, self._rank, self._comm, container.global_num_sims
         )
         self.assertListEqual(list(expected_ranks_of_sims), list(actual_ranks_of_sims))
 
 
 class GlobalAdaptivityCalculator:
-    def __init__(self, is_active, active_lids, active_gids, associated, on_rank):
+    def __init__(self, is_active, active_lids, active_gids, associated):
         self._is_sim_active = is_active
         self._active_lids = active_lids
         self._active_gids = active_gids
         self._sim_is_associated_to = associated
-        self._on_rank = on_rank
 
     def get_active_sim_local_ids(self):
         return self._active_lids
 
     def get_active_sim_global_ids(self):
         return self._active_gids
-
-    def set_is_on_rank(self, *args, **kwargs):
-        pass
 
 
 class TestLBActive(TestCase):
@@ -241,7 +233,6 @@ class TestLBActive(TestCase):
             active_lids,
             active_gids,
             [-2] * global_number_of_sims,
-            [gid in global_ids for gid in range(global_number_of_sims)],
         )
 
         sim_cls = create_simulation_class(
@@ -252,34 +243,32 @@ class TestLBActive(TestCase):
             None,
         )
 
-        micro_sims = []
-        for i in global_ids:
-            micro_sims.append(sim_cls(i))
+        container = SimulationContainer()
+        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        for lid, gid in enumerate(container.local_gids):
+            container[lid] = sim_cls(gid)
 
         load_balancer = ActiveBalancer(
             MagicMock(),
             ModelManager(sim_cls),
             adaptivity_controller,
-            lambda sim: sim.get_state(),
-            lambda sim, state: sim.set_state(state),
+            container,
             MagicMock(),
             config,
-            micro_sims,
-            global_ids,
-            global_number_of_sims,
             self._comm,
             self._rank,
         )
 
         load_balancer.balance()
 
-        actual_global_ids = []
-        for sim in micro_sims:
+        actual_global_ids = []#
+        for lid in container.local_gids:
+            sim = container[lid]
             actual_global_ids.append(sim.get_global_id())
         self.assertListEqual(actual_global_ids, expected_global_ids)
 
         actual_ranks_of_sims = get_ranks_of_sims(
-            actual_global_ids, self._rank, self._comm, global_number_of_sims
+            container.local_gids, self._rank, self._comm, container.global_num_sims
         )
         self.assertListEqual(expected_ranks_of_sims, list(actual_ranks_of_sims))
 
@@ -315,7 +304,6 @@ class TestLBActive(TestCase):
             active_lids,
             active_gids,
             [-2, -2, 0, 1, 0],
-            [gid in global_ids for gid in range(global_number_of_sims)],
         )
 
         sim_cls = create_simulation_class(
@@ -326,21 +314,18 @@ class TestLBActive(TestCase):
             None,
         )
 
-        micro_sims = []
-        for i in global_ids:
-            micro_sims.append(sim_cls(i))
+        container = SimulationContainer()
+        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        for lid, gid in enumerate(container.local_gids):
+            container[lid] = sim_cls(gid)
 
         load_balancer = ActiveBalancer(
             MagicMock(),
             ModelManager(sim_cls),
             adaptivity_controller,
-            lambda sim: sim.get_state(),
-            lambda sim, state: sim.set_state(state),
+            container,
             MagicMock(),
             config,
-            micro_sims,
-            global_ids,
-            global_number_of_sims,
             self._comm,
             self._rank,
         )
@@ -348,11 +333,10 @@ class TestLBActive(TestCase):
         load_balancer._bypass_active = True
 
         load_balancer.balance()
-        self.assertEqual(global_ids, expected_global_ids)
 
-        self.assertListEqual(global_ids, expected_global_ids)
+        self.assertListEqual(container.local_gids, expected_global_ids)
         actual_ranks_of_sims = get_ranks_of_sims(
-            global_ids, self._rank, self._comm, global_number_of_sims
+            container.local_gids, self._rank, self._comm, container.global_num_sims
         )
 
         self.assertTrue(np.array_equal(expected_ranks_of_sims, actual_ranks_of_sims))
@@ -419,7 +403,6 @@ class TestLBActive(TestCase):
             active_lids,
             active_gids,
             [-2] * global_number_of_sims,
-            [gid in global_ids for gid in range(global_number_of_sims)],
         )
 
         sim_cls = create_simulation_class(
@@ -430,21 +413,18 @@ class TestLBActive(TestCase):
             None,
         )
 
-        micro_sims = []
-        for i in global_ids:
-            micro_sims.append(sim_cls(i))
+        container = SimulationContainer()
+        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        for lid, gid in enumerate(container.local_gids):
+            container[lid] = sim_cls(gid)
 
         load_balancer = ActiveBalancer(
             MagicMock(),
             ModelManager(sim_cls),
             adaptivity_controller,
-            lambda sim: sim.get_state(),
-            lambda sim, state: sim.set_state(state),
+            container,
             MagicMock(),
             config,
-            micro_sims,
-            global_ids,
-            global_number_of_sims,
             self._comm,
             self._rank,
         )
@@ -452,12 +432,13 @@ class TestLBActive(TestCase):
         load_balancer.balance()
 
         actual_global_ids = []
-        for sim in micro_sims:
+        for lid in container.local_gids:
+            sim = container[lid]
             actual_global_ids.append(sim.get_global_id())
         self.assertListEqual(actual_global_ids, expected_global_ids)
 
         actual_ranks_of_sims = get_ranks_of_sims(
-            actual_global_ids, self._rank, self._comm, global_number_of_sims
+            container.local_gids, self._rank, self._comm, container.global_num_sims
         )
         self.assertListEqual(expected_ranks_of_sims, list(actual_ranks_of_sims))
 
@@ -522,7 +503,6 @@ class TestLBActive(TestCase):
             active_lids,
             active_gids,
             [-2, -2, -2, 0, 1, 13, 12, 12, -2, 1, 2, 8, -2, -2, -2],
-            [gid in global_ids for gid in range(global_number_of_sims)],
         )
 
         sim_cls = create_simulation_class(
@@ -533,21 +513,18 @@ class TestLBActive(TestCase):
             None,
         )
 
-        micro_sims = []
-        for i in global_ids:
-            micro_sims.append(sim_cls(i))
+        container = SimulationContainer()
+        container.initialize(global_number_of_sims, len(global_ids), global_ids, [np.zeros(3) for _ in global_ids])
+        for lid, gid in enumerate(container.local_gids):
+            container[lid] = sim_cls(gid)
 
         load_balancer = ActiveBalancer(
             MagicMock(),
             ModelManager(sim_cls),
             adaptivity_controller,
-            lambda sim: sim.get_state(),
-            lambda sim, state: sim.set_state(state),
+            container,
             MagicMock(),
             config,
-            micro_sims,
-            global_ids,
-            global_number_of_sims,
             self._comm,
             self._rank,
         )
@@ -556,11 +533,9 @@ class TestLBActive(TestCase):
 
         load_balancer.balance()
 
-        self.assertEqual(global_ids, expected_global_ids)
-
-        self.assertListEqual(global_ids, expected_global_ids)
+        self.assertListEqual(container.local_gids, expected_global_ids)
         actual_ranks_of_sims = get_ranks_of_sims(
-            global_ids, self._rank, self._comm, global_number_of_sims
+            container.local_gids, self._rank, self._comm, container.global_num_sims
         )
 
         self.assertTrue(np.array_equal(expected_ranks_of_sims, actual_ranks_of_sims))

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -87,7 +87,9 @@ class TestFunctionCalls(TestCase):
         """
         manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
         container = SimulationContainer()
-        container.initialize(4, 4, [0, 1, 2, 3], np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]))
+        container.initialize(
+            4, 4, [0, 1, 2, 3], np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        )
         manager._sim_container = container
         manager._mesh_vertex_ids = container.local_coords
 
@@ -110,7 +112,9 @@ class TestFunctionCalls(TestCase):
 
         # manually initialize container
         container = SimulationContainer()
-        container.initialize(4, 4, [0, 1, 2, 3], np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]))
+        container.initialize(
+            4, 4, [0, 1, 2, 3], np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        )
         manager._sim_container = container
         for lid in container.range_lid:
             container[lid] = MicroSimulation(lid)

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import numpy as np
 
 import micro_manager
+from micro_manager.simulation_container import SimulationContainer
 
 
 class MicroSimulation:
@@ -31,7 +32,7 @@ class MicroSimulation:
         pass
 
 
-class TestFunctioncalls(TestCase):
+class TestFunctionCalls(TestCase):
     def setUp(self):
         self.fake_read_data_names = ["Macro-Scalar-Data", "Macro-Vector-Data"]
         self.fake_read_data = [
@@ -71,11 +72,11 @@ class TestFunctioncalls(TestCase):
         manager.initialize()
 
         self.assertEqual(manager._micro_dt, 0.1)  # from Interface.initialize
-        self.assertEqual(manager._global_number_of_sims, 4)
+        self.assertEqual(manager._sim_container.global_num_sims, 4)
         self.assertListEqual(manager._mesh_vertex_ids.tolist(), [0, 1, 2, 3])
-        self.assertEqual(len(manager._micro_sims), 4)
+        self.assertEqual(len(manager._sim_container), 4)
         self.assertEqual(
-            manager._micro_sims[0].very_important_value, 0
+            manager._sim_container[0].very_important_value, 0
         )  # test inheritance
         self.assertListEqual(manager._read_data_names, self.fake_read_data_names)
         self.assertListEqual(self.fake_write_data_names, manager._write_data_names)
@@ -85,9 +86,10 @@ class TestFunctioncalls(TestCase):
         Test if the internal functions _read_data_from_precice and _write_data_to_precice work as expected.
         """
         manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
-
-        manager._global_ids_of_local_sims = 4
-        manager._mesh_vertex_ids = np.array([0, 1, 2, 3])
+        container = SimulationContainer()
+        container.initialize(4, 4, [0, 1, 2, 3], np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]))
+        manager._sim_container = container
+        manager._mesh_vertex_ids = container.local_coords
 
         manager._write_data_to_precice(self.fake_write_data)
         read_data = manager._read_data_from_precice(1.0)
@@ -106,8 +108,12 @@ class TestFunctioncalls(TestCase):
         manager = micro_manager.MicroManagerCoupling("micro-manager-config.json")
         manager.initialize()
 
-        manager._local_number_of_sims = 4
-        manager._micro_sims = [MicroSimulation(i) for i in range(4)]
+        # manually initialize container
+        container = SimulationContainer()
+        container.initialize(4, 4, [0, 1, 2, 3], np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]))
+        manager._sim_container = container
+        for lid in container.range_lid:
+            container[lid] = MicroSimulation(lid)
         manager._micro_sims_active_steps = np.zeros(4, dtype=np.int32)
 
         micro_sims_output = manager._solve_micro_simulations(self.fake_read_data, 1.0)

--- a/tests/unit/test_micro_simulation.py
+++ b/tests/unit/test_micro_simulation.py
@@ -74,44 +74,44 @@ class TestMicroSimulationInterface(unittest.TestCase):
 
 class TestMicroSimulationLocal(unittest.TestCase):
     def test_solve(self):
-        local = MicroSimulationLocal(0, False, MinimalSim)
+        local = MicroSimulationLocal(0, "MinimalSim", False, MinimalSim)
         result = local.solve({"in": 1}, 0.1)
         self.assertEqual(result, {"out": 1})
 
     def test_get_set_state(self):
-        local = MicroSimulationLocal(0, False, MinimalSim)
+        local = MicroSimulationLocal(0, "MinimalSim", False, MinimalSim)
         local.set_state(42)
         self.assertEqual(local.get_state(), 42)
 
     def test_get_set_global_id(self):
-        local = MicroSimulationLocal(5, False, MinimalSim)
+        local = MicroSimulationLocal(5, "MinimalSim", False, MinimalSim)
         self.assertEqual(local.get_global_id(), 5)
         local.set_global_id(99)
         self.assertEqual(local.get_global_id(), 99)
 
     def test_late_init_sets_instance_gid_to_minus_one(self):
         """When late_init=True, the wrapped instance should be constructed with gid=-1."""
-        local = MicroSimulationLocal(3, True, MinimalSim)
+        local = MicroSimulationLocal(3, "MinimalSim", True, MinimalSim)
         # The outer local gid should remain 3
         self.assertEqual(local.get_global_id(), 3)
         # The inner instance should have been constructed with -1
         self.assertEqual(local._instance.get_global_id(), -1)
 
     def test_initialize(self):
-        local = MicroSimulationLocal(0, False, SimWithInitialize)
+        local = MicroSimulationLocal(0, "SimWithInitialize", False, SimWithInitialize)
         result = local.initialize({"data": 1})
         self.assertEqual(result, {"init": True})
 
     def test_output(self):
-        local = MicroSimulationLocal(0, False, SimWithOutput)
+        local = MicroSimulationLocal(0, "SimWithOutput", False, SimWithOutput)
         self.assertIsNone(local.output())
 
     def test_requires_initialize(self):
-        local = MicroSimulationLocal(0, False, SimWithInitialize)
+        local = MicroSimulationLocal(0, "SimWithInitialize", False, SimWithInitialize)
         self.assertTrue(local.requires_initialize())
 
     def test_requires_output(self):
-        local = MicroSimulationLocal(0, False, SimWithOutput)
+        local = MicroSimulationLocal(0, "SimWithOutput", False, SimWithOutput)
         self.assertTrue(local.requires_output())
 
     def test_getattr_delegates_to_instance(self):
@@ -120,7 +120,7 @@ class TestMicroSimulationLocal(unittest.TestCase):
         class SimWithExtra(MinimalSim):
             extra_attr = "hello"
 
-        local = MicroSimulationLocal(7, False, SimWithExtra)
+        local = MicroSimulationLocal(7, "SimWithExtra", False, SimWithExtra)
         # extra_attr is not defined on MicroSimulationLocal — must come via __getattr__
         self.assertEqual(local.extra_attr, "hello")
 
@@ -134,6 +134,7 @@ class TestMicroSimulationRemote(unittest.TestCase):
         return (
             MicroSimulationRemote(
                 gid=0,
+                name="MinimalSim",
                 late_init=late_init,
                 num_ranks=1,
                 conn=conn,
@@ -191,6 +192,7 @@ class TestMicroSimulationRemote(unittest.TestCase):
         conn.recv.return_value = None
         remote = MicroSimulationRemote(
             gid=0,
+            name="SimWithInitialize",
             late_init=False,
             num_ranks=1,
             conn=conn,
@@ -210,6 +212,7 @@ class TestMicroSimulationRemote(unittest.TestCase):
         conn.recv.return_value = None
         remote = MicroSimulationRemote(
             gid=0,
+            name="SimWithOutput",
             late_init=False,
             num_ranks=1,
             conn=conn,
@@ -233,6 +236,7 @@ class TestMicroSimulationRemote(unittest.TestCase):
         conn.recv.return_value = None
         remote = MicroSimulationRemote(
             gid=5,
+            name="MinimalSim",
             late_init=True,
             num_ranks=1,
             conn=conn,

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -5,6 +5,7 @@ import numpy as np
 import micro_manager
 from micro_manager.simulation_container import SimulationContainer
 
+
 class MicroSimulation:
     def __init__(self, sim_id):
         self.sim_id = sim_id
@@ -53,10 +54,7 @@ class TestSimulationCrashHandling(TestCase):
         manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
         container = SimulationContainer()
         container.initialize(
-            4,
-            4,
-            [0, 1, 2, 3],
-            np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]])
+            4, 4, [0, 1, 2, 3], np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]])
         )
         manager._has_sim_crashed = [False] * 4
         manager._mesh_vertex_coords = container.local_coords
@@ -109,7 +107,7 @@ class TestSimulationCrashHandling(TestCase):
             5,
             5,
             [0, 1, 2, 3, 4],
-            np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]])
+            np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]]),
         )
         manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
         manager._micro_sims_active_steps = np.zeros(5, dtype=np.int32)

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import numpy as np
 
 import micro_manager
-
+from micro_manager.simulation_container import SimulationContainer
 
 class MicroSimulation:
     def __init__(self, sim_id):
@@ -51,15 +51,21 @@ class TestSimulationCrashHandling(TestCase):
         manager.initialize()
 
         manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
-        manager._local_number_of_sims = 4
-        manager._has_sim_crashed = [False] * 4
-        manager._mesh_vertex_coords = np.array(
-            [[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]]
+        container = SimulationContainer()
+        container.initialize(
+            4,
+            4,
+            [0, 1, 2, 3],
+            np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]])
         )
+        manager._has_sim_crashed = [False] * 4
+        manager._mesh_vertex_coords = container.local_coords
         manager._is_adaptivity_on = (
             False  # make sure adaptivity is off overriding config
         )
-        manager._micro_sims = [MicroSimulation(i) for i in range(4)]
+        for lid in container.range_lid:
+            container[lid] = MicroSimulation(lid)
+        manager._sim_container = container
 
         micro_sims_output = manager._solve_micro_simulations(macro_data, 1.0)
 
@@ -98,15 +104,20 @@ class TestSimulationCrashHandling(TestCase):
         manager = micro_manager.MicroManagerCoupling("micro-manager-config_crash.json")
         manager.initialize()
 
-        manager._global_ids_of_local_sims = [0, 1, 2, 3, 4]
+        container = SimulationContainer()
+        container.initialize(
+            5,
+            5,
+            [0, 1, 2, 3, 4],
+            np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]])
+        )
         manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
-        manager._local_number_of_sims = 5
         manager._micro_sims_active_steps = np.zeros(5, dtype=np.int32)
         manager._has_sim_crashed = [False] * 5
-        manager._mesh_vertex_coords = np.array(
-            [[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]]
-        )
-        manager._micro_sims = [MicroSimulation(i) for i in range(5)]
+        manager._mesh_vertex_coords = container.local_coords
+        for lid in container.range_lid:
+            container[lid] = MicroSimulation(lid)
+        manager._sim_container = container
 
         manager._adaptivity_controller._similarity_dists = np.array([0, 0, 0, 0, 0])
         manager._adaptivity_controller._is_sim_active = np.array(

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import numpy as np
 from mpi4py import MPI
 
+from micro_manager.simulation_container import SimulationContainer
 from micro_manager.adaptivity.model_adaptivity import ModelAdaptivity
 from micro_manager.micro_manager import MicroManagerCoupling
 
@@ -51,13 +52,14 @@ class DummyModelManager:
 
 
 class TestModelAdaptivity(TestCase):
-    def _make_controller(self, switching_func):
+    def _make_controller(self, container, switching_func):
         controller = ModelAdaptivity.__new__(ModelAdaptivity)
         controller._switching_func = switching_func
         controller._model_classes = [
             DummyModelClass("fine"),
             DummyModelClass("coarse"),
         ]
+        controller._sim_container = container
         controller._model_manager = DummyModelManager()
         controller._comm = MPI.COMM_SELF
         controller._logger = MagicMock()
@@ -71,14 +73,15 @@ class TestModelAdaptivity(TestCase):
         resolution. Such an out-of-range request should be clamped to the
         current resolution and treated as no model change.
         """
-        controller = self._make_controller(lambda resolution, *_: -1)
+        container = SimulationContainer()
+        container.initialize(1, 1, [0], [np.array([0.0, 0.0, 0.0])])
+        container[0] = DummySimulation("fine")
+        controller = self._make_controller(container, lambda resolution, *_: -1)
 
         controller.check_convergence(
-            np.array([[0.0, 0.0, 0.0]]),
             1.0,
             [{}],
             None,
-            [DummySimulation("fine")],
         )
 
         self.assertTrue(controller._converged)
@@ -90,14 +93,15 @@ class TestModelAdaptivity(TestCase):
         available resolution. This guards against endless iterations caused by
         repeated out-of-range coarsening requests.
         """
-        controller = self._make_controller(lambda resolution, *_: 1)
+        container = SimulationContainer()
+        container.initialize(1, 1, [0], [np.array([0.0, 0.0, 0.0])])
+        container[0] = DummySimulation("coarse")
+        controller = self._make_controller(container, lambda resolution, *_: 1)
 
         controller.check_convergence(
-            np.array([[0.0, 0.0, 0.0]]),
             1.0,
             [{}],
             None,
-            [DummySimulation("coarse")],
         )
 
         self.assertTrue(controller._converged)
@@ -109,14 +113,15 @@ class TestModelAdaptivity(TestCase):
         adaptivity loop must continue in this case so the requested switch can
         be applied.
         """
-        controller = self._make_controller(lambda resolution, *_: 1)
+        container = SimulationContainer()
+        container.initialize(1, 1, [0], [np.array([0.0, 0.0, 0.0])])
+        container[0] = DummySimulation("fine")
+        controller = self._make_controller(container, lambda resolution, *_: 1)
 
         controller.check_convergence(
-            np.array([[0.0, 0.0, 0.0]]),
             1.0,
             [{}],
             None,
-            [DummySimulation("fine")],
         )
 
         self.assertFalse(controller._converged)
@@ -135,15 +140,16 @@ class TestModelAdaptivity(TestCase):
                 return 0
             return 1
 
-        controller = self._make_controller(switching_function)
+        container = SimulationContainer()
+        container.initialize(1, 1, [0], [np.array([0.0, 0.0, 0.0])])
+        container[0] = DummySimulation("fine", global_id=0)
+        controller = self._make_controller(container, switching_function)
         manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
         manager._model_adaptivity_controller = controller
         manager._is_adaptivity_on = False
         manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
-        manager._global_mesh_vertex_coords = manager._mesh_vertex_coords
-        manager._global_ids_of_local_sims = [0]
         manager._t = 1.0
-        manager._micro_sims = [DummySimulation("fine", global_id=0)]
+        manager._sim_container = container
 
         solve_calls = []
 
@@ -174,7 +180,7 @@ class TestModelAdaptivity(TestCase):
             "Output from the previous resolution must not be reused after a model switch.",
         )
 
-        self.assertEqual(manager._micro_sims[0].name, "coarse")
+        self.assertEqual(manager._sim_container[0].name, "coarse")
         self.assertEqual(result, [{"result": 2, "model_resolution": 1}])
         self.assertTrue(controller._converged)
 
@@ -185,15 +191,16 @@ class TestModelAdaptivity(TestCase):
         requesting an even coarser model. The loop should perform one solve,
         recognize that no valid model change remains, and return normally.
         """
-        controller = self._make_controller(lambda resolution, *_: 1)
+        container = SimulationContainer()
+        container.initialize(1, 1, [0], [np.array([0.0, 0.0, 0.0])])
+        container[0] = DummySimulation("coarse")
+        controller = self._make_controller(container, lambda resolution, *_: 1)
         manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
         manager._model_adaptivity_controller = controller
         manager._is_adaptivity_on = False
         manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
-        manager._global_mesh_vertex_coords = manager._mesh_vertex_coords
-        manager._global_ids_of_local_sims = [0]
         manager._t = 1.0
-        manager._micro_sims = [DummySimulation("coarse")]
+        manager._sim_container = container
 
         solve_calls = []
 


### PR DESCRIPTION
The implementation provides a dedicated simulation container that encapsulates all micro-simulation data-related aspects.
This should lay the groundwork for follow-up encapsulation refactorings.

The proposed container keeps track of local GIDs, simulation instances, and corresponding macro coordinates, and provides additional utility methods. Adding and removing simulations can now be performed by calling the respective methods. Assigning simulation instances can be performed by using the index operator.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
