### PR TITLE
Shift Simulation Class ownership and loading to Model Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Moved Simulation Class ownership and loading to Model Manager [#286](https://github.com/precice/micro-manager/pull/286)
 - Added simulation container for more encapsulation [#284](https://github.com/precice/micro-manager/pull/284)
 - Redesigned configuration loading for enhanced clarity and standardization [#264](https://github.com/precice/micro-manager/pull/264)
 - Added RBF interpolation, currently used within adaptivity for output interpolation [#242](https://github.com/precice/micro-manager/pull/242)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ The Micro Manager is configured with a [JSON](https://en.wikipedia.org/wiki/JSON
 
 ```json
 {
-    "micro_file_name": "python/micro.py",
+    "micro_file_names": ["python/micro.py"],
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "Macro-Mesh",
@@ -29,13 +29,13 @@ The Micro Manager is configured with a [JSON](https://en.wikipedia.org/wiki/JSON
 
 These parameters are in the outer section.
 
-| Parameter                  | Description                                                                                                                                                                                           | Default       |
-|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `micro_file_name`          | Path to the file containing the Python importable micro simulation class. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed. | -             |
-| `micro_stateless`          | Boolean if micro simulation is stateless allowing model instancing.                                                                                                                                   | False         |
-| `output_directory`         | Path to output directory for logging and performance metrics. Directory is created if not existing already.                                                                                           | `.`           |
-| `memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels.               | Empty string. |
-| `memory_usage_output_n`    | Interval of output.                                                                                                                                                                                   | 1             |
+| Parameter                  | Description                                                                                                                                                                                                  | Default       |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `micro_file_names`         | Paths to the files containing the Python importable micro simulation classes. If the files are not in the working directory, give the relative paths from the directory where the Micro Manager is executed. | -             |
+| `micro_stateless_flags`    | List of booleans if micro simulation is stateless allowing model instancing.                                                                                                                                 | False         |
+| `output_directory`         | Path to output directory for logging and performance metrics. Directory is created if not existing already.                                                                                                  | `.`           |
+| `memory_usage_output_type` | Set to either `local`, `global`, or `all`. `local` outputs rank-wise peak memory usage. `global` outputs global averaged peak memory usage. `all` outputs both local and global levels.                      | Empty string. |
+| `memory_usage_output_n`    | Interval of output.                                                                                                                                                                                          | 1             |
 
 All output is to a CSV file with the peak memory usage (RSS) in every time window, in MBs.
 
@@ -192,9 +192,7 @@ To turn on model adaptivity, set `"model_adaptivity": true` in `simulation_param
 
 | Parameter            | Description                                                                                                                                                                                                                                        |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `micro_file_names`   | List of paths to the files containing the Python importable micro simulation classes, in order of decreasing model fidelity. If the files are not in the working directory, give the relative path from the directory where the Micro Manager is executed. Requires a minimum of 2 files. |
 | `switching_function` | Path to the file containing the Python importable switching function. If the file is not in the working directory, give the relative path from the directory where the Micro Manager is executed.                                                  |
-| `micro_stateless`    | List of boolean values, whether the respective micro simulation model is stateless and can use model instancing.                                                                                                                                   |
 
 Example of model adaptivity configuration is
 
@@ -202,9 +200,7 @@ Example of model adaptivity configuration is
 "simulation_params": {
     "model_adaptivity": true,
     "model_adaptivity_settings": {
-        "micro_file_names": ["python-dummy/micro_dummy", "python-dummy/micro_dummy", "python-dummy/micro_dummy"],
         "switching_function": "mada_switcher",
-        "micro_stateless": [False, True, True]
     }
 }
 ```

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "cpp-dummy/micro_dummy",
+    "micro_file_names": ["cpp-dummy/micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "Macro-Mesh",

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "cpp-dummy/micro_dummy",
+    "micro_file_names": ["cpp-dummy/micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "Macro-Mesh",

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "python-dummy/micro_dummy",
+    "micro_file_names": ["python-dummy/micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config-adaptivity.xml",
         "macro_mesh_name": "Macro-Mesh",

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "python-dummy/micro_dummy",
+    "micro_file_names": ["python-dummy/micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "Macro-Mesh",

--- a/examples/micro-manager-python-mada-config.json
+++ b/examples/micro-manager-python-mada-config.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "python-dummy/micro_dummy",
+    "micro_file_names": ["python-dummy/micro_dummy", "python-dummy/micro_dummy", "python-dummy/micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "Macro-Mesh",
@@ -11,7 +11,6 @@
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
         "model_adaptivity": true,
         "model_adaptivity_settings": {
-            "micro_file_names": ["python-dummy/micro_dummy", "python-dummy/micro_dummy", "python-dummy/micro_dummy"],
             "switching_function": "mada_switcher"
         }
     },

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -1,7 +1,7 @@
 """
 Class ModelAdaptivity provides methods to change micro simulation resolution on the fly.
 """
-from typing import Union, Optional
+from typing import Union, Optional, List, Dict, Any
 
 from micro_manager.config import Config
 from micro_manager.micro_simulation import (
@@ -29,8 +29,6 @@ class ModelAdaptivity:
         comm: MPI.Comm,
         rank: int,
         log_file: str,
-        conn: Connection,
-        num_ranks: int,
     ) -> None:
         """
         Class constructor.
@@ -49,43 +47,13 @@ class ModelAdaptivity:
             Rank of the MPI communicator.
         log_file : str
             Path to the log file to write to.
-        conn: Connection
-            Connection to workers
-        num_ranks : int
-            Number of workers
         """
         self._logger = Logger(__name__, log_file, rank)
 
         self._comm = comm
         self._model_manager = model_manager
         self._sim_container = sim_container
-        self._model_files = config.model_adaptivity_file_names()
         self._switching_func_name = config.model_adaptivity_switching_function()
-
-        stateless_flags = config.model_adaptivity_micro_stateless()
-        self._model_classes = []
-        pos = 0
-        for model_file in self._model_files:
-            try:
-                model = load_backend_class(model_file)
-                self._model_classes.append(
-                    create_simulation_class(
-                        self._logger, model, model_file, num_ranks, conn
-                    )
-                )
-                self._model_manager.register(
-                    self._model_classes[pos], stateless_flags[pos]
-                )
-                pos += 1
-            except Exception as e:
-                self._logger.log_info_rank_zero(
-                    f"Failed to load model class with error: {e}"
-                )
-        if (
-            len(self._model_classes) != len(self._model_files)
-            or len(self._model_classes) == 0
-        ):
-            raise RuntimeError("Not all models were loaded. Stopping!")
 
         FUNC_NAME = "switching_function"
         self._switching_func = ModelAdaptivity.switching_interface
@@ -105,8 +73,8 @@ class ModelAdaptivity:
         resolution: int,
         location: np.ndarray,
         t: float,
-        input: dict,
-        prev_output: Optional[dict],
+        input: Dict[str, Any],
+        prev_output: Optional[Dict[str, Any]],
     ) -> int:
         """
         Switching interface function, use as reference
@@ -119,9 +87,9 @@ class ModelAdaptivity:
             Array with gaussian point for respective sim. D is the mesh dimension.
         t : float
             Current time in simulation.
-        input : dict
+        input : Dict[str, Any]
             input object.
-        prev_output : [None, dict-like]
+        prev_output : Optional[Dict[str, Any]]
             Contains the output of the previous model evaluation.
 
         """
@@ -148,26 +116,22 @@ class ModelAdaptivity:
     def switch_models(
         self,
         t: float,
-        inputs: list[dict],
-        prev_output: Optional[list[dict]],
-        active_sim_ids: Optional[list] = None,
-    ) -> list[int]:
+        inputs: List[Dict[str, Any]],
+        prev_output: Optional[List[Dict[str, Any]]],
+        active_sim_ids: Optional[List[int]] = None,
+    ) -> List[int]:
         """
         Switches models within sims list. If active_sim_ids is None, all sims are considered as active.
 
         Parameters
         ----------
-        locations : np.array - shape(N,D)
-            Array with gaussian points for all sims. D is the mesh dimension.
         t : float
             Current time in simulation.
-        inputs : list[dict]
+        inputs : List[Dict[str, Any]]
             List of input objects.
-        prev_output : [None, list[dict]]
+        prev_output : Optional[List[Dict[str, Any]]]
             Contains the outputs of the previous model evaluation.
-        sims : list
-            List of all simulation objects.
-        active_sim_ids : [list, None]
+        active_sim_ids : Optional[List[int]]
             List of all active simulation ids.
 
         Returns
@@ -192,7 +156,9 @@ class ModelAdaptivity:
 
             sim = self._sim_container[lid]
             gid = self._sim_container.local_gids[lid]
-            target_class = self.get_resolution_sim_class(target_res[lid])
+            target_class = self._model_manager.get_cls_by_idx(
+                clamp_in_range(target_res[lid], 0, self.get_num_resolutions() - 1)
+            )
 
             # we store state for each resolution separately
             # keys are sim names of respective resolution
@@ -225,9 +191,9 @@ class ModelAdaptivity:
     def check_convergence(
         self,
         t: float,
-        inputs: list,
-        prev_output: Optional[list[dict]],
-        active_sim_ids: Optional[list] = None,
+        inputs: List[Dict[str, Any]],
+        prev_output: Optional[List[Dict[str, Any]]],
+        active_sim_ids: Optional[List[int]] = None,
     ) -> None:
         """
         Similarly to switch_models, checks whether models would be switched in next step.
@@ -237,11 +203,11 @@ class ModelAdaptivity:
         ----------
         t : float
             Current time in simulation.
-        inputs : list[dict]
+        inputs : List[Dict[str, Any]]
             List of all input objects.
-        prev_output : [None, list[dict]]
+        prev_output : Optional[List[Dict[str, Any]]]
             Contains the outputs of the previous model evaluation.
-        active_sim_ids : [list, None]
+        active_sim_ids : Optional[List[int]]
             List of all active simulation ids.
         """
         locations = self._sim_container.local_coords
@@ -265,45 +231,7 @@ class ModelAdaptivity:
         num_resolutions : int
             Number of loaded resolutions.
         """
-        return len(self._model_classes)
-
-    def get_resolution_sim_class(
-        self, resolution: Union[int, np.ndarray]
-    ) -> Union[MicroSimulationClass, list[MicroSimulationClass]]:
-        """
-        Looks up the class associated with the provided resolution.
-
-        Parameters
-        ----------
-        resolution : [int, np.array]
-            target resolution
-
-        Returns
-        -------
-        sim_class : class
-            associated class
-        """
-        return self._model_classes[
-            clamp_in_range(resolution, 0, len(self._model_classes) - 1)
-        ]
-
-    def get_sim_class_resolution(self, sim: MicroSimulationClass) -> int:
-        """
-        Looks up the resolution associated with the provided simulation object.
-
-        Parameters
-        ----------
-        sim : Simulation
-            Simulation object
-
-        Returns
-        -------
-        resolution : int
-            target resolution
-        """
-        return next(
-            (idx for idx, cls in enumerate(self._model_classes) if cls.name == sim.name)
-        )
+        return self._model_manager.num_models
 
     def _gather_current_resolutions(self, active_sims: np.ndarray) -> np.ndarray:
         """
@@ -321,7 +249,7 @@ class ModelAdaptivity:
         """
         return np.array(
             [
-                self.get_sim_class_resolution(self._sim_container[lid])
+                self._model_manager.get_idx_of_sim(self._sim_container[lid])
                 if active_sims[lid] == 1
                 else -1
                 for lid in self._sim_container.range_lid
@@ -331,10 +259,10 @@ class ModelAdaptivity:
     def _gather_target_resolutions(
         self,
         cur_res: np.ndarray,
-        locations: np.ndarray,
+        locations: List[np.ndarray],
         t: float,
-        inputs: list[dict],
-        prev_output: Optional[list[dict]],
+        inputs: List[Dict[str, Any]],
+        prev_output: Optional[List[Dict[str, Any]]],
         active_sims: np.ndarray,
     ) -> np.ndarray:
         """
@@ -342,22 +270,22 @@ class ModelAdaptivity:
 
         Parameters
         ----------
-        cur_res : np.array
+        cur_res : np.ndarray
             Current resolutions, from _gather_current_resolutions.
-        locations : np.array
+        locations : List[np.ndarray]
             Array with gaussian points for all sims. D is the mesh dimension.
         t : float
             Current time in simulation.
-        inputs : list[dict]
+        inputs : List[Dict[str, Any]]
             List of all input objects.
-        prev_output : [None, list[dict]]
+        prev_output : Optional[List[Dict[str, Any]]]
             Contains the outputs of the previous model evaluation.
         active_sims : np.array
             Boolean array indicating whether the model is active or not.
 
         Returns
         -------
-        resolutions : np.array
+        resolutions : np.ndarray
             Target resolutions.
         """
         switch_tgt = np.zeros_like(cur_res)
@@ -372,24 +300,26 @@ class ModelAdaptivity:
         res_tgt[active_sims] = clamp_in_range(
             switch_tgt[active_sims] + cur_res[active_sims],
             0,
-            len(self._model_classes) - 1,
+            self.get_num_resolutions() - 1,
         )
         return res_tgt
 
-    def _create_active_mask(self, active_sim_ids: list, size: int) -> np.ndarray:
+    def _create_active_mask(
+        self, active_sim_ids: Optional[List[int]], size: int
+    ) -> np.ndarray:
         """
         Converts list of active simulation ids to np boolean mask.
 
         Parameters
         ----------
-        active_sim_ids : np.array
+        active_sim_ids : Optional[List[int]]
             List of all active simulation ids.
         size : int
             size of active_sim_ids
 
         Returns
         -------
-        active_mask : np.array
+        active_mask : np.ndarray
             Boolean mask of active simulation ids.
         """
         if active_sim_ids is None:

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -530,24 +530,39 @@ class Config:
         # ======================================================
 
         # convert paths to python-importable paths
-        self.micro_file_name.set = (
-            self.json["micro_file_name"]
-            .get_or_raise(
-                "Micro simulation file name: {data}",
-                "'micro_file_name' must be specified!",
-                str,
-            )
-            .replace("/", ".")
-            .replace("\\", ".")
-            .replace(".py", "")
+        file_names = self.json["micro_file_names"].get_or_raise(
+            "Micro simulation file name: {data}",
+            "'micro_file_name' must be specified!",
+            List[str],
         )
+        self.micro_file_names.set = [
+            name.replace("/", ".").replace("\\", ".").replace(".py", "")
+            for name in file_names
+        ]
+        if len(self.micro_file_names()) < 1:
+            self._logger.log_info_rank_zero(
+                "Must provide at least one micro simulation file."
+            )
+            raise RuntimeError("Missing Micro Simulation File")
 
-        self.enable_micro_stateless.set = self.json["micro_stateless"].get_with_default(
-            False,
+        self.micro_stateless_flags.set = self.json[
+            "micro_stateless_flags"
+        ].get_with_default(
+            [False] * len(self.micro_file_names()),
             "Only creating one full instance of Micro Model.",
             "Creating full instance of Micro Model per mesh vertex.",
-            bool,
+            List[bool],
         )
+
+        for i in range(len(self.micro_file_names())):
+            if self.micro_stateless_flags()[i]:
+                self._logger.log_info_rank_zero(
+                    f"Only creating one full instance of Micro Model {i}."
+                )
+            else:
+                self._logger.log_info_rank_zero(
+                    f"Creating full instance of Micro Model {i} per mesh vertex."
+                )
 
         self.output_dir.set = self.json["output_directory"].get_or_none(
             "Logging and metrics output directory: {data}",
@@ -884,14 +899,7 @@ class Config:
             )
 
         if self.enable_model_adaptivity():
-            file_names = self.json["simulation_params"]["model_adaptivity_settings"][
-                "micro_file_names"
-            ].get_or_raise()
-            self.model_adaptivity_file_names.set = [
-                name.replace("/", ".").replace("\\", ".").replace(".py", "")
-                for name in file_names
-            ]
-            if len(file_names) < 2:
+            if len(self.micro_file_names()) < 2:
                 self._logger.log_info_rank_zero(
                     "Not enough Micro Models provided for Model Adaptivity. Need min 2."
                 )
@@ -903,21 +911,6 @@ class Config:
             self.model_adaptivity_switching_function.set = self.json[
                 "simulation_params"
             ]["model_adaptivity_settings"]["switching_function"].get_or_raise()
-            self.model_adaptivity_micro_stateless.set = self.json["simulation_params"][
-                "model_adaptivity_settings"
-            ]["micro_stateless"].get_with_default(
-                [False] * len(file_names),
-            )
-
-            for i in range(len(file_names)):
-                if self.model_adaptivity_micro_stateless()[i]:
-                    self._logger.log_info_rank_zero(
-                        f"Only creating one full instance of Micro Model {i}."
-                    )
-                else:
-                    self._logger.log_info_rank_zero(
-                        f"Creating full instance of Micro Model {i} per mesh vertex."
-                    )
 
         # ======================================================
         #          Crash Interpolation and Diagnostics
@@ -1106,26 +1099,26 @@ class Config:
         pass
 
     @config_entry
-    def micro_file_name(self) -> str:
+    def micro_file_names(self) -> List[str]:
         """
-        Get the path to the Python script of the micro-simulation.
+        Get the paths to the Python scripts of the micro-simulations.
 
         Returns
         -------
-        micro_file_name : str
-            String carrying the path to the Python script of the micro-simulation.
+        micro_file_names : List[str]
+            List of strings carrying the paths to the Python scripts of the micro-simulations.
         """
         pass
 
     @config_entry
-    def enable_micro_stateless(self) -> bool:
+    def micro_stateless_flags(self) -> List[bool]:
         """
-        Boolean stating whether micro model is stateless or not.
+        List of booleans stating whether micro models are stateless or not.
 
         Returns
         -------
-        stateless : bool
-            True if micro model is stateless, False otherwise.
+        stateless_list : List[bool]
+            Entry is True if micro model is stateless, False otherwise.
         """
         pass
 
@@ -1495,30 +1488,6 @@ class Config:
         adaptivity : bool
             True is model adaptivity settings are done, False otherwise.
 
-        """
-        pass
-
-    @config_entry
-    def model_adaptivity_file_names(self) -> List[str]:
-        """
-        Get the paths to the Python scripts of the model-adaptive-micro-simulations.
-
-        Returns
-        -------
-        micro_file_names : List[str]
-            String carrying the path to the Python script of the micro-simulation.
-        """
-        pass
-
-    @config_entry
-    def model_adaptivity_micro_stateless(self) -> List[bool]:
-        """
-        List of boolean stating whether the respective micro model is stateless or not.
-
-        Returns
-        -------
-        stateless : List[bool]
-            True if micro model is stateless, False otherwise.
         """
         pass
 

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -557,11 +557,11 @@ class Config:
         for i in range(len(self.micro_file_names())):
             if self.micro_stateless_flags()[i]:
                 self._logger.log_info_rank_zero(
-                    f"Only creating one full instance of Micro Model {i}."
+                    f"Creating only one instance of Micro Model {i}."
                 )
             else:
                 self._logger.log_info_rank_zero(
-                    f"Creating full instance of Micro Model {i} per mesh vertex."
+                    f"Creating all instances of Micro Model {i} per mesh vertex."
                 )
 
         self.output_dir.set = self.json["output_directory"].get_or_none(

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -533,7 +533,7 @@ class Config:
         file_names = self.json["micro_file_names"].get_or_raise(
             "Micro simulation file name: {data}",
             "'micro_file_name' must be specified!",
-            List[str],
+            list,
         )
         self.micro_file_names.set = [
             name.replace("/", ".").replace("\\", ".").replace(".py", "")
@@ -551,7 +551,7 @@ class Config:
             [False] * len(self.micro_file_names()),
             "Only creating one full instance of Micro Model.",
             "Creating full instance of Micro Model per mesh vertex.",
-            List[bool],
+            list,
         )
 
         for i in range(len(self.micro_file_names())):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -563,7 +563,9 @@ class MicroManagerCoupling(MicroManager):
         )
 
         # load micro sim
-        micro_problem_cls = None
+        self._model_manager.load_models(self._config, num_ranks, self._conn)
+        micro_problem_cls = self._model_manager.get_cls_by_idx(0)
+
         if self._is_model_adaptivity_on:
             self._model_adaptivity_controller: ModelAdaptivity = ModelAdaptivity(
                 self._model_manager,
@@ -572,24 +574,6 @@ class MicroManagerCoupling(MicroManager):
                 self._comm,
                 self._rank,
                 self._log_file,
-                self._conn,
-                num_ranks,
-            )
-            micro_problem_cls = (
-                self._model_adaptivity_controller.get_resolution_sim_class(0)
-            )
-        else:
-            micro_problem_base = load_backend_class(self._config.micro_file_name())
-            micro_problem_cls = create_simulation_class(
-                self._logger,
-                micro_problem_base,
-                self._config.micro_file_name(),
-                self._config.tasking_num_workers(),
-                self._conn,
-                "MicroSimulationDefault",
-            )
-            self._model_manager.register(
-                micro_problem_cls, self._config.enable_micro_stateless()
             )
 
         # Create micro simulation objects

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -142,7 +142,7 @@ class MicroManagerCoupling(MicroManager):
         self._t = 0  # global time
         self._n = 0  # sim-step
 
-        self._model_manager = ModelManager()
+        self._model_manager = ModelManager(self._logger)
         self._conn = None
         self._is_load_balancing = (
             self._config.enable_load_balancing() and self._is_parallel

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -1,6 +1,12 @@
-from micro_manager.micro_simulation import (
+from typing import Optional, Any
+
+from .tools.logging_wrapper import Logger
+from .config import Config
+from .micro_simulation import (
     MicroSimulationClass,
     MicroSimulationInterface,
+    load_backend_class,
+    create_simulation_class,
 )
 
 
@@ -10,30 +16,18 @@ class ModelWrapper(MicroSimulationInterface):
     This is used to replace instances in the main simulation container.
     """
 
-    def __init__(self, global_id, backend):
+    def __init__(self, global_id: int, backend: MicroSimulationInterface):
         self._global_id = global_id
         self._backend = backend
 
-    def set_global_id(self, global_id):
+    def __getattr__(self, name):
+        return getattr(self._backend, name)
+
+    def set_global_id(self, global_id: int):
         self._global_id = global_id
 
     def get_global_id(self) -> int:
         return self._global_id
-
-    def solve(self, macro_data, dt):
-        return self._backend.solve(macro_data, dt)
-
-    def get_state(self):
-        return self._backend.get_state()
-
-    def set_state(self, state):
-        self._backend.set_state(state)
-
-    def initialize(self, *args, **kwargs):
-        return self._backend.initialize(*args, **kwargs)
-
-    def output(self):
-        return self._backend.output()
 
     def destroy(self):
         # we do not want to delete our compute instance
@@ -43,10 +37,6 @@ class ModelWrapper(MicroSimulationInterface):
     def __class__(self):
         return self._backend.__class__
 
-    @property
-    def name(self):
-        return self._backend.name
-
 
 class ModelManager:
     """
@@ -55,10 +45,31 @@ class ModelManager:
     as the ModelManager handles either case.
     """
 
-    def __init__(self):
+    def __init__(self, logger: Logger):
         self._registered_classes: list[MicroSimulationClass] = []
         self._stateless_map: dict[MicroSimulationClass, bool] = dict()
         self._backend_map: dict[MicroSimulationClass, MicroSimulationInterface] = dict()
+        self._logger: Logger = logger
+
+    def load_models(self, config: Config, n_workers: int, conn_workers: Optional[Any]):
+        stateless_flags = config.micro_stateless_flags()
+        for idx, model_file in enumerate(config.micro_file_names()):
+            try:
+                base_model = load_backend_class(model_file)
+                sim_cls = create_simulation_class(
+                    self._logger, base_model, model_file, n_workers, conn_workers
+                )
+                self.register(sim_cls, stateless_flags[idx])
+            except Exception as e:
+                self._logger.log_info_rank_zero(
+                    f"Failed to load model class with error: {e}"
+                )
+
+        if (
+            len(self._registered_classes) != len(stateless_flags)
+            or len(self._registered_classes) == 0
+        ):
+            raise RuntimeError("Not all models were loaded. Stopping!")
 
     def register(self, micro_sim_cls: MicroSimulationClass, stateless: bool):
         """
@@ -81,6 +92,10 @@ class ModelManager:
             self._backend_map[micro_sim_cls] = micro_sim_cls(
                 len(self._registered_classes) - 1
             )
+
+    @property
+    def num_models(self) -> int:
+        return len(self._registered_classes)
 
     def get_cls_by_name(self, name: str) -> MicroSimulationClass:
         """
@@ -115,6 +130,28 @@ class ModelManager:
             Class given by index
         """
         return self._registered_classes[idx]
+
+    def get_idx_of_sim(self, sim: MicroSimulationInterface) -> int:
+        """
+        Returns the model index of the provided simulation object
+
+        Parameters
+        ----------
+        sim: MicroSimulationInterface
+            simulation object to be checked
+
+        Returns
+        -------
+        idx: int
+            model index
+        """
+        return next(
+            (
+                idx
+                for idx, cls in enumerate(self._registered_classes)
+                if cls.name == sim.name
+            )
+        )
 
     def is_stateless(self, name: str) -> bool:
         """

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "micro_dummy",
+    "micro_file_names": ["micro_dummy"],
     "output_dir": "adaptivity_output",
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "micro_dummy",
+    "micro_file_names": ["micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "Macro-Cube-Mesh",

--- a/tests/integration/test_unit_cube/micro-manager-config-load-balancing.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-load-balancing.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "micro_dummy",
+    "micro_file_names": ["micro_dummy"],
     "output_dir": "adaptivity_output",
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "micro_dummy",
+    "micro_file_names": ["micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "Macro-Cube-Mesh",

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "micro_dummy",
+    "micro_file_names": ["micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "Macro-Cube-Mesh",

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "micro_dummy",
+    "micro_file_names": ["micro_dummy"],
     "coupling_params": {
         "precice_config_file_name": "precice-config.xml",
         "macro_mesh_name": "Macro-Cube-Mesh",

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "test_micro_manager",
+    "micro_file_names": ["test_micro_manager"],
     "coupling_params": {
         "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "Macro-Mesh",

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "test_micro_simulation_crash_handling",
+    "micro_file_names": ["test_micro_simulation_crash_handling"],
     "coupling_params": {
         "precice_config_file_name": "dummy-config.xml",
         "macro_mesh_name": "Macro-Mesh",


### PR DESCRIPTION
Before, simulation classes were owned in various locations (model adaptivity handler, micro manager, partially model manager).
With this implementation, the ownership and central loading method are transferred to the Model Manager.
Further, multiple Micro Simulation Classes can now be provided to the Micro Manager by default, rather than only when using Model Adaptivity. However, the excess classes are only used when Model Adaptivity is enabled. This should simplify the config file structure.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
