### PR TITLE
Rename tolerance to distinguish from time in doc

### DIFF
--- a/docs/adaptivity.md
+++ b/docs/adaptivity.md
@@ -51,13 +51,14 @@ Bastidas, Manuela & Bringedal, Carina & Pop, Iuliu Sorin. (2021). A two-scale it
 
 These steps are repeated every time the adaptivity computation is triggered.
 
-The coarsening tolerance $$ t_c $$ is calculated by
+The coarsening tolerance $$ tol_c $$ is calculated by
 
-$$ t_c = C_c C_r \displaystyle\max_{x_{1},x_{2} \in N(t_{n})} {D(x_{1},x_{2}; t_{n})} $$
+$$ tol_c = C_c C_r \displaystyle\max_{x_{1},x_{2} \in N(t_{n})} {D(x_{1},x_{2}; t_{n})} $$
 
-The refining tolerance $$ t_r $$ is calculated by
 
-$$ t_r = C_r \displaystyle\max_{x_{1},x_{2} \in N(t_{n})} {D(x_{1},x_{2}; t_{n})} $$
+The refining tolerance $$ tol_r $$ is calculated by
+
+$$ tol_r = C_r \displaystyle\max_{x_{1},x_{2} \in N(t_{n})} {D(x_{1},x_{2}; t_{n})} $$
 
 The primary tuning parameters for adaptivity are the history parameter $$ \Lambda $$, the coarsening constant $$ C_c $$, and the refining constant $$ C_r $$. Their effects can be interpreted as:
 

--- a/docs/adaptivity.md
+++ b/docs/adaptivity.md
@@ -55,7 +55,6 @@ The coarsening tolerance $$ tol_c $$ is calculated by
 
 $$ tol_c = C_c C_r \displaystyle\max_{x_{1},x_{2} \in N(t_{n})} {D(x_{1},x_{2}; t_{n})} $$
 
-
 The refining tolerance $$ tol_r $$ is calculated by
 
 $$ tol_r = C_r \displaystyle\max_{x_{1},x_{2} \in N(t_{n})} {D(x_{1},x_{2}; t_{n})} $$


### PR DESCRIPTION
't'  is used for both `tolerance` and `time` in these equations, which can be confusing.

Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
