### PR TITLE
Refactor Adaptivity to a unified interface for all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Added uniform interface for Adaptivity for all cases [#294](https://github.com/precice/micro-manager/pull/294)
 - Fixed simulation activation issue of calling `get_state` prior to full initialization [#308](https://github.com/precice/micro-manager/pull/308)
 - Skipped double initialization of sim with id 0 when lazy initialization is used [#307](https://github.com/precice/micro-manager/pull/307)
 - Fixed macro data not populating adaptivity buffers and MPI irecv buffer size [#306](https://github.com/precice/micro-manager/pull/306)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -1,25 +1,68 @@
 """
 Functionality for adaptive initialization and control of micro simulations
 """
-
+from collections import defaultdict
 from math import exp
-from typing import Callable
-from micro_manager.tools.logging_wrapper import Logger
+from typing import Callable, Dict, Optional, List, Any, Union, Tuple
+from abc import ABC
+
 from micro_manager.config import Config
 from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.model_manager import ModelManager
 from micro_manager.simulation_container import SimulationContainer
+from micro_manager.adaptivity.adaptivity_interface import AdaptivityInterface
+from micro_manager.tools.profiling import Profiler
+from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.mpi_handler import MPIHandler
 
 import numpy as np
 
 
-class AdaptivityCalculator:
+class NoOpAdaptivity(AdaptivityInterface):
+    """
+    Adaptivity implementation that does not perform any adaptivity.
+    """
+
+    def __init__(self, container: SimulationContainer) -> None:
+        self._container: SimulationContainer = container
+
+    def get_active_steps(self) -> Dict[int, int]:
+        return defaultdict(lambda: 0)
+
+    def get_active_lids(self) -> List[int]:
+        return list(self._container.range_lid)
+
+    def get_inactive_lids(self) -> List[int]:
+        return []
+
+    def get_active_gids(self) -> List[int]:
+        return self._container.local_gids
+
+    def get_inactive_gids(self) -> List[int]:
+        return []
+
+    def get_full_field_micro_output(
+        self,
+        micro_input: List[Dict[str, Any]],
+        micro_output: List[Optional[Dict[str, Any]]],
+    ) -> List[Dict[str, Any]]:
+        assert all([entry is not None for entry in micro_output])
+        return micro_output
+
+    def get_adaptivity_buffer(self) -> Dict[str, List[Any]]:
+        return {}
+
+    def get_associated_map(self) -> Dict[int, int]:
+        return {}
+
+
+class AdaptivityCalculator(AdaptivityInterface, ABC):
     def __init__(
         self,
         config: Config,
         nsims: int,
         sim_container: SimulationContainer,
+        profiler: Profiler,
         micro_problem_cls: MicroSimulationClass,
         model_manager: ModelManager,
         base_logger: Logger,
@@ -33,9 +76,11 @@ class AdaptivityCalculator:
         config : object of class Config
             Object which has getter functions to get parameters defined in the configuration file.
         nsims : int
-            Number of micro simulations.
+            Initial number of micro simulations.
         sim_container : SimulationContainer
             Simulation container object.
+        profiler: Profiler
+            Profiler object
         micro_problem_cls : callable
             Class of micro problem.
         model_manager : object
@@ -45,84 +90,203 @@ class AdaptivityCalculator:
         mpi : MPIHandler
             mpi handler object
         """
-        self._refine_const = config.adaptivity_refining_constant()
-        self._coarse_const = config.adaptivity_coarsening_constant()
-        self._hist_param = config.adaptivity_history_param()
-        self._adaptivity_data_names = config.data_for_adaptivity()
-        self._adaptivity_type = config.adaptivity_type()
-        self._adaptivity_output_type = config.adaptivity_output_type()
-
-        self._micro_problem_cls = micro_problem_cls
-        self._model_manager = model_manager
+        # ===============================
+        # Other Modules and Configuration
+        # ===============================
+        self._micro_problem_cls: MicroSimulationClass = micro_problem_cls
+        self._model_manager: ModelManager = model_manager
         self._sim_container: SimulationContainer = sim_container
+        self._profiler: Profiler = profiler
+        self._mpi: MPIHandler = mpi
+        self._base_logger: Logger = base_logger
+        self._logger_global_metrics: Optional[Logger] = None
+        self._logger_local_metrics: Optional[Logger] = None
+        self._interpolation = (
+            None  # to be init by inheriting class (TODO needs interface)
+        )
+        self._interp_min: int = -1
+        self._mappings: List[Tuple[List[str], List[str]]] = []
+        self._mapping_configs: List[Dict[str, Any]] = []
 
-        self._coarse_tol = 0.0
-        self._ref_tol = 0.0
+        self._refine_const: float = config.adaptivity_refining_constant()
+        self._coarse_const: float = config.adaptivity_coarsening_constant()
+        self._hist_param: float = config.adaptivity_history_param()
 
-        self._mpi = mpi
-        self._base_logger = base_logger
+        self._coarse_tol: float = 0.0
+        self._ref_tol: float = 0.0
+        self._max_similarity_dist: float = 0.0
 
-        self._max_similarity_dist = 0.0
+        self._similarity_measure: Callable[
+            [np.ndarray], np.ndarray
+        ] = self._get_similarity_measure(config.adaptivity_similarity_measure())
 
-        self._interpolation = None
-        self._interp_min = -1
-        self._mappings = []
-        self._mapping_configs = []
-        mappings = config.adaptivity_mapping_configs()
-        self._load_mappings(mappings)
+        self._data_names: List[str] = config.data_for_adaptivity()
+        # Names of macro data to be used for adaptivity computation
+        self._macro_data_names: List[str] = []
+        # Names of micro data to be used for adaptivity computation
+        self._micro_data_names: List[str] = []
+        self._run_every_step: bool = config.enable_adaptivity_each_implicit_iteration()
+        self._n: int = config.adaptivity_n()
+        self._output_n: int = config.adaptivity_output_n()
 
+        # ===============================
+        #         Data Buffers
+        # ===============================
+        self._data_for_adaptivity: Dict[str, List[Any]] = dict()
         # is_sim_active: 1D array having state (active or inactive) of each micro simulation
         # Start adaptivity calculation with all sims active
         # This array is modified in place via the function update_active_sims and update_inactive_sims
-        self._is_sim_active = np.array([True] * nsims, dtype=np.bool_)
-
+        self._is_sim_active: np.ndarray = np.array([True] * nsims, dtype=np.bool_)
+        self._sim_active_steps: Dict[int, int] = {
+            gid: 0 for gid in self._sim_container.local_gids
+        }
         # sim_is_associated_to: 1D array with values of associated simulations of inactive simulations. Active simulations have None
         # Active sims do not have an associated sim
         # This array is modified in place via the function associate_inactive_to_active
-        self._sim_is_associated_to = np.full((nsims), -2, dtype=np.intc)
+        self._sim_is_associated_to: Dict[int, int] = {}
+        self._just_deactivated: List[int] = []
+        self._similarity_dists: np.ndarray = np.empty(shape=0)
 
-        self._just_deactivated: list[int] = []
-
-        self._similarity_measure = self._get_similarity_measure(
-            config.adaptivity_similarity_measure()
-        )
-
+        # ===============================
+        #      Member Initialization
+        # ===============================
+        self.update_buffers(alloc=True)
+        # initialize mappings
+        mappings = config.adaptivity_mapping_configs()
+        self._load_mappings(mappings)
+        # initialize read/write names
+        coupling_read_names = config.read_data_names()
+        coupling_write_names = config.write_data_names()
+        for name in self._data_names:
+            if name in coupling_read_names:
+                self._macro_data_names.append(name)
+            if name in coupling_write_names:
+                self._micro_data_names.append(name)
+        # initialize output
         output_dir = config.output_dir()
-
+        metrics_output_dir = "adaptivity-metrics"
         if output_dir is not None:
-            metrics_output_dir = output_dir + "/adaptivity-metrics"
-        else:
-            metrics_output_dir = "adaptivity-metrics"
-
-        if self._mpi.rank == 0 and (
-            self._adaptivity_output_type == "global"
-            or self._adaptivity_output_type == "all"
-        ):
-            self._global_metrics_logger = Logger(
+            metrics_output_dir = f"{output_dir}/{metrics_output_dir}"
+        output_type = config.adaptivity_output_type()
+        # initialize global logging
+        if self._mpi.rank == 0 and output_type in ["global", "all"]:
+            self._logger_global_metrics = Logger(
                 "global-metrics-logger",
                 metrics_output_dir + "-global.csv",
                 self._mpi.rank,
                 csv_logger=True,
             )
-
-            self._global_metrics_logger.log_info(
+            self._logger_global_metrics.log_info(
                 "n|n active|n inactive|avg active|avg inactive|max active|rank of max active|max inactive|rank of max inactive"
             )
-
-        if (
-            self._adaptivity_output_type == "local"
-            or self._adaptivity_output_type == "all"
-        ):
-            self._metrics_logger = Logger(
+        # initialize local logging
+        if output_type in ["local", "all"]:
+            self._logger_local_metrics = Logger(
                 "metrics-logger",
                 metrics_output_dir + "-" + str(self._mpi.rank) + ".csv",
                 self._mpi.rank,
                 csv_logger=True,
             )
+            self._logger_local_metrics.log_info("n|n active|n inactive|assoc ranks")
 
-            self._metrics_logger.log_info("n|n active|n inactive|assoc ranks")
+    def compute_step(self, n: int, first_iteration: bool, dt: float):
+        if n % self._n != 0:
+            return
+        if not (self._run_every_step or first_iteration):
+            return
 
-    def _load_mappings(self, mappings: list) -> None:
+        with self._profiler.measure("micro_manager.solve.adaptivity_computation"):
+            # compute adaptivity
+            self.compute(dt)
+
+            # update counters
+            active_gids = self.get_active_gids()
+            for gid in active_gids:
+                self._sim_active_steps[gid] += 1
+            # Write a checkpoint if a simulation is just activated.
+            # This checkpoint will be asynchronous to the checkpoints written at the start of the time window.
+            self._sim_container.write_checkpoints(only_none=True)
+
+    def get_active_steps(self) -> Dict[int, int]:
+        return self._sim_active_steps
+
+    def get_macro_data_names(self) -> Optional[List[str]]:
+        return self._macro_data_names
+
+    def get_micro_data_names(self) -> Optional[List[str]]:
+        return self._micro_data_names
+
+    def postprocess_active_output(self, micro_output: Dict[str, Any], gid: int) -> None:
+        micro_output["Active-State"] = 1
+        micro_output["Active-Steps"] = self._sim_active_steps[gid]
+
+    def postprocess_inactive_output(
+        self, micro_output: Dict[str, Any], gid: int
+    ) -> None:
+        micro_output["Active-State"] = 0
+        micro_output["Active-Steps"] = self._sim_active_steps[gid]
+
+    def postprocess_remove(self, micro_output: Dict[str, Any]) -> None:
+        del micro_output["Active-State"]
+        del micro_output["Active-Steps"]
+
+    def get_associated_map(self) -> Dict[int, int]:
+        return self._sim_is_associated_to
+
+    def get_adaptivity_buffer(self) -> Dict[str, List[Any]]:
+        return self._data_for_adaptivity
+
+    def get_read_buffer(self) -> Optional[Dict[str, List[Any]]]:
+        return {}
+
+    def update_buffers(
+        self,
+        micro_data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]] = None,
+        macro_data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]] = None,
+        invert: bool = False,
+        alloc: bool = False,
+    ) -> None:
+        if alloc:
+            for name in self._data_names:
+                self._data_for_adaptivity[name] = [
+                    0
+                ] * self._sim_container.local_num_sims
+
+        self._update_data_buffers_impl(self._micro_data_names, micro_data, invert)
+        self._update_data_buffers_impl(self._macro_data_names, macro_data, invert)
+
+    def _update_data_buffers_impl(
+        self,
+        names: List[str],
+        data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]] = None,
+        invert: bool = False,
+    ) -> None:
+        """
+        Copies data from the provided data buffer into the adaptivity buffer with the selected names.
+
+        Parameters
+        ----------
+        names : List[str]
+            Name selection.
+        data : Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]]
+            Data to be copied.
+        invert : bool
+            If True, then the expected data format is a dictionary of lists.
+        """
+        if data is None:
+            return
+
+        # writing loops explicitly to avoid branching within
+        if invert:
+            for name in names:
+                for lid in self._sim_container.range_lid:
+                    self._data_for_adaptivity[name][lid] = data[name][lid]
+        else:
+            for lid in self._sim_container.range_lid:
+                for name in names:
+                    self._data_for_adaptivity[name][lid] = data[lid][name]
+
+    def _load_mappings(self, mappings: List[Dict[str, Any]]) -> None:
         """
         Translates the mapping information provided from the configuration file into a
         interpolation method parseable structure.
@@ -132,7 +296,7 @@ class AdaptivityCalculator:
 
         Parameters
         ----------
-        mappings : list
+        mappings : List[Dict[str, Any]]
             List of mappings as provided by the configuration file.
         """
         for mapping in mappings:
@@ -228,7 +392,7 @@ class AdaptivityCalculator:
 
             self._sim_is_associated_to[inactive_id] = associated_active_id
 
-    def _check_for_activation(self, inactive_id: int, active_ids: np.ndarray) -> bool:
+    def _check_for_activation(self, inactive_id: int, active_ids: List[int]) -> bool:
         """
         Check if an inactive simulation needs to be activated.
 
@@ -236,8 +400,8 @@ class AdaptivityCalculator:
         ----------
         inactive_id : int
             ID of inactive simulation which is checked for activation.
-        active_ids : numpy array
-            1D array having IDs of active micro simulations.
+        active_ids : List[int]
+            List containing IDs of active micro simulations.
         Return
         ------
         tag : bool
@@ -248,7 +412,7 @@ class AdaptivityCalculator:
         # If inactive sim is not similar to any active sim, activate it
         return min(dists) > self._ref_tol
 
-    def _check_for_deactivation(self, active_id: int, active_ids: list) -> bool:
+    def _check_for_deactivation(self, active_id: int, active_ids: List[int]) -> bool:
         """
         Check if an active simulation needs to be deactivated.
 
@@ -256,7 +420,7 @@ class AdaptivityCalculator:
         ----------
         active_id : int
             ID of active simulation which is checked for deactivation.
-        active_ids : list
+        active_ids : List[int]
             List having IDs of active micro simulations.
 
         Return
@@ -271,7 +435,11 @@ class AdaptivityCalculator:
                     return True
         return False
 
-    def _interpolate_output(self, micro_input, micro_sims_output) -> None:
+    def _interpolate_output(
+        self,
+        micro_input: List[Dict[str, Any]],
+        micro_sims_output: List[Dict[str, Any]],
+    ) -> None:
         """
         Interpolates the micro output based on the available inputs and outputs using the selected
         interpolation method and desired mappings.
@@ -284,10 +452,10 @@ class AdaptivityCalculator:
 
         Parameters
         ----------
-        micro_input : list
+        micro_input : List[Dict[str, Any]]
             List of all local micro simulation inputs.
 
-        micro_sims_output : list
+        micro_sims_output : List[Dict[str, Any]]
             List of all local micro simulation outputs. (current state)
         """
         targets = []
@@ -296,8 +464,8 @@ class AdaptivityCalculator:
         assert len(targets) == len(set(targets))
 
         # precompute arg sizes
-        active_lids = self.get_active_sim_local_ids()
-        inactive_lids = self.get_inactive_sim_local_ids()
+        active_lids = self.get_active_lids()
+        inactive_lids = self.get_inactive_lids()
         arg_sizes = {}
         for name, value in micro_input[-1].items():
             arg_sizes[name] = (

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -278,10 +278,14 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
 
         # writing loops explicitly to avoid branching within
         if invert:
+            if len(data.keys()) == 0:
+                return
             for name in names:
                 for lid in self._sim_container.range_lid:
                     self._data_for_adaptivity[name][lid] = data[name][lid]
         else:
+            if len(data) == 0:
+                return
             for lid in self._sim_container.range_lid:
                 for name in names:
                     self._data_for_adaptivity[name][lid] = data[lid][name]

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -48,7 +48,9 @@ class NoOpAdaptivity(AdaptivityInterface):
         micro_output: List[Optional[Dict[str, Any]]],
     ) -> List[Dict[str, Any]]:
         if any([entry is None for entry in micro_output]):
-            raise RuntimeError("Some micro outputs are None. NoOpAdaptivity requires fully populated micro output.")
+            raise RuntimeError(
+                "Some micro outputs are None. NoOpAdaptivity requires fully populated micro output."
+            )
         return micro_output
 
     def get_adaptivity_buffer(self) -> Dict[str, List[Any]]:
@@ -166,7 +168,7 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
                 self._macro_data_names.append(name)
             if name in coupling_write_names:
                 self._micro_data_names.append(name)
-        
+
         # initialize output
         output_dir = config.output_dir()
         metrics_output_dir = "adaptivity-metrics"
@@ -209,7 +211,7 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
 
             # update counters
             active_gids = self.get_active_gids()
-    
+
             for gid in active_gids:
                 self._sim_active_steps[gid] += 1
             # Write a checkpoint if a simulation is just activated.

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -526,8 +526,9 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
                     ]
                     offset += arg_sizes[dst_arg]
 
+    @staticmethod
     def _get_similarity_measure(
-        self, similarity_measure: str
+        similarity_measure: str,
     ) -> Callable[[np.ndarray], np.ndarray]:
         """
         Get similarity measure to be used for similarity calculation
@@ -543,19 +544,20 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
             Function to be used for similarity calculation. Takes data as input and returns similarity measure
         """
         if similarity_measure == "L1":
-            return self._l1
+            return AdaptivityCalculator._l1
         elif similarity_measure == "L2":
-            return self._l2
+            return AdaptivityCalculator._l2
         elif similarity_measure == "L1rel":
-            return self._l1rel
+            return AdaptivityCalculator._l1rel
         elif similarity_measure == "L2rel":
-            return self._l2rel
+            return AdaptivityCalculator._l2rel
         else:
             raise ValueError(
                 'Similarity measure not supported. Currently supported similarity measures are "L1", "L2", "L1rel", "L2rel".'
             )
 
-    def _l1(self, data: np.ndarray) -> np.ndarray:
+    @staticmethod
+    def _l1(data: np.ndarray) -> np.ndarray:
         """
         Calculate L1 norm of data
 
@@ -571,7 +573,8 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
         """
         return np.linalg.norm(data[np.newaxis, :] - data[:, np.newaxis], ord=1, axis=-1)
 
-    def _l2(self, data: np.ndarray) -> np.ndarray:
+    @staticmethod
+    def _l2(data: np.ndarray) -> np.ndarray:
         """
         Calculate L2 norm of data
 
@@ -587,7 +590,8 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
         """
         return np.linalg.norm(data[np.newaxis, :] - data[:, np.newaxis], ord=2, axis=-1)
 
-    def _l1rel(self, data: np.ndarray) -> np.ndarray:
+    @staticmethod
+    def _l1rel(data: np.ndarray) -> np.ndarray:
         """
         Calculate L1 norm of relative difference of data.
         The relative difference is calculated by dividing the difference of two data points by the maximum of the absolute value of the two data points.
@@ -612,7 +616,8 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
             axis=-1,
         )
 
-    def _l2rel(self, data: np.ndarray) -> np.ndarray:
+    @staticmethod
+    def _l2rel(data: np.ndarray) -> np.ndarray:
         """
         Calculate L2 norm of relative difference of data.
         The relative difference is calculated by dividing the difference of two data points by the maximum of the absolute value of the two data points.

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -177,7 +177,7 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
         output_type = config.adaptivity_output_type()
 
         # initialize global logging
-        if self._mpi.rank == 0 and output_type in ["global", "all"]:
+        if output_type in ["global", "all"]:
             self._logger_global_metrics = Logger(
                 "global-metrics-logger",
                 metrics_output_dir + "-global.csv",

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -21,6 +21,7 @@ import numpy as np
 class NoOpAdaptivity(AdaptivityInterface):
     """
     Adaptivity implementation that does not perform any adaptivity.
+    All micro problems are active in all time windows.
     """
 
     def __init__(self, container: SimulationContainer) -> None:
@@ -46,7 +47,8 @@ class NoOpAdaptivity(AdaptivityInterface):
         micro_input: List[Dict[str, Any]],
         micro_output: List[Optional[Dict[str, Any]]],
     ) -> List[Dict[str, Any]]:
-        assert all([entry is not None for entry in micro_output])
+        if any([entry is None for entry in micro_output]):
+            raise RuntimeError("Some micro outputs are None. NoOpAdaptivity requires fully populated micro output.")
         return micro_output
 
     def get_adaptivity_buffer(self) -> Dict[str, List[Any]]:
@@ -151,9 +153,11 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
         #      Member Initialization
         # ===============================
         self.update_buffers(alloc=True)
+
         # initialize mappings
         mappings = config.adaptivity_mapping_configs()
         self._load_mappings(mappings)
+
         # initialize read/write names
         coupling_read_names = config.read_data_names()
         coupling_write_names = config.write_data_names()
@@ -162,12 +166,14 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
                 self._macro_data_names.append(name)
             if name in coupling_write_names:
                 self._micro_data_names.append(name)
+        
         # initialize output
         output_dir = config.output_dir()
         metrics_output_dir = "adaptivity-metrics"
         if output_dir is not None:
             metrics_output_dir = f"{output_dir}/{metrics_output_dir}"
         output_type = config.adaptivity_output_type()
+
         # initialize global logging
         if self._mpi.rank == 0 and output_type in ["global", "all"]:
             self._logger_global_metrics = Logger(
@@ -179,6 +185,7 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
             self._logger_global_metrics.log_info(
                 "n|n active|n inactive|avg active|avg inactive|max active|rank of max active|max inactive|rank of max inactive"
             )
+
         # initialize local logging
         if output_type in ["local", "all"]:
             self._logger_local_metrics = Logger(
@@ -190,6 +197,7 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
             self._logger_local_metrics.log_info("n|n active|n inactive|assoc ranks")
 
     def compute_step(self, n: int, first_iteration: bool, dt: float):
+        # See AdaptivityInterface for docstring
         if n % self._n != 0:
             return
         if not (self._run_every_step or first_iteration):
@@ -201,6 +209,7 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
 
             # update counters
             active_gids = self.get_active_gids()
+    
             for gid in active_gids:
                 self._sim_active_steps[gid] += 1
             # Write a checkpoint if a simulation is just activated.
@@ -208,35 +217,44 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
             self._sim_container.write_checkpoints(only_none=True)
 
     def get_active_steps(self) -> Dict[int, int]:
+        # See AdaptivityInterface for docstring
         return self._sim_active_steps
 
     def get_macro_data_names(self) -> Optional[List[str]]:
+        # See AdaptivityInterface for docstring
         return self._macro_data_names
 
     def get_micro_data_names(self) -> Optional[List[str]]:
+        # See AdaptivityInterface for docstring
         return self._micro_data_names
 
     def postprocess_active_output(self, micro_output: Dict[str, Any], gid: int) -> None:
+        # See AdaptivityInterface for docstring
         micro_output["Active-State"] = 1
         micro_output["Active-Steps"] = self._sim_active_steps[gid]
 
     def postprocess_inactive_output(
         self, micro_output: Dict[str, Any], gid: int
     ) -> None:
+        # See AdaptivityInterface for docstring
         micro_output["Active-State"] = 0
         micro_output["Active-Steps"] = self._sim_active_steps[gid]
 
     def postprocess_remove(self, micro_output: Dict[str, Any]) -> None:
+        # See AdaptivityInterface for docstring
         del micro_output["Active-State"]
         del micro_output["Active-Steps"]
 
     def get_associated_map(self) -> Dict[int, int]:
+        # See AdaptivityInterface for docstring
         return self._sim_is_associated_to
 
     def get_adaptivity_buffer(self) -> Dict[str, List[Any]]:
+        # See AdaptivityInterface for docstring
         return self._data_for_adaptivity
 
     def get_read_buffer(self) -> Optional[Dict[str, List[Any]]]:
+        # See AdaptivityInterface for docstring
         return {}
 
     def update_buffers(
@@ -246,6 +264,7 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
         invert: bool = False,
         alloc: bool = False,
     ) -> None:
+        # See AdaptivityInterface for docstring
         if alloc:
             for name in self._data_names:
                 self._data_for_adaptivity[name] = [

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -184,7 +184,7 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
                 self._mpi.rank,
                 csv_logger=True,
             )
-            self._logger_global_metrics.log_info(
+            self._logger_global_metrics.log_info_rank_zero(
                 "n|n active|n inactive|avg active|avg inactive|max active|rank of max active|max inactive|rank of max inactive"
             )
 

--- a/micro_manager/adaptivity/adaptivity_interface.py
+++ b/micro_manager/adaptivity/adaptivity_interface.py
@@ -47,7 +47,9 @@ class AdaptivityInterface(ABC):
         """
         return
 
-    def postprocess_inactive_output(self, micro_output: Dict[str, Any], gid: int) -> None:
+    def postprocess_inactive_output(
+        self, micro_output: Dict[str, Any], gid: int
+    ) -> None:
         """
         Attached adaptivity data to the given micro simulation output.
 
@@ -83,11 +85,11 @@ class AdaptivityInterface(ABC):
         return
 
     def update_buffers(
-            self,
-            micro_data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]]=None,
-            macro_data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]]=None,
-            invert: bool=False,
-            alloc: bool=False,
+        self,
+        micro_data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]] = None,
+        macro_data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]] = None,
+        invert: bool = False,
+        alloc: bool = False,
     ) -> None:
         """
         Updates the rank local computation buffer with the provided data.
@@ -205,9 +207,9 @@ class AdaptivityInterface(ABC):
 
     @abstractmethod
     def get_full_field_micro_output(
-            self,
-            micro_input: List[Dict[str, Any]],
-            micro_output: List[Optional[Dict[str, Any]]]
+        self,
+        micro_input: List[Dict[str, Any]],
+        micro_output: List[Optional[Dict[str, Any]]],
     ) -> List[Dict[str, Any]]:
         """
         Constructs the simulation outputs for all inactive simulations (given by missing output data).
@@ -252,9 +254,7 @@ class AdaptivityInterface(ABC):
         ...
 
     def check_micro_simulation_initialize(
-            self,
-            logger: Logger,
-            micro_init_return_value: Optional[Dict[str, Any]]
+        self, logger: Logger, micro_init_return_value: Optional[Dict[str, Any]]
     ) -> None:
         """
         Performs an initial check on the keys of the micro simulation output. (used during initialization)
@@ -286,7 +286,3 @@ class AdaptivityInterface(ABC):
             logger.log_warning_rank_zero(
                 f'The initialize() method of the Micro simulation returns extra initial data which isn\'t used by the adaptivity: {", ".join(extra)}'
             )
-
-
-
-

--- a/micro_manager/adaptivity/adaptivity_interface.py
+++ b/micro_manager/adaptivity/adaptivity_interface.py
@@ -1,0 +1,292 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any, List, Optional, Union
+
+from micro_manager.tools.logging_wrapper import Logger
+
+
+class AdaptivityInterface(ABC):
+    def compute(self, dt: float) -> None:
+        """
+        Performs the internal adaptivity computation.
+        Will be called by compute_step, if the computation criteria are met.
+
+        Parameters
+        ----------
+        dt : float
+            Delta time within current time window.
+        """
+        return
+
+    def compute_step(self, n: int, first_iteration: bool, dt: float) -> None:
+        """
+        Main driving method of adaptivity.
+        Checks the provided parameters whether adaptivity should be performed.
+        Calls compute.
+
+        Parameters
+        ----------
+        n : int
+            Current time step number.
+        first_iteration : bool
+            True if this is the first iteration of the current time window.
+        dt : float
+            Delta time within current time window.
+        """
+        return
+
+    def postprocess_active_output(self, micro_output: Dict[str, Any], gid: int) -> None:
+        """
+        Attached adaptivity data to the given micro simulation output.
+
+        Parameters
+        ----------
+        micro_output : Dict[str, Any]
+            Micro simulation output. (active simulation)
+        gid : int
+            GID of the corresponding micro simulation.
+        """
+        return
+
+    def postprocess_inactive_output(self, micro_output: Dict[str, Any], gid: int) -> None:
+        """
+        Attached adaptivity data to the given micro simulation output.
+
+        Parameters
+        ----------
+        micro_output : Dict[str, Any]
+            Micro simulation output. (inactive simulation)
+        gid : int
+            GID of the corresponding micro simulation.
+        """
+        return
+
+    def postprocess_remove(self, micro_output: Dict[str, Any]) -> None:
+        """
+        Removes any attached adaptivity data from the given micro simulation output.
+
+        Parameters
+        ----------
+        micro_output : Dict[str, Any]
+            Micro simulation output.
+        """
+        return
+
+    def log_metrics(self, n: int) -> None:
+        """
+        Optionally logs the configured adaptivity metrics for the provided time step number.
+
+        Parameters
+        ----------
+        n : int
+            Current time step number.
+        """
+        return
+
+    def update_buffers(
+            self,
+            micro_data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]]=None,
+            macro_data: Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]]=None,
+            invert: bool=False,
+            alloc: bool=False,
+    ) -> None:
+        """
+        Updates the rank local computation buffer with the provided data.
+        If alloc is True, then the rank local buffers are reallocated to the current
+        simulation container size. micro_data and macro_data can be either provided
+        as lists of data dictionaries or as a dictionary of data lists.
+        In case of the latter, invert must be set to True.
+
+        Parameters
+        ----------
+        micro_data : Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]]
+            Micro simulation output data.
+        macro_data : Optional[Union[List[Dict[str, Any]], Dict[str, List[Any]]]]
+            Micro simulation input data.
+        invert : bool
+            If True, then the expected data format is a dictionary of lists.
+        alloc : bool
+            If True, reallocates rank local data buffers.
+        """
+        return
+
+    def get_read_buffer(self) -> Optional[Dict[str, List[Any]]]:
+        """
+        If required by the underlying implementation, returns a buffer into which
+        the CouplingHandler can write the read data directly into.
+
+        Returns
+        -------
+        read_buffer : Optional[Dict[str, List[Any]]]
+            Read buffer for CouplingHandler. (can be None)
+        """
+        return None
+
+    def get_macro_data_names(self) -> Optional[List[str]]:
+        """
+        Gets the relevant data names for adaptivity from the micro simulation inputs.
+
+        Returns
+        -------
+        macro_data_names : Optional[List[str]]
+            Micro simulation input data names.
+        """
+        return None
+
+    def get_micro_data_names(self) -> Optional[List[str]]:
+        """
+        Gets the relevant data names for adaptivity from the micro simulation outputs.
+
+        Returns
+        -------
+        micro_data_names : Optional[List[str]]
+            Micro simulation output data names.
+        """
+        return None
+
+    @abstractmethod
+    def get_active_steps(self) -> Dict[int, int]:
+        """
+        Gets a map from GIDs to their number of active simulation steps.
+
+        Returns
+        -------
+        active_steps : Dict[int, int]
+            Map from GIDs to their number of active simulation steps.
+        """
+        ...
+
+    @abstractmethod
+    def get_active_lids(self) -> List[int]:
+        """
+        Gets a list of the (rank local) active LIDs.
+
+        Returns
+        -------
+        active_lids : List[int]
+            List of the (rank local) active LIDs.
+        """
+        ...
+
+    @abstractmethod
+    def get_inactive_lids(self) -> List[int]:
+        """
+        Gets a list of the (rank local) inactive LIDs.
+
+        Returns
+        -------
+        inactive_lids : List[int]
+            List of the (rank local) inactive LIDs.
+        """
+        ...
+
+    @abstractmethod
+    def get_active_gids(self) -> List[int]:
+        """
+        Gets a list of the (rank local) active GIDs.
+
+        Returns
+        -------
+        active_gids : List[int]
+            List of the (rank local) active GIDs.
+        """
+        ...
+
+    @abstractmethod
+    def get_inactive_gids(self) -> List[int]:
+        """
+        Gets a list of the (rank local) inactive GIDs.
+
+        Returns
+        -------
+        inactive_gids : List[int]
+            List of the (rank local) inactive GIDs.
+        """
+        ...
+
+    @abstractmethod
+    def get_full_field_micro_output(
+            self,
+            micro_input: List[Dict[str, Any]],
+            micro_output: List[Optional[Dict[str, Any]]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Constructs the simulation outputs for all inactive simulations (given by missing output data).
+
+        Parameters
+        ----------
+        micro_input : List[Dict[str, Any]]
+            Micro simulation input data.
+        micro_output : List[Optional[Dict[str, Any]]]
+            Micro simulation output data buffer. Active simulation outputs are available, inactive ones are None.
+
+        Returns
+        -------
+        full_field_micro_output : List[Dict[str, Any]]
+             Fully populated simulation output data.
+        """
+        ...
+
+    @abstractmethod
+    def get_adaptivity_buffer(self) -> Dict[str, List[Any]]:
+        """
+        Gets the rank local data buffer used for adaptivity computation.
+
+        Returns
+        -------
+        adaptivity_buffer : Dict[str, List[Any]]
+            Keys are data names, values are rank local data buffers.
+        """
+        ...
+
+    @abstractmethod
+    def get_associated_map(self) -> Dict[int, int]:
+        """
+        Gets an association map of inactive simulations to active simulations given by IDs.
+        For LocalAdaptivity the IDs are LIDs. For GlobalAdaptivity the IDs are GIDs.
+
+        Returns
+        -------
+        associated_map : Dict[int, int]
+            Keys are inactive IDs, values are active IDs.
+        """
+        ...
+
+    def check_micro_simulation_initialize(
+            self,
+            logger: Logger,
+            micro_init_return_value: Optional[Dict[str, Any]]
+    ) -> None:
+        """
+        Performs an initial check on the keys of the micro simulation output. (used during initialization)
+
+        Parameters
+        ----------
+        logger : Logger
+            Logger object.
+        micro_init_return_value : Optional[Dict[str, Any]]
+            Optional micro simulation return value.
+        """
+        if micro_init_return_value is None:
+            return
+
+        macro_names = self.get_macro_data_names()
+        micro_names = self.get_micro_data_names()
+        if macro_names is None or micro_names is None:
+            return
+
+        # Check for missing data
+        expected = set(micro_names)
+        provided = set(micro_init_return_value.keys())
+        if missing := expected - provided:
+            raise Exception(
+                "The initialize() method needs to return data which is required for the adaptivity calculation. "
+                f'Of the expected data {", ".join(expected)}, the following is missing: {", ".join(missing)}'
+            )
+        elif extra := provided - set(macro_names + micro_names):
+            logger.log_warning_rank_zero(
+                f'The initialize() method of the Micro simulation returns extra initial data which isn\'t used by the adaptivity: {", ".join(extra)}'
+            )
+
+
+
+

--- a/micro_manager/adaptivity/adaptivity_selection.py
+++ b/micro_manager/adaptivity/adaptivity_selection.py
@@ -1,38 +1,42 @@
-from .global_adaptivity import GlobalAdaptivityCalculator
-from .local_adaptivity import LocalAdaptivityCalculator
-from .adaptivity import AdaptivityCalculator
+from micro_manager.config import Config
+from micro_manager.simulation_container import SimulationContainer
+from micro_manager.tools.profiling import Profiler
+from micro_manager.tools.logging_wrapper import Logger
+from micro_manager.tools.mpi_handler import MPIHandler
+from micro_manager.micro_simulation import MicroSimulationClass
+from micro_manager.model_manager import ModelManager
+from micro_manager.adaptivity.adaptivity_interface import AdaptivityInterface
+from micro_manager.adaptivity.adaptivity import NoOpAdaptivity
+from micro_manager.adaptivity.local_adaptivity import LocalAdaptivityCalculator
+from micro_manager.adaptivity.global_adaptivity import GlobalAdaptivityCalculator
 
 
 def create_adaptivity_calculator(
-    config,
-    sim_container,
-    profiler,
-    logger,
-    mpi,
-    micro_problem_cls,
-    model_manager,
-) -> AdaptivityCalculator:
+    config: Config,
+    sim_container: SimulationContainer,
+    profiler: Profiler,
+    logger: Logger,
+    mpi: MPIHandler,
+    micro_problem_cls: MicroSimulationClass,
+    model_manager: ModelManager,
+) -> AdaptivityInterface:
+    if not config.enable_adaptivity():
+        return NoOpAdaptivity(sim_container)
+
     adaptivity_type = config.adaptivity_type()
-
-    if adaptivity_type == "local":
-        return LocalAdaptivityCalculator(
-            config,
-            sim_container,
-            logger,
-            mpi,
-            micro_problem_cls,
-            model_manager,
-        )
-
-    if adaptivity_type == "global":
-        return GlobalAdaptivityCalculator(
-            config,
-            sim_container,
-            profiler,
-            logger,
-            mpi,
-            micro_problem_cls,
-            model_manager,
-        )
+    args = (
+        config,
+        sim_container,
+        profiler,
+        logger,
+        mpi,
+        micro_problem_cls,
+        model_manager,
+    )
+    match adaptivity_type:
+        case "local":
+            return LocalAdaptivityCalculator(*args)
+        case "global":
+            return GlobalAdaptivityCalculator(*args)
 
     raise ValueError("Unknown adaptivity type")

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -5,8 +5,9 @@ on each rank is done.
 
 Note: All ID variables used in the methods of this class are global IDs, unless they have *local* in their name.
 """
+from collections import defaultdict
 from copy import deepcopy
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 import numpy as np
 
 from .adaptivity import AdaptivityCalculator
@@ -55,6 +56,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             config,
             sim_container.global_num_sims,
             sim_container,
+            profiler,
             micro_problem_cls,
             model_manager,
             base_logger,
@@ -62,7 +64,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         )
 
         self._interpolation = RBF_PU(base_logger, mpi)
-        self._profiler = profiler
 
         buffer_size = self._sim_container.global_num_sims**2
         array_buffer, mpi_node = self._mpi.create_node_buffer(MPI.FLOAT, buffer_size)
@@ -83,11 +84,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             # Initialize the similarity distances to zero
             self._similarity_dists.fill(0.0)
 
-    def compute_adaptivity(
-        self,
-        dt: float,
-        data_for_adaptivity: dict,
-    ) -> None:
+    def compute(self, dt: float) -> None:
         """
         Compute adaptivity globally based on similarity distances and micro simulation states
 
@@ -95,23 +92,19 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         dt : float
             Current time step of the macro-micro coupled problem
-        micro_sims : list
-            List of objects of class MicroProblem, which are the micro simulations
-        data_for_adaptivity : dict
-            Dictionary with keys as names of data to be used in the similarity calculation, and values as the respective data for the micro simulations
         """
-        for name in data_for_adaptivity.keys():
-            if name not in self._adaptivity_data_names:
+        for name in self._data_for_adaptivity.keys():
+            if name not in self._data_names:
                 raise ValueError(
                     "Data for adaptivity must be one of the following: {}".format(
-                        self._adaptivity_data_names.keys()
+                        self._data_names
                     )
                 )
 
         # Gather adaptivity data from all ranks
         global_data_for_adaptivity = dict()
-        for name in data_for_adaptivity.keys():
-            data_as_list = self._mpi.comm.allgather(data_for_adaptivity[name])
+        for name in self._data_for_adaptivity.keys():
+            data_as_list = self._mpi.comm.allgather(self._data_for_adaptivity[name])
             global_ids_as_list = self._mpi.comm.allgather(
                 self._sim_container.local_gids
             )
@@ -144,86 +137,88 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         self._associate_inactive_to_active()
 
-    def get_active_sim_local_ids(self) -> np.ndarray:
+    def get_active_lids(self) -> List[int]:
         """
         Get the local ids of active simulations on this rank.
 
         Returns
         -------
-        numpy array
-            1D array of active simulation ids
+        active_lids : List[int]
+            List of active simulation LIDs
         """
-        active_sim_ids = []
-        for gid in self._sim_container.local_gids:
+        active_lids: List[int] = []
+        for lid, gid in enumerate(self._sim_container.local_gids):
             if self._is_sim_active[gid]:
-                active_sim_ids.append(self._sim_container.local_gids.index(gid))
+                active_lids.append(lid)
 
-        return np.array(active_sim_ids)
+        return active_lids
 
-    def get_inactive_sim_local_ids(self) -> np.ndarray:
+    def get_inactive_lids(self) -> List[int]:
         """
         Get the local ids of inactive simulations on this rank.
 
         Returns
         -------
-        numpy array
-            1D array of inactive simulation ids
+        inactive_lids : List[int]
+            List of inactive simulation ids
         """
-        inactive_sim_ids = []
-        for gid in self._sim_container.local_gids:
+        inactive_lids: List[int] = []
+        for lid, gid in enumerate(self._sim_container.local_gids):
             if not self._is_sim_active[gid]:
-                inactive_sim_ids.append(self._sim_container.local_gids.index(gid))
+                inactive_lids.append(lid)
 
-        return np.array(inactive_sim_ids)
+        return inactive_lids
 
-    def get_active_sim_global_ids(self) -> np.ndarray:
+    def get_active_gids(self) -> List[int]:
         """
         Get the global ids of active simulations on this rank.
 
         Returns
         -------
-        numpy array
-            1D array of active simulation ids
+        active_gids : List[int]
+            List of active simulation ids
         """
-        active_sim_ids = []
+        active_gids: List[int] = []
         for gid in self._sim_container.local_gids:
             if self._is_sim_active[gid]:
-                active_sim_ids.append(gid)
+                active_gids.append(gid)
 
-        return np.array(active_sim_ids)
+        return active_gids
 
-    def get_inactive_sim_global_ids(self) -> np.ndarray:
+    def get_inactive_gids(self) -> List[int]:
         """
         Get the global ids of inactive simulations on this rank.
 
         Returns
         -------
-        numpy array
-            1D array of inactive simulation ids
+        inactive_gids : List[int]
+            List of inactive simulation ids
         """
-        inactive_sim_ids = []
+        inactive_gids = []
         for gid in self._sim_container.local_gids:
             if not self._is_sim_active[gid]:
-                inactive_sim_ids.append(gid)
+                inactive_gids.append(gid)
 
-        return np.array(inactive_sim_ids)
+        return inactive_gids
 
     def get_full_field_micro_output(
-        self, micro_input: list, micro_output: list
-    ) -> list:
+        self,
+        micro_input: List[Dict[str, Any]],
+        micro_output: List[Optional[Dict[str, Any]]],
+    ) -> List[Dict[str, Any]]:
         """
         Get the full field micro output from active simulations to inactive simulations.
 
         Parameters
         ----------
-        micro_input : list
+        micro_input : List[Dict[str, Any]]
             List of dicts containing the input data for each simulation.
-        micro_output : list
+        micro_output : List[Optional[Dict[str, Any]]]
             List of dicts having individual output of each simulation. Only the active simulation outputs are entered.
 
         Returns
         -------
-        micro_output : list
+        micro_output : List[Dict[str, Any]]
             List of dicts having individual output of each simulation. Active and inactive simulation outputs are entered.
         """
         with self._profiler.measure(
@@ -266,6 +261,11 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         n : int
             Time step count at which the metrics are logged
         """
+        if n % self._output_n != 0:
+            return
+        if self._logger_global_metrics is None and self._logger_local_metrics is None:
+            return
+
         active_sims_on_this_rank = 0
         inactive_sims_on_this_rank = 0
         for gid in self._sim_container.local_gids:
@@ -274,10 +274,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             else:
                 inactive_sims_on_this_rank += 1
 
-        if (
-            self._adaptivity_output_type == "all"
-            or self._adaptivity_output_type == "local"
-        ):
+        if self._logger_local_metrics is not None:
             ranks_of_sims = self._sim_container.get_ranks_of_sims()
 
             assoc_ranks = []  # Ranks to which inactive sims on this rank are associated
@@ -287,7 +284,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                     if not assoc_rank in assoc_ranks:
                         assoc_ranks.append(assoc_rank)
 
-            self._metrics_logger.log_info(
+            self._logger_local_metrics.log_info(
                 "{}|{}|{}|{}".format(
                     n,
                     active_sims_on_this_rank,
@@ -296,10 +293,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 )
             )
 
-        if (
-            self._adaptivity_output_type == "all"
-            or self._adaptivity_output_type == "global"
-        ):
+        if self._logger_global_metrics is not None:
             active_sims_rankwise = self._mpi.comm.gather(
                 active_sims_on_this_rank, root=0
             )
@@ -310,7 +304,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             if self._mpi.rank == 0:
                 size = self._mpi.size
 
-                self._global_metrics_logger.log_info(
+                self._logger_global_metrics.log_info(
                     "{}|{}|{}|{}|{}|{}|{}|{}|{}".format(
                         n,
                         sum(active_sims_rankwise),
@@ -333,9 +327,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             self._coarse_const * self._refine_const * self._max_similarity_dist
         )
 
-        active_gids_this_rank = self.get_active_sim_global_ids()
+        active_gids_this_rank = self.get_active_gids()
         # Gather global ids of active sims from all ranks
-        active_gids_all_ranks = self._mpi.comm.allgather(active_gids_this_rank.tolist())
+        active_gids_all_ranks = self._mpi.comm.allgather(active_gids_this_rank)
 
         active_gids_to_iterate = []
         # Iterate over global ids of active sims in a round-robin fashion across ranks
@@ -358,7 +352,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
     def _communicate_micro_output(
         self,
-        micro_output: list,
+        micro_output: List[Optional[Dict[str, Any]]],
     ) -> None:
         """
         Communicate micro output from active simulation to their associated inactive simulations.
@@ -366,7 +360,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         Parameters
         ----------
-        micro_output : list
+        micro_output : List[Optional[Dict[str, Any]]]
             List of dicts having individual output of each simulation. Only the active simulation outputs are entered.
         """
         # Keys are global IDs of active simulations associated to inactive
@@ -374,7 +368,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         # simulations.
         active_to_inactive_map: Dict[int, list] = dict()
 
-        inactive_gids = self.get_inactive_sim_global_ids()
+        inactive_gids = self.get_inactive_gids()
 
         for gid in inactive_gids:
             assoc_active_gid = self._sim_is_associated_to[gid]
@@ -417,7 +411,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         """
         self._ref_tol = self._refine_const * self._max_similarity_dist
 
-        _sim_is_associated_to_updated = np.copy(self._sim_is_associated_to)
+        _sim_is_associated_to_updated = self._sim_is_associated_to.copy()
 
         # -------------------- Global computation on every rank ----------------------------
         # Check inactive simulations for activation and collect IDs of those to be activated
@@ -429,7 +423,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             if self._check_for_activation(gid, active_gids_all_ranks):
                 self._is_sim_active[gid] = True
                 # Active sim cannot have an associated sim
-                _sim_is_associated_to_updated[gid] = -2
+                del _sim_is_associated_to_updated[gid]
                 if gid not in self._just_deactivated:
                     # Add the newly activated gid to active_gids_all_ranks for further checks
                     active_gids_all_ranks = np.append(active_gids_all_ranks, gid)
@@ -442,7 +436,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         # Keys are global IDs of active sims not on this rank, values are lists of local and
         # global IDs of inactive sims associated to the active sims which are on this rank
-        to_be_activated_map: Dict[int, list] = dict()
+        to_be_activated_map: Dict[int, List[int]] = defaultdict(lambda: [])
 
         # Only handle activation of simulations on this rank
         for gid in to_be_activated_gids:
@@ -460,19 +454,15 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 ] = self._model_manager.get_instance(gid, self._micro_problem_cls)
                 self._sim_container.set_sim_state(to_be_activated_lid, state)
             else:  # Associated active simulation is not on this rank
-                if assoc_active_gid in to_be_activated_map:
-                    to_be_activated_map[assoc_active_gid].append(to_be_activated_lid)
-                else:
-                    to_be_activated_map[assoc_active_gid] = [to_be_activated_lid]
+                to_be_activated_map[assoc_active_gid].append(to_be_activated_lid)
 
         self._profiler.begin(
             "micro_manager.global_adaptivity.update_inactive_sims.communication"
         )
 
         sim_states_and_global_ids = []
-        for lid in self._sim_container.range_lid:
+        for lid, gid in enumerate(self._sim_container.local_gids):
             sim = self._sim_container[lid]
-            gid = self._sim_container.local_gids[lid]
             if sim == 0 or sim is None:
                 sim_states_and_global_ids.append((None, gid))
             else:
@@ -496,9 +486,8 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 self._sim_container.set_sim_state(lid, state)
 
         # Delete the micro simulation object if it is inactive
-        for gid in self._sim_container.local_gids:
+        for lid, gid in enumerate(self._sim_container.local_gids):
             if not self._is_sim_active[gid]:
-                lid = self._sim_container.local_gids.index(gid)
                 if self._sim_container[lid] is None:
                     continue
                 # Release resources now, especially for remote simulation instance.
@@ -510,7 +499,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
 
         self._profiler.end()
 
-        self._sim_is_associated_to = np.copy(_sim_is_associated_to_updated)
+        self._sim_is_associated_to = _sim_is_associated_to_updated
 
     def _create_send_map(
         self, requested_gids: List[int], lid_range_data: List[Any]

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -218,7 +218,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         """
         if n % self._output_n != 0:
             return
-        if self._logger_local_metrics is None or self._logger_global_metrics is None:
+        if self._logger_local_metrics is None and self._logger_global_metrics is None:
             return
 
         active_sims_on_this_rank = 0

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -3,6 +3,8 @@ Class LocalAdaptivityCalculator provides methods to adaptively control of micro 
 in a local way. If the Micro Manager is run in parallel, simulations on one rank are compared to
 each other. A global comparison is not done.
 """
+from typing import Optional, List, Dict, Any
+
 import numpy as np
 from copy import deepcopy
 
@@ -11,6 +13,7 @@ from micro_manager.config import Config
 from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.mpi_handler import MPIHandler, MPI, MPIHandlerRankLocal
+from micro_manager.tools.profiling import Profiler
 from micro_manager.model_manager import ModelManager
 from micro_manager.interpolation import RBF_PU
 from micro_manager.simulation_container import SimulationContainer
@@ -21,6 +24,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         self,
         config: Config,
         sim_container: SimulationContainer,
+        profiler: Profiler,
         base_logger: Logger,
         mpi: MPIHandler,
         micro_problem_cls: MicroSimulationClass,
@@ -35,6 +39,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             Object which has getter functions to get parameters defined in the configuration file.
         sim_container : SimulationContainer
             Simulation container object.
+        profiler : Profiler
+            Profiler object.
         base_logger : object of class Logger
             Logger object to log messages.
         mpi : MPIHandler
@@ -48,6 +54,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             config,
             sim_container.local_num_sims,
             sim_container,
+            profiler,
             micro_problem_cls,
             model_manager,
             base_logger,
@@ -64,12 +71,9 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         self._similarity_dists = np.zeros(
             (sim_container.local_num_sims, sim_container.local_num_sims)
         )
+        self._max_similarity_dist_local: float = 0.0
 
-    def compute_adaptivity(
-        self,
-        dt: float,
-        data_for_adaptivity: dict,
-    ) -> None:
+    def compute(self, dt: float) -> None:
         """
         Compute adaptivity locally (within a rank).
 
@@ -77,25 +81,20 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         ----------
         dt : float
             Current time step
-        data_for_adaptivity : dict
-            A dictionary containing the names of the data to be used in adaptivity as keys and information on whether
-            the data are scalar or vector as values.
         """
-        for name in data_for_adaptivity.keys():
-            if name not in self._adaptivity_data_names:
+        for name in self._data_for_adaptivity.keys():
+            if name not in self._data_names:
                 raise ValueError(
                     "Data for adaptivity must be one of the following: {}".format(
-                        self._adaptivity_data_names.keys()
+                        self._data_names
                     )
                 )
 
-        self._update_similarity_dists(dt, data_for_adaptivity)
-
-        self._local_max_similarity_dist = np.amax(self._similarity_dists)
-
+        self._update_similarity_dists(dt, self._data_for_adaptivity)
+        self._max_similarity_dist_local = np.amax(self._similarity_dists)
         # Gather maximum similarity distance from every rank, and use the global maximum distance
         self._max_similarity_dist = self._mpi.comm.allreduce(
-            self._local_max_similarity_dist, op=MPI.MAX
+            self._max_similarity_dist_local, op=MPI.MAX
         )
 
         self._update_active_sims()
@@ -104,81 +103,91 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
 
         self._associate_inactive_to_active()
 
-    def get_active_sim_local_ids(self) -> np.ndarray:
+    def get_active_lids(self) -> List[int]:
         """
         Get the local ids of active simulations on this rank.
 
         Returns
         -------
-        numpy array
-            1D array of active simulation ids
+        active_lids : List[int]
+            List of active simulation LIDs
         """
-        return np.where(self._is_sim_active)[0]
+        return np.where(self._is_sim_active)[0].tolist()
 
-    def get_active_sim_global_ids(self) -> np.ndarray:
+    def get_active_gids(self) -> List[int]:
         """
-        Get the global(local) ids of active simulations on this rank.
+        Get the global ids of active simulations on this rank.
 
         For local adaptivity, global ids are same as local ids.
 
         Returns
         -------
-        numpy array
-            1D array of active simulation ids
+        active_gids : List[int]
+            List of active simulation GIDs
         """
-        active_sim_ids = self.get_active_sim_local_ids()
-        return active_sim_ids
+        active_gids: List[int] = []
+        for lid, gid in enumerate(self._sim_container.local_gids):
+            if self._is_sim_active[lid]:
+                active_gids.append(gid)
 
-    def get_inactive_sim_local_ids(self) -> np.ndarray:
+        return active_gids
+
+    def get_inactive_lids(self) -> List[int]:
         """
         Get the local ids of inactive simulations on this rank.
 
         Returns
         -------
-        numpy array
-            1D array of inactive simulation ids
+        inactive_lids : List[int]
+            List of inactive simulation LIDs
         """
-        return np.where(self._is_sim_active == False)[0]
+        return np.where(self._is_sim_active == False)[0].tolist()
 
-    def get_inactive_sim_global_ids(self) -> np.ndarray:
+    def get_inactive_gids(self) -> List[int]:
         """
-        Get the global(local) ids of inactive simulations on this rank.
+        Get the global ids of inactive simulations on this rank.
 
         For local adaptivity, global ids are same as local ids.
 
         Returns
         -------
-        numpy array
-            1D array of inactive simulation ids
+        inactive_gids : List[int]
+            List of inactive simulation GIDs
         """
-        inactive_sim_ids = self.get_inactive_sim_local_ids()
-        return inactive_sim_ids
+        inactive_gids: List[int] = []
+        for lid, gid in enumerate(self._sim_container.local_gids):
+            if not self._is_sim_active[lid]:
+                inactive_gids.append(gid)
+
+        return inactive_gids
 
     def get_full_field_micro_output(
-        self, micro_input: list, micro_output: list
-    ) -> list:
+        self,
+        micro_input: List[Dict[str, Any]],
+        micro_output: List[Optional[Dict[str, Any]]],
+    ) -> List[Dict[str, Any]]:
         """
         Get the full field micro output from active simulations to inactive simulations.
 
         Parameters
         ----------
-        micro_input : list
+        micro_input : List[Dict[str, Any]]
             List of dicts containing the input data for each simulation.
-        micro_output : list
+        micro_output : List[Optional[Dict[str, Any]]]
             List of dicts having individual output of each simulation. Only the active simulation outputs are entered.
 
         Returns
         -------
-        micro_output : list
+        micro_output : List[Dict[str, Any]]
             List of dicts having individual output of each simulation. Active and inactive simulation outputs are entered.
         """
         micro_sims_output = deepcopy(micro_output)
 
-        inactive_sim_ids = self.get_inactive_sim_local_ids()
+        inactive_lids = self.get_inactive_lids()
 
-        for inactive_id in inactive_sim_ids:
-            micro_sims_output[inactive_id] = deepcopy(
-                micro_sims_output[self._sim_is_associated_to[inactive_id]]
+        for inactive_lid in inactive_lids:
+            micro_sims_output[inactive_lid] = deepcopy(
+                micro_sims_output[self._sim_is_associated_to[inactive_lid]]
             )
         self._interpolate_output(micro_input, micro_sims_output)
 
@@ -207,6 +216,11 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         n : int
             Time step count at which the metrics are logged
         """
+        if n % self._output_n != 0:
+            return
+        if self._logger_local_metrics is None or self._logger_global_metrics is None:
+            return
+
         active_sims_on_this_rank = 0
         inactive_sims_on_this_rank = 0
         for local_id in range(self._is_sim_active.size):
@@ -215,11 +229,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             else:
                 inactive_sims_on_this_rank += 1
 
-        if (
-            self._adaptivity_output_type == "all"
-            or self._adaptivity_output_type == "local"
-        ):
-            self._metrics_logger.log_info(
+        if self._logger_local_metrics is not None:
+            self._logger_local_metrics.log_info(
                 "{}|{}|{}".format(
                     n,
                     active_sims_on_this_rank,
@@ -227,10 +238,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
                 )
             )
 
-        if (
-            self._adaptivity_output_type == "global"
-            or self._adaptivity_output_type == "all"
-        ):
+        if self._logger_global_metrics is not None:
             active_sims_rankwise = self._mpi.comm.gather(
                 active_sims_on_this_rank, root=0
             )
@@ -241,7 +249,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             if self._mpi.rank == 0:
                 size = self._mpi.size
 
-                self._global_metrics_logger.log_info(
+                self._logger_global_metrics.log_info(
                     "{}|{}|{}|{}|{}|{}|{}|{}|{}".format(
                         n,
                         sum(active_sims_rankwise),
@@ -264,17 +272,16 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             self._coarse_const * self._refine_const * self._max_similarity_dist
         )
 
-        active_gids = self.get_active_sim_local_ids().tolist()
-
-        active_gids_to_check = active_gids.copy()
+        active_lids = self.get_active_lids()
+        active_lids_to_check = active_lids.copy()
 
         # Update the set of active micro sims
-        for gid in active_gids:
-            if self._check_for_deactivation(gid, active_gids_to_check):
-                self._is_sim_active[gid] = False
-                self._just_deactivated.append(gid)
+        for lid in active_lids:
+            if self._check_for_deactivation(lid, active_lids_to_check):
+                self._is_sim_active[lid] = False
+                self._just_deactivated.append(lid)
                 # Remove deactivated gid from further checks
-                active_gids_to_check.remove(gid)
+                active_lids_to_check.remove(lid)
 
     def _update_inactive_sims(self) -> None:
         """
@@ -286,23 +293,23 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         """
         self._ref_tol = self._refine_const * self._max_similarity_dist
 
-        active_lids = self.get_active_sim_local_ids()
-        inactive_lids = self.get_inactive_sim_local_ids()
+        active_lids = self.get_active_lids()
+        inactive_lids = self.get_inactive_lids()
 
-        to_be_activated_ids = []
+        to_be_activated_lids: List[int] = []
         # Update the set of inactive micro sims
         for lid in inactive_lids:
             if self._check_for_activation(lid, active_lids):
                 self._is_sim_active[lid] = True
                 if lid not in self._just_deactivated:
-                    to_be_activated_ids.append(lid)
+                    to_be_activated_lids.append(lid)
                     # Add the newly activated lid to active_lids for further checks
                     active_lids = np.append(active_lids, lid)
 
         self._just_deactivated.clear()  # Clear the list of sims deactivated in this step
 
         # Update the set of inactive micro sims
-        for lid in to_be_activated_ids:
+        for lid in to_be_activated_lids:
             associated_active_id = self._sim_is_associated_to[lid]
             self._sim_container[lid] = self._model_manager.get_instance(
                 lid, self._micro_problem_cls
@@ -310,7 +317,7 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             state = self._sim_container.get_sim_state(associated_active_id)
             self._sim_container.set_sim_state(lid, state)
             # Active sim cannot have an associated sim
-            self._sim_is_associated_to[lid] = -2
+            del self._sim_is_associated_to[lid]
 
         # Delete the inactive micro simulations which have not been activated
         for lid in range(self._is_sim_active.size):

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -261,8 +261,9 @@ class LoadBalancer:
         cls_name = None
         is_stateless = None
         state = None
-        active_steps = self._adaptivity_controller.get_active_steps()[gid]
-        del self._adaptivity_controller.get_active_steps()[gid]
+        active_dict = self._adaptivity_controller.get_active_steps()
+        active_steps = active_dict[gid]
+        del active_dict[gid]
         assoc_gid = None
 
         if not is_inactive:
@@ -447,11 +448,7 @@ class ActiveBalancer(LoadBalancer):
         pass
 
     def _get_active_exchange_counts(self):
-        # TODO find other solution for this
-        avg_active_sims = (
-            np.count_nonzero(self._adaptivity_controller._is_sim_active)
-            / self._mpi.comm.size
-        )
+        avg_active_sims = len(self._get_global_active_gids()) / self._mpi.comm.size
         f_avg_active_sims = np.floor(avg_active_sims - self._threshold)
         c_avg_active_sims = np.ceil(avg_active_sims + self._threshold)
 

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -314,7 +314,7 @@ class LoadBalancer:
             if current_partitioning[gid] == target_rank:
                 continue
             if current_partitioning[gid] == self._mpi.rank:
-                entry = self._gather_send_data(gid, inactive_set)
+                entry = self._gather_send_data(int(gid), inactive_set)
                 send_map[target_rank].append(entry)
                 continue
 

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -82,7 +82,7 @@ class LoadBalancer:
             "NoOpAdaptivity",
         ]:
             raise NotImplementedError(
-                "Adaptivity must be GlobalAdaptivity for Load Balancing or deactivated."
+                "To use load balancing, adaptivity must be turned off, or the global variant must be used."
             )
 
     def balance(self):

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -7,7 +7,7 @@ import numpy as np
 from precice import Participant
 
 from micro_manager.config import Config
-from micro_manager.adaptivity.adaptivity import AdaptivityCalculator
+from micro_manager.adaptivity.adaptivity_interface import AdaptivityInterface
 from micro_manager.model_manager import ModelManager
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.mpi_handler import MPIHandler
@@ -27,6 +27,8 @@ class LoadBalancerSimData:
     cls_name: Optional[str]
     gid: int
     coord: np.ndarray
+    active_steps: int
+    assoc_gid: Optional[int]
 
 
 class LoadBalancer:
@@ -34,7 +36,7 @@ class LoadBalancer:
         self,
         profiler: Profiler,
         model_manager: ModelManager,
-        adaptivity_controller: Optional[AdaptivityCalculator],
+        adaptivity_controller: AdaptivityInterface,
         sim_container: SimulationContainer,
         log: Logger,
         config: Config,
@@ -50,8 +52,8 @@ class LoadBalancer:
             Profiling object
         model_manager: ModelManager
             model manager object to construct instances
-        adaptivity_controller: Optional[AdaptivityCalculator]
-            handles adaptivity calculation if provided
+        adaptivity_controller: AdaptivityInterface
+            handles adaptivity calculation
         log: Logger
             logger object
         config: Config
@@ -75,13 +77,12 @@ class LoadBalancer:
             config.load_balancing_partitioning()
         )
 
-        if (
-            self._enabled
-            and adaptivity_controller is not None
-            and type(adaptivity_controller).__name__ != "GlobalAdaptivityCalculator"
-        ):
+        if self._enabled and type(adaptivity_controller).__name__ not in [
+            "GlobalAdaptivityCalculator",
+            "NoOpAdaptivity",
+        ]:
             raise NotImplementedError(
-                "Adaptivity must be GlobalAdaptivity for Load Balancing"
+                "Adaptivity must be GlobalAdaptivity for Load Balancing or deactivated."
             )
 
     def balance(self):
@@ -260,10 +261,17 @@ class LoadBalancer:
         cls_name = None
         is_stateless = None
         state = None
+        active_steps = self._adaptivity_controller.get_active_steps()[gid]
+        del self._adaptivity_controller.get_active_steps()[gid]
+        assoc_gid = None
+
         if not is_inactive:
             cls_name = self._sim_container[lid].name
             is_stateless = self._model_manager.is_stateless(cls_name)
             state = None if is_stateless else self._sim_container.get_sim_state(lid)
+        else:
+            assoc_gid = self._adaptivity_controller.get_associated_map()[gid]
+            del self._adaptivity_controller.get_associated_map()[gid]
 
         return LoadBalancerSimData(
             is_inactive,
@@ -272,6 +280,8 @@ class LoadBalancer:
             cls_name,
             gid,
             coord,
+            active_steps,
+            assoc_gid,
         )
 
     def _get_communication_map(
@@ -320,17 +330,10 @@ class LoadBalancer:
             set of global active gids
         """
         # local count
-        active_gid_arr = None
-        if self._adaptivity_controller is not None:
-            active_gid_arr = [
-                self._sim_container.local_gids[lid]
-                for lid in self._adaptivity_controller.get_active_sim_local_ids()
-            ]
-        else:
-            active_gid_arr = self._sim_container.local_gids
+        active_gids = self._adaptivity_controller.get_active_gids()
 
         # bcast to all and merge
-        tmp = self._mpi.comm.allgather(active_gid_arr)
+        tmp = self._mpi.comm.allgather(active_gids)
         global_active_gids = list()
         for l in tmp:
             global_active_gids.extend(l)
@@ -386,6 +389,13 @@ class LoadBalancer:
                 sim = self._model_manager.get_instance_by_name(
                     entry.gid, entry.cls_name
                 )
+            else:
+                self._adaptivity_controller.get_associated_map()[
+                    entry.gid
+                ] = entry.assoc_gid
+            self._adaptivity_controller.get_active_steps()[
+                entry.gid
+            ] = entry.active_steps
             lid = self._sim_container.add_sim(entry.gid, sim, entry.coord)
 
             if not entry.is_stateless and entry.state is not None:
@@ -401,7 +411,7 @@ class ActiveBalancer(LoadBalancer):
         self,
         profiler: Profiler,
         model_manager: ModelManager,
-        adaptivity_controller: Optional[AdaptivityCalculator],
+        adaptivity_controller: AdaptivityInterface,
         sim_container: SimulationContainer,
         log: Logger,
         config: Config,
@@ -422,7 +432,7 @@ class ActiveBalancer(LoadBalancer):
         self._bypass_skip = False  # used for testing
         self._bypass_active = False  # used for testing
 
-        if adaptivity_controller is None:
+        if type(adaptivity_controller).__name__ != "GlobalAdaptivityCalculator":
             raise ValueError(
                 "Active Count balancing requires GlobalAdaptivityCalculator"
             )
@@ -437,6 +447,7 @@ class ActiveBalancer(LoadBalancer):
         pass
 
     def _get_active_exchange_counts(self):
+        # TODO find other solution for this
         avg_active_sims = (
             np.count_nonzero(self._adaptivity_controller._is_sim_active)
             / self._mpi.comm.size
@@ -444,7 +455,7 @@ class ActiveBalancer(LoadBalancer):
         f_avg_active_sims = np.floor(avg_active_sims - self._threshold)
         c_avg_active_sims = np.ceil(avg_active_sims + self._threshold)
 
-        active_sims_local_ids = self._adaptivity_controller.get_active_sim_local_ids()
+        active_sims_local_ids = self._adaptivity_controller.get_active_lids()
         n_active_sims_local = len(active_sims_local_ids)
         send_sims = 0  # Sims that this rank wants to send
         recv_sims = 0  # Sims that this rank wants to receive
@@ -501,9 +512,7 @@ class ActiveBalancer(LoadBalancer):
             recv_map : dict
                 keys are global IDs of sim states to receive, values are ranks to receive from
         """
-        active_sims_global_ids = list(
-            self._adaptivity_controller.get_active_sim_global_ids()
-        )
+        active_sims_global_ids = self._adaptivity_controller.get_active_gids()
         rank_wise_global_ids_of_active_sims = self._mpi.comm.allgather(
             active_sims_global_ids
         )
@@ -602,7 +611,7 @@ class ActiveBalancer(LoadBalancer):
         global_ids_of_inactive_sims = inactive_gids
 
         for gid in global_ids_of_inactive_sims:
-            assoc_active_gid = self._adaptivity_controller._sim_is_associated_to[gid]
+            assoc_active_gid = self._adaptivity_controller.get_associated_map()[gid]
             rank_of_inactive_sim = ranks_of_sims[gid]
             rank_of_assoc_active_sim = ranks_of_sims[assoc_active_gid]
             if rank_of_inactive_sim != rank_of_assoc_active_sim:
@@ -694,7 +703,7 @@ class ActiveBalancer(LoadBalancer):
 def create_load_balancer(
     profiler: Profiler,
     model_manager: ModelManager,
-    adaptivity_controller: Optional[AdaptivityCalculator],
+    adaptivity_controller: AdaptivityInterface,
     sim_container: SimulationContainer,
     log: Logger,
     config: Config,

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -484,20 +484,20 @@ class MicroManagerCoupling(MicroManager):
 
         # If lazy initialization is on, initial states of inactive simulations need to be determined
         if self._lazy_init:
-            initial_micro_data_list: List[Optional[Dict[str, Any]]] = [
-                None
-            ] * self._sim_container.local_num_sims
+            initial_micro_data_list: List[Dict[str, Any]] = [dict()]
             # If there is initial micro data, and if this rank has sims to init, then the data is to be gathered
             if initial_micro_data and len(micro_sims_to_init) > 0:
-                initial_micro_data_list: List[Dict[str, Any]] = [
+                initial_micro_data_list = [
                     dict(zip(initial_micro_data.keys(), t))
                     for t in zip(*initial_micro_data.values())
                 ]
+            else:
+                initial_micro_data_list *= self._sim_container.local_num_sims
 
-            initial_micro_data_list: List[
-                Dict[str, Any]
-            ] = self._adaptivity_controller.get_full_field_micro_output(
-                initial_macro_data, initial_micro_data_list
+            initial_micro_data_list = (
+                self._adaptivity_controller.get_full_field_micro_output(
+                    initial_macro_data, initial_micro_data_list
+                )
             )
 
             self._adaptivity_controller.update_buffers(initial_micro_data_list)

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -165,7 +165,9 @@ class MicroManagerCoupling(MicroManager):
                 self._sim_container.write_checkpoints()
 
             read_buffer = self._adaptivity_controller.get_read_buffer()
-            micro_sims_input = self._coupling.read_data_from_precice(read_buffer=read_buffer)
+            micro_sims_input = self._coupling.read_data_from_precice(
+                read_buffer=read_buffer
+            )
             self._adaptivity_controller.update_buffers(None, read_buffer, invert=True)
 
             with self._profiler.measure("micro_manager.solve.solve_micro_simulations"):

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -14,7 +14,7 @@ Detailed documentation: https://precice.org/tooling-micro-manager-overview.html
 
 import os
 import sys
-from typing import Callable
+from typing import Callable, Dict, List, Any, Optional, Iterable, Collection
 import numpy as np
 from psutil import Process
 import csv
@@ -27,6 +27,8 @@ from .micro_manager_base import MicroManager
 
 from .adaptivity.model_adaptivity import ModelAdaptivity
 from .adaptivity.adaptivity_selection import create_adaptivity_calculator
+from .adaptivity.adaptivity import NoOpAdaptivity
+from .adaptivity.adaptivity_interface import AdaptivityInterface
 
 from .domain_decomposition import DomainDecomposer, create_domain_decomposer
 from .tasking.connection import spawn_local_workers
@@ -64,11 +66,10 @@ class MicroManagerCoupling(MicroManager):
         self._config.read_json_micro_manager()
 
         self._memory_usage_output_type = self._config.memory_usage_output_type()
-
         self._memory_usage_output_n = self._config.memory_usage_output_n()
 
+        self._micro_n_out = self._config.micro_output_n()
         self._output_dir = self._config.output_dir()
-
         if self._output_dir is not None:
             self._output_dir = os.path.abspath(self._output_dir) + "/"
             subprocess.run(["mkdir", "-p", self._output_dir])  # Create output directory
@@ -76,7 +77,6 @@ class MicroManagerCoupling(MicroManager):
             self._output_dir = os.path.abspath(os.getcwd()) + "/"
 
         self._sim_container = SimulationContainer(self._mpi)
-
         self._coupling: CouplingHandler = CouplingHandler(
             self._config,
             self._mpi,
@@ -97,38 +97,11 @@ class MicroManagerCoupling(MicroManager):
                 self._crash_threshold = 0.2
                 self._number_of_nearest_neighbors = 4
 
-        self._micro_n_out = self._config.micro_output_n()
-
         self._lazy_init = self._config.enable_adaptivity_lazy_init()
 
-        self._is_adaptivity_on = self._config.enable_adaptivity()
-
-        if self._is_adaptivity_on:
-            self._data_for_adaptivity: dict[str, list] = dict()
-
-            self._adaptivity_data_names = self._config.data_for_adaptivity()
-
-            # Names of macro data to be used for adaptivity computation
-            self._adaptivity_macro_data_names: list = []
-
-            # Names of micro data to be used for adaptivity computation
-            self._adaptivity_micro_data_names: list = []
-            for name in self._adaptivity_data_names:
-                if name in self._coupling.read_data_names:
-                    self._adaptivity_macro_data_names.append(name)
-                if name in self._coupling.write_data_names:
-                    self._adaptivity_micro_data_names.append(name)
-
-            self._adaptivity_in_every_implicit_step = (
-                self._config.enable_adaptivity_each_implicit_iteration()
-            )
-
-        self._adaptivity_n = self._config.adaptivity_n()
-
-        self._adaptivity_output_type = self._config.adaptivity_output_type()
-
-        self._adaptivity_output_n = self._config.adaptivity_output_n()
-
+        self._adaptivity_controller: AdaptivityInterface = NoOpAdaptivity(
+            self._sim_container
+        )
         self._is_model_adaptivity_on = self._config.enable_model_adaptivity()
 
         self._t = 0  # global time
@@ -166,32 +139,12 @@ class MicroManagerCoupling(MicroManager):
         first_iteration = True
         lb_counter = -1
 
-        if self._is_adaptivity_on:
-            # Log initial adaptivity metrics
-            self._adaptivity_controller.log_metrics(self._n)
+        # Log initial adaptivity metrics
+        self._adaptivity_controller.log_metrics(self._n)
 
         while self._coupling.is_ongoing():
             dt = self._coupling.dt
-
-            if self._is_adaptivity_on:
-                if (self._adaptivity_in_every_implicit_step or first_iteration) and (
-                    self._n % self._adaptivity_n == 0
-                ):
-                    with self._profiler.measure(
-                        "micro_manager.solve.adaptivity_computation"
-                    ):
-                        self._adaptivity_controller.compute_adaptivity(
-                            dt,
-                            self._data_for_adaptivity,
-                        )
-                        for (
-                            gid
-                        ) in self._adaptivity_controller.get_active_sim_global_ids():
-                            self._micro_sims_active_steps[gid] += 1
-
-                        # Write a checkpoint if a simulation is just activated.
-                        # This checkpoint will be asynchronous to the checkpoints written at the start of the time window.
-                        self._sim_container.write_checkpoints(only_none=True)
+            self._adaptivity_controller.compute_step(self._n, first_iteration, dt)
 
             # handle load balancing, in first iteration all sims are assumed to have same cost
             performed_lb = False
@@ -201,11 +154,7 @@ class MicroManagerCoupling(MicroManager):
 
                 # Reset simulation state checkpoints after load balancing
                 self._sim_container.clear_checkpoints()
-                if self._is_adaptivity_on:
-                    for name in self._adaptivity_data_names:
-                        self._data_for_adaptivity[name] = [
-                            0
-                        ] * self._sim_container.local_num_sims
+                self._adaptivity_controller.update_buffers(alloc=True)
                 # Reset simulation crash state information after load balancing
                 self._has_sim_crashed = [False] * self._sim_container.local_num_sims
                 # self._participant.stop_last_profiling_section()
@@ -215,15 +164,9 @@ class MicroManagerCoupling(MicroManager):
             if self._coupling.requires_writing_checkpoint() or performed_lb:
                 self._sim_container.write_checkpoints()
 
-            read_buffer = {} if self._is_adaptivity_on else None
-            micro_sims_input = self._coupling.read_data_from_precice(
-                read_buffer=read_buffer
-            )
-            # TODO: will be removed in adaptivity refactoring
-            if self._is_adaptivity_on and read_buffer is not None:
-                for name in read_buffer.keys():
-                    if name in self._adaptivity_macro_data_names:
-                        self._data_for_adaptivity[name] = read_buffer[name]
+            read_buffer = self._adaptivity_controller.get_read_buffer()
+            micro_sims_input = self._coupling.read_data_from_precice(read_buffer=read_buffer)
+            self._adaptivity_controller.update_buffers(None, read_buffer, invert=True)
 
             with self._profiler.measure("micro_manager.solve.solve_micro_simulations"):
                 micro_sims_output = micro_sim_solve(micro_sims_input, dt)
@@ -277,12 +220,7 @@ class MicroManagerCoupling(MicroManager):
                             if sim is not None:
                                 sim.output()
 
-                if (
-                    self._is_adaptivity_on
-                    and self._adaptivity_output_type
-                    and (self._n % self._adaptivity_output_n == 0)
-                ):
-                    self._adaptivity_controller.log_metrics(self._n)
+                self._adaptivity_controller.log_metrics(self._n)
 
                 if self._memory_usage_output_type and (
                     self._n % self._memory_usage_output_n == 0 or self._n == 1
@@ -306,12 +244,7 @@ class MicroManagerCoupling(MicroManager):
             mem_usage_n.append(self._n)
 
         # Final adaptivity metrics logging at the end of the simulation if not already logged at the end of the last time window
-        if (
-            self._is_adaptivity_on
-            and self._adaptivity_output_type
-            and self._n % self._adaptivity_output_n != 0
-        ):
-            self._adaptivity_controller.log_metrics(self._n)
+        self._adaptivity_controller.log_metrics(self._n)
 
         if (
             self._memory_usage_output_type == "all"
@@ -404,10 +337,6 @@ class MicroManagerCoupling(MicroManager):
                 "the adaptivity and determine which simulations to initialize."
             )
 
-        if self._is_adaptivity_on:
-            for name in self._adaptivity_data_names:
-                self._data_for_adaptivity[name] = [0] * local_num_sims
-
         # Create lists of global IDs
         local_gids = self._coupling.generate_gids(
             local_macro_coords,
@@ -453,231 +382,123 @@ class MicroManagerCoupling(MicroManager):
                 self._log_file,
             )
 
-        # Create micro simulation objects
-        if not self._lazy_init:
-            for lid in self._sim_container.range_lid:
-                self._sim_container[lid] = self._model_manager.get_instance(
-                    self._sim_container.local_gids[lid], micro_problem_cls
-                )
-
-        if self._is_adaptivity_on:
-            self._adaptivity_controller = create_adaptivity_calculator(
-                self._config,
-                self._sim_container,
-                self._profiler,
-                self._logger,
-                self._mpi,
-                micro_problem_cls,
-                self._model_manager,
-            )
-
-            self._micro_sims_active_steps = np.zeros(
-                self._sim_container.global_num_sims
-            )  # DECLARATION
-
-        self._micro_sims_init = False  # DECLARATION
-
-        # Read initial data from preCICE, if it is available
-        read_buffer = {} if self._is_adaptivity_on else None
-        initial_macro_data = self._coupling.read_data_from_precice(0, read_buffer)
-        # TODO: will be removed in adaptivity refactoring
-        if self._is_adaptivity_on and read_buffer is not None:
-            for name in read_buffer.keys():
-                if name in self._adaptivity_macro_data_names:
-                    self._data_for_adaptivity[name] = read_buffer[name]
-
-        first_id = 0  # 0 if lazy initialization is off, otherwise the first active simulation ID
-        micro_sims_to_init = range(
-            1, self._sim_container.local_num_sims
-        )  # All sims if lazy init is off, otherwise all active simulations
-
-        # Additional bool to check if there are sims to init
-        are_there_sims_to_init = True
-
-        if not initial_macro_data:
-            is_initial_data_available = False
-
-            if self._lazy_init:
-                raise Exception(
-                    "Initial macro data is required for lazy initialization."
-                )
-        else:
-            is_initial_data_available = True
-
-            # For lazy initialization, compute adaptivity with the initial macro data
-            if self._lazy_init:
-                for i in self._sim_container.range_lid:
-                    for name in self._adaptivity_macro_data_names:
-                        self._data_for_adaptivity[name][i] = initial_macro_data[i][name]
-
-                self._adaptivity_controller.compute_adaptivity(
-                    self._coupling.micro_dt, self._data_for_adaptivity
-                )
-
-                active_sim_lids = self._adaptivity_controller.get_active_sim_local_ids()
-
-                if active_sim_lids.size == 0:
-                    self._logger.log_info(
-                        "There are no active simulations on this rank."
-                    )
-                    micro_sims_to_init = []
-                    are_there_sims_to_init = False
-                else:
-                    for i in active_sim_lids:
-                        self._sim_container[i] = self._model_manager.get_instance(
-                            self._sim_container.local_gids[i], micro_problem_cls
-                        )
-
-                    first_id = active_sim_lids[0]  # First active simulation ID
-                    # Only active simulations will be initialized, skip first as it is initialized separately
-                    micro_sims_to_init = active_sim_lids[1:]
-                    are_there_sims_to_init = True
-
-        test_instance = self._model_manager.get_instance(
-            self._sim_container.global_num_sims + 1, micro_problem_cls
+        self._adaptivity_controller = create_adaptivity_calculator(
+            self._config,
+            self._sim_container,
+            self._profiler,
+            self._logger,
+            self._mpi,
+            micro_problem_cls,
+            self._model_manager,
         )
-        test_data = None
-        if is_initial_data_available:
-            test_data = initial_macro_data[0]
-        (
-            self._micro_sims_init,
-            sim_requires_init_data,
-        ) = micro_problem_cls.check_initialize(
-            test_instance,
-            test_data,
-        )
-        test_instance.destroy()
-        del test_instance
-
-        if sim_requires_init_data and not is_initial_data_available:
-            raise Exception(
-                "The initialize() method of the Micro simulation requires initial data, but no initial macro data has been provided."
-            )
-
-        initial_micro_data: dict[str, list] = dict()
-
-        if are_there_sims_to_init and self._micro_sims_init:
-            # Call initialize() method of the micro simulation to check if it returns any initial data
-            if sim_requires_init_data:
-                initial_micro_output = self._sim_container[first_id].initialize(
-                    initial_macro_data[first_id]
-                )
-            else:
-                initial_micro_output = self._sim_container[first_id].initialize()
-
-            if initial_micro_output is None:
-                self._logger.log_warning_rank_zero(
-                    "The initialize() call of the Micro simulation has not returned any initial data."
-                    " This means that the initialize() call has no effect on the adaptivity. The initialize method will nevertheless still be called."
-                )
-                self._micro_sims_init = False
-
-                if sim_requires_init_data:
-                    for i in micro_sims_to_init:
-                        self._sim_container[i].initialize(initial_macro_data[i])
-                else:
-                    for i in micro_sims_to_init:
-                        self._sim_container[i].initialize()
-            else:  # Case where the initialize() method returns data
-                if self._is_adaptivity_on:
-                    # Check for missing data
-                    expected, provided = set(self._adaptivity_micro_data_names), set(
-                        initial_micro_output.keys()
-                    )
-                    if missing := expected - provided:
-                        raise Exception(
-                            "The initialize() method needs to return data which is required for the adaptivity calculation. "
-                            f'Of the expected data {", ".join(expected)}, the following is missing: {", ".join(missing)}'
-                        )
-                    elif extra := provided - set(
-                        self._adaptivity_macro_data_names
-                        + self._adaptivity_micro_data_names
-                    ):
-                        self._logger.log_warning_rank_zero(
-                            f'The initialize() method of the Micro simulation returns extra initial data which isn\'t used by the adaptivity: {", ".join(extra)}'
-                        )
-
-                    for name in initial_micro_output.keys():
-                        initial_micro_data[name] = [
-                            0
-                        ] * self._sim_container.local_num_sims
-                        # Save initial data from first micro simulation as we anyway have it
-                        initial_micro_data[name][first_id] = initial_micro_output[name]
-
-                    # Save initial data from first micro simulation as we anyway have it
-                    for name in initial_micro_output.keys():
-                        if name in self._data_for_adaptivity:
-                            self._data_for_adaptivity[name][
-                                first_id
-                            ] = initial_micro_output[name]
-
-                    # Gather initial data from the rest of the micro simulations
-                    if sim_requires_init_data:
-                        for i in micro_sims_to_init:
-                            initial_micro_output = self._sim_container[i].initialize(
-                                initial_macro_data[i]
-                            )
-                            for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][
-                                    i
-                                ] = initial_micro_output[name]
-                                initial_micro_data[name][i] = initial_micro_output[name]
-                    else:
-                        for i in micro_sims_to_init:
-                            initial_micro_output = self._sim_container[i].initialize()
-                            for name in self._adaptivity_micro_data_names:
-                                self._data_for_adaptivity[name][
-                                    i
-                                ] = initial_micro_output[name]
-                                initial_micro_data[name][i] = initial_micro_output[name]
-                else:  # If adaptivity is off, the returned initial data from the initialize() method will be ignored
-                    self._logger.log_warning_rank_zero(
-                        "The initialize() method of the Micro simulation returns initial data, but adaptivity is turned off. The returned data will be ignored. The initialize method will nevertheless still be called."
-                    )
-                    if sim_requires_init_data:
-                        for i in range(1, self._sim_container.local_num_sims):
-                            self._sim_container[i].initialize(initial_macro_data[i])
-                    else:
-                        for i in range(1, self._sim_container.local_num_sims):
-                            self._sim_container[i].initialize()
-
-        self._micro_sims_have_output = micro_problem_cls.check_output()
 
         self.load_balancing = create_load_balancer(
             self._profiler,
             self._model_manager,
-            self._adaptivity_controller if self._is_adaptivity_on else None,
+            self._adaptivity_controller,
             self._sim_container,
             self._logger,
             self._config,
             self._mpi,
         )
 
-        # If lazy initialization is on, initial states of inactive simulations need to be determined
-        if self._lazy_init:
-            # If there is initial micro data, and if this rank has sims to init, then the data is to be gathered
-            if initial_micro_data and are_there_sims_to_init:
-                initial_micro_data_list: list[dict] = [
-                    dict(zip(initial_micro_data, t))
-                    for t in zip(*initial_micro_data.values())
-                ]
-            else:
-                # Ranks without active simulations provide empty dicts
-                initial_micro_data_list: list[dict] = [
-                    dict() for _ in range(self._sim_container.local_num_sims)
-                ]
+        # Read initial data from preCICE, if it is available
+        read_buffer = self._adaptivity_controller.get_read_buffer()
+        initial_macro_data = self._coupling.read_data_from_precice(0, read_buffer)
+        self._adaptivity_controller.update_buffers(None, read_buffer, invert=True)
 
-            initial_micro_data_list = (
-                self._adaptivity_controller.get_full_field_micro_output(
-                    initial_macro_data, initial_micro_data_list
+        # Simulation construction and initialization
+        # All sims if lazy init is off, otherwise only active simulations
+        micro_sims_to_init: Collection[int] = self._sim_container.range_lid
+        if self._lazy_init:
+            if len(initial_macro_data) == 0:
+                raise Exception(
+                    "Initial macro data is required for lazy initialization."
                 )
+            self._adaptivity_controller.compute(self._coupling.micro_dt)
+            active_sim_lids = self._adaptivity_controller.get_active_lids()
+            # Only active simulations will be initialized
+            micro_sims_to_init = active_sim_lids
+            if len(active_sim_lids) == 0:
+                self._logger.log_info("There are no active simulations on this rank.")
+        for lid in micro_sims_to_init:
+            self._sim_container[lid] = self._model_manager.get_instance(
+                self._sim_container.local_gids[lid], micro_problem_cls
             )
 
-            for i in range(self._sim_container.local_num_sims):
-                for name in self._adaptivity_micro_data_names:
-                    self._data_for_adaptivity[name][i] = initial_micro_data_list[i][
-                        name
-                    ]
+        # test base micro simulation IO behavior
+        test_instance = self._model_manager.get_instance(
+            self._sim_container.global_num_sims + 1, micro_problem_cls
+        )
+        test_data = initial_macro_data[0] if len(initial_macro_data) > 0 else None
+        (
+            micro_sims_has_init,
+            sim_requires_init_data,
+            micro_sims_init_has_return_value,
+            micro_sims_init_return_value,
+        ) = micro_problem_cls.check_initialize(
+            test_instance,
+            test_data,
+        )
+        self._adaptivity_controller.check_micro_simulation_initialize(
+            self._logger,
+            micro_sims_init_return_value,
+        )
+        test_instance.destroy()
+        del test_instance
+        self._micro_sims_have_output = micro_problem_cls.check_output()
+
+        # call initialize method on simulation instances
+        initial_micro_data: Dict[str, List[Any]] = dict()
+        if len(micro_sims_to_init) > 0 and micro_sims_has_init:
+            # optionally initialize the initial_micro_data buffer if required
+            if not micro_sims_init_has_return_value:
+                self._logger.log_warning_rank_zero(
+                    "The initialize() call of the Micro simulation has not returned any initial data."
+                    " This means that the initialize() call has no effect on the adaptivity. The initialize method will nevertheless still be called."
+                )
+            # Case where the initialize() method returns data
+            else:
+                adaptivity_micro_names: Optional[
+                    List[str]
+                ] = self._adaptivity_controller.get_micro_data_names()
+                if adaptivity_micro_names is None:
+                    self._logger.log_warning_rank_zero(
+                        "The initialize() method of the Micro simulation returns initial data, but adaptivity is turned off. The returned data will be ignored. The initialize method will nevertheless still be called."
+                    )
+                for name in adaptivity_micro_names or []:
+                    initial_micro_data[name] = [0] * self._sim_container.local_num_sims
+
+            # perform actual simulation initialization
+            for i in micro_sims_to_init:
+                init_arg = initial_macro_data[i] if sim_requires_init_data else []
+                initial_micro_output = self._sim_container[i].initialize(*init_arg)
+                for name in initial_micro_data.keys():
+                    initial_micro_data[name][i] = initial_micro_output[name]
+            if len(initial_micro_data) != 0:
+                self._adaptivity_controller.update_buffers(
+                    initial_micro_data, None, invert=True
+                )
+
+        # If lazy initialization is on, initial states of inactive simulations need to be determined
+        if self._lazy_init:
+            initial_micro_data_list: List[Optional[Dict[str, Any]]] = [
+                None
+            ] * self._sim_container.local_num_sims
+            # If there is initial micro data, and if this rank has sims to init, then the data is to be gathered
+            if initial_micro_data and len(micro_sims_to_init) > 0:
+                initial_micro_data_list: List[Dict[str, Any]] = [
+                    dict(zip(initial_micro_data.keys(), t))
+                    for t in zip(*initial_micro_data.values())
+                ]
+
+            initial_micro_data_list: List[
+                Dict[str, Any]
+            ] = self._adaptivity_controller.get_full_field_micro_output(
+                initial_macro_data, initial_micro_data_list
+            )
+
+            self._adaptivity_controller.update_buffers(initial_micro_data_list)
 
         self._profiler.end()
 
@@ -686,110 +507,33 @@ class MicroManagerCoupling(MicroManager):
     # ***************
 
     def _solve_micro_simulations(
-        self, micro_sims_input: list, dt: float, computed_outputs: dict = {}
-    ) -> list:
+        self,
+        micro_sims_input: List[Dict[str, Any]],
+        dt: float,
+        computed_outputs: Dict[int, Dict[str, Any]] = {},
+    ) -> List[Dict[str, Any]]:
         """
-        Solve all micro simulations and assemble the micro simulations outputs in a list of dicts format.
+        (Adaptively) solve micro simulations and assemble the micro simulations outputs in a list of dicts format.
 
         Parameters
         ----------
-        micro_sims_input : list
+        micro_sims_input : List[Dict[str, Any]]
             List of dicts in which keys are names of data and the values are the data which are required inputs to
             solve a micro simulation.
         dt : float
             Time step size.
-        computed_outputs : dict
+        computed_outputs : Dict[int, Dict[str, Any]]
             Dictionary of global ids to already computed outputs
 
         Returns
         -------
-        micro_sims_output : list
+        micro_sims_output : List[Dict[str, Any]]
             List of dicts in which keys are names of data and the values are the data which are required outputs of
         """
-        micro_sims_output: list[dict] = [None] * self._sim_container.local_num_sims
-
-        for lid in self._sim_container.range_lid:
-            sim = self._sim_container[lid]
-            # skip already computed outputs
-            gid = self._sim_container.local_gids[lid]
-            if gid in computed_outputs:
-                micro_sims_output[lid] = computed_outputs[gid]
-                continue
-
-            # If micro simulation has not crashed in a previous iteration, attempt to solve it
-            if not self._has_sim_crashed[lid]:
-                # Attempt to solve the micro simulation
-                try:
-                    self.load_balancing.pre_sim_solve(gid)
-                    micro_sims_output[lid] = sim.solve(micro_sims_input[lid], dt)
-                    self.load_balancing.post_sim_solve(gid)
-
-                # If simulation crashes, log the error and keep the output constant at the previous iteration's output
-                except Exception as error_message:
-                    self._logger.log_error(
-                        "Micro simulation at macro coordinates {} with input {} has experienced an error. "
-                        "See next entry on this rank for error message.".format(
-                            self._sim_container.local_coords[lid], micro_sims_input[lid]
-                        )
-                    )
-                    self._logger.log_error(error_message)
-                    self._has_sim_crashed[lid] = True
-
-        # If interpolate is off, terminate after crash
-        if not self._interpolate_crashed_sims:
-            crashed_sims_on_all_ranks = np.zeros(self._mpi.size, dtype=np.int64)
-            self._mpi.comm.Allgather(
-                np.sum(self._has_sim_crashed), crashed_sims_on_all_ranks
-            )
-            if sum(crashed_sims_on_all_ranks) > 0:
-                self._logger.log_info(
-                    "Exiting simulation after micro simulation crash."
-                )
-                sys.exit()
-
-        # Interpolate result for crashed simulation
-        unset_sims = [
-            lid for lid, value in enumerate(micro_sims_output) if value is None
-        ]
-
-        # Iterate over all crashed simulations to interpolate output
-        if self._interpolate_crashed_sims:
-            for lid in unset_sims:
-                self._logger.log_info(
-                    "Interpolating output for crashed simulation at macro vertex {}.".format(
-                        self._sim_container.local_coords[lid]
-                    )
-                )
-                micro_sims_output[lid] = self._interpolate_output_for_crashed_sim(
-                    micro_sims_input, micro_sims_output, lid
-                )
-
-        return micro_sims_output
-
-    def _solve_micro_simulations_with_adaptivity(
-        self, micro_sims_input: list, dt: float, computed_outputs: dict = {}
-    ) -> list:
-        """
-        Adaptively solve micro simulations and assemble the micro simulations outputs in a list of dicts format.
-
-        Parameters
-        ----------
-        micro_sims_input : list
-            List of dicts in which keys are names of data and the values are the data which are required inputs to
-            solve a micro simulation.
-        dt : float
-            Time step size.
-        computed_outputs : dict
-            Dictionary of global ids to already computed outputs
-
-        Returns
-        -------
-        micro_sims_output : list
-            List of dicts in which keys are names of data and the values are the data which are required outputs of
-        """
-        active_sim_lids = self._adaptivity_controller.get_active_sim_local_ids()
-
-        micro_sims_output = [0] * self._sim_container.local_num_sims
+        active_sim_lids = self._adaptivity_controller.get_active_lids()
+        micro_sims_output: List[Optional[Dict[str, Any]]] = [
+            None
+        ] * self._sim_container.local_num_sims
 
         # Solve all active micro simulations
         for lid in active_sim_lids:
@@ -807,12 +551,9 @@ class MicroManagerCoupling(MicroManager):
                         micro_sims_input[lid], dt
                     )
                     self.load_balancing.post_sim_solve(gid)
-
-                    # Mark the micro sim as active for export
-                    micro_sims_output[lid]["Active-State"] = 1
-                    micro_sims_output[lid][
-                        "Active-Steps"
-                    ] = self._micro_sims_active_steps[gid]
+                    self._adaptivity_controller.postprocess_active_output(
+                        micro_sims_output[lid], gid
+                    )
 
                 # If simulation crashes, log the error and keep the output constant at the previous iteration's output
                 except Exception as error_message:
@@ -840,7 +581,7 @@ class MicroManagerCoupling(MicroManager):
         # Interpolate result for crashed simulation
         unset_sims = []
         for lid in active_sim_lids:
-            if micro_sims_output[lid] == 0:
+            if micro_sims_output[lid] is None:
                 unset_sims.append(lid)
 
         # Iterate over all crashed simulations to interpolate output
@@ -851,35 +592,37 @@ class MicroManagerCoupling(MicroManager):
                         self._sim_container.local_coords[lid]
                     )
                 )
-
+                self.load_balancing.pre_sim_solve(self._sim_container.local_gids[lid])
                 micro_sims_output[lid] = self._interpolate_output_for_crashed_sim(
                     micro_sims_input, micro_sims_output, lid, active_sim_lids
                 )
+                self.load_balancing.post_sim_solve(self._sim_container.local_gids[lid])
 
-        micro_sims_output = self._adaptivity_controller.get_full_field_micro_output(
+        micro_sims_output: List[
+            Dict[str, Any]
+        ] = self._adaptivity_controller.get_full_field_micro_output(
             micro_sims_input, micro_sims_output
         )
 
-        inactive_sim_lids = self._adaptivity_controller.get_inactive_sim_local_ids()
+        inactive_sim_lids = self._adaptivity_controller.get_inactive_lids()
 
         # Resolve micro sim output data for inactive simulations
         for inactive_lid in inactive_sim_lids:
             self.load_balancing.pre_sim_solve(
                 self._sim_container.local_gids[inactive_lid]
             )
-            micro_sims_output[inactive_lid]["Active-State"] = 0
             gid = self._sim_container.local_gids[inactive_lid]
-            micro_sims_output[inactive_lid][
-                "Active-Steps"
-            ] = self._micro_sims_active_steps[gid]
             self.load_balancing.post_sim_solve(
                 self._sim_container.local_gids[inactive_lid]
             )
+            self._adaptivity_controller.postprocess_inactive_output(
+                micro_sims_output[inactive_lid], gid
+            )
 
         # Collect micro sim output for adaptivity calculation
-        for lid in self._sim_container.range_lid:
-            for name in self._adaptivity_micro_data_names:
-                self._data_for_adaptivity[name][lid] = micro_sims_output[lid][name]
+        self._adaptivity_controller.update_buffers(
+            micro_sims_output, None, invert=False
+        )
 
         return micro_sims_output
 
@@ -888,9 +631,7 @@ class MicroManagerCoupling(MicroManager):
     ) -> list:
         self._model_adaptivity_controller.initialise_solve()
 
-        active_sim_ids = None
-        if self._is_adaptivity_on:
-            active_sim_ids = self._adaptivity_controller.get_active_sim_local_ids()
+        active_sim_ids = self._adaptivity_controller.get_active_lids()
         output = None
 
         while self._model_adaptivity_controller.should_iterate():
@@ -934,25 +675,20 @@ class MicroManagerCoupling(MicroManager):
         solve_variant : Callable
             Solve variant function based on the adaptivity type.
         """
-        if self._is_adaptivity_on:
-            solve_variant = self._solve_micro_simulations_with_adaptivity
-        else:
-            solve_variant = self._solve_micro_simulations
-
         if self._is_model_adaptivity_on:
             return partial(
                 self._solve_micro_simulations_with_model_adaptivity,
-                solve_variant=solve_variant,
+                solve_variant=self._solve_micro_simulations,
             )
         else:
-            return solve_variant
+            return self._solve_micro_simulations
 
     def _interpolate_output_for_crashed_sim(
         self,
         micro_sims_input: list,
         micro_sims_output: list,
         unset_sim_lid: int,
-        active_sim_ids: np.ndarray = None,
+        active_sim_ids: List[int],
     ) -> dict:
         """
         Using the output of neighboring simulations, interpolate the output for a crashed simulation.
@@ -966,7 +702,7 @@ class MicroManagerCoupling(MicroManager):
             List dicts containing output of local micro simulations.
         unset_sim_lid : int
             Index of the crashed simulation in the list of all local simulations currently interpolating.
-        active_sim_ids : numpy.ndarray, optional
+        active_sim_ids : List[int]
             Array of active simulation IDs.
 
         Returns
@@ -976,10 +712,7 @@ class MicroManagerCoupling(MicroManager):
         """
         # Find neighbors of the crashed simulation in active and non-crashed simulations
         # Set iteration length to only iterate over active simulations
-        if self._is_adaptivity_on:
-            iter_length = active_sim_ids
-        else:
-            iter_length = range(len(micro_sims_input))
+        iter_length = active_sim_ids
         micro_sims_active_input_lists = []
         micro_sims_active_values = []
         # Turn crashed simulation macro parameters into list to use as coordinate for interpolation
@@ -1022,14 +755,9 @@ class MicroManagerCoupling(MicroManager):
         # Collect neighbor vertices for interpolation
         for neighbor in nearest_neighbors:
             # Remove data not required for interpolation from values
-            if self._is_adaptivity_on:
-                interpol_space.append(micro_sims_active_input_lists[neighbor].copy())
-                interpol_values.append(micro_sims_active_values[neighbor].copy())
-                interpol_values[-1].pop("Active-State", None)
-                interpol_values[-1].pop("Active-Steps", None)
-            else:
-                interpol_space.append(micro_sims_active_input_lists[neighbor].copy())
-                interpol_values.append(micro_sims_active_values[neighbor].copy())
+            interpol_space.append(micro_sims_active_input_lists[neighbor].copy())
+            interpol_values.append(micro_sims_active_values[neighbor].copy())
+            self._adaptivity_controller.postprocess_remove(interpol_values[-1])
 
         # Interpolate for each parameter
         output_interpol = dict()
@@ -1042,9 +770,8 @@ class MicroManagerCoupling(MicroManager):
                 interpol_space, crashed_position, key_values
             )
         # Reintroduce removed information
-        if self._is_adaptivity_on:
-            output_interpol["Active-State"] = 1
-            output_interpol["Active-Steps"] = self._micro_sims_active_steps[
-                unset_sim_lid
-            ]
+        self._adaptivity_controller.postprocess_active_output(
+            output_interpol,
+            self._sim_container.local_gids[unset_sim_lid],
+        )
         return output_interpol

--- a/micro_manager/micro_simulation.py
+++ b/micro_manager/micro_simulation.py
@@ -7,6 +7,7 @@ created object is uniquely identifiable in a global setting.
 from abc import ABC, abstractmethod
 import inspect
 import importlib as ipl
+from typing import Optional, Dict, Any, Tuple, List
 
 from .tasking.task import (
     ConstructTask,
@@ -370,8 +371,10 @@ class MicroSimulationClass:
         return self._sim_cls
 
     def check_initialize(
-        self, test_instance: MicroSimulationInterface, test_input: dict
-    ) -> tuple[bool, bool]:
+        self,
+        test_instance: MicroSimulationInterface,
+        test_input: Optional[Dict[str, Any]],
+    ) -> Tuple[bool, bool, bool, Optional[Dict[str, Any]]]:
         """
         Check whether the micro simulation class implements ``initialize``.
 
@@ -381,56 +384,53 @@ class MicroSimulationClass:
 
         Parameters
         ----------
-        test_instance : object
+        test_instance : MicroSimulationInterface
             An instance of the micro simulation class used for signature probing.
-        test_input : dict
+        test_input : Optional[Dict[str, Any]]
             Sample input data used to probe whether ``initialize`` accepts arguments.
 
         Returns
         -------
-        check_result : tuple[bool, bool]
-            (has_initialize, requires_initial_data)
+        check_result : Tuple[bool, bool, bool, Optional[Dict[str, Any]]]
+            (has_initialize, requires_initial_data, has_return_value, return_value)
         """
         if not test_instance.requires_initialize():
-            return False, False
+            return False, False, False, None
 
         has_args = False
+        has_return_value = False
+        result = None
 
-        # Try to get the signature of the initialize() method, if it is written in Python
+        # Try to call the initialize() method without initial data
         try:
-            argspec = inspect.getfullargspec(self._sim_cls.initialize)
-            # The first argument in the signature is self
-            if len(argspec.args) == 1:
-                has_args = False
-            elif len(argspec.args) == 2:
+            result = test_instance.initialize()
+            has_args = False
+        except TypeError:
+            self._log.log_info_rank_zero(
+                "The initialize() method of the micro simulation has arguments. "
+                "Attempting to call it with initial data."
+            )
+
+            if test_input is None:
+                raise Exception(
+                    "The initialize() method of the Micro simulation requires initial data, "
+                    "but no initial macro data has been provided."
+                )
+
+            try:
+                result = test_instance.initialize(test_input)
                 has_args = True
-            else:
+            except TypeError:
                 raise Exception(
                     "The initialize() method of the Micro simulation has an incorrect number of arguments."
                 )
-        except TypeError:
-            self._log.log_info_rank_zero(
-                "The signature of initialize() method of the micro simulation cannot be determined. "
-                + "Trying to determine the signature by calling the method."
-            )
-            # Try to call the initialize() method without initial data
-            try:
-                test_instance.initialize()
-                has_args = False
-            except TypeError:
-                self._log.log_info_rank_zero(
-                    "The initialize() method of the micro simulation has arguments. "
-                    + "Attempting to call it again with initial data."
-                )
-                try:
-                    test_instance.initialize(test_input)
-                    has_args = True
-                except TypeError:
-                    raise Exception(
-                        "The initialize() method of the Micro simulation has an incorrect number of arguments."
-                    )
+        has_return_value = result is not None
 
-        return True, has_args
+        if has_return_value:
+            if type(result) != dict:
+                raise Exception("The initialize() method must return a dict.")
+
+        return True, has_args, has_return_value, result
 
     def check_output(self) -> bool:
         """

--- a/micro_manager/simulation_container.py
+++ b/micro_manager/simulation_container.py
@@ -1,7 +1,7 @@
 from .micro_simulation import MicroSimulationInterface
 from .tools.mpi_handler import MPIHandler
 
-from typing import Optional, Any, List, Dict, Set, Iterable, Tuple
+from typing import Optional, Any, List, Dict, Set, Iterable, Tuple, Collection
 import numpy as np
 
 
@@ -146,25 +146,25 @@ class SimulationContainer:
         return self._sim_coords
 
     @property
-    def range_lid(self) -> Iterable[int]:
+    def range_lid(self) -> Collection[int]:
         """
         Returns an iterator that yields all current local IDs.
 
         Returns
         -------
-        lid_range : Iterable[int]
+        lid_range : Collection[int]
             lid iterator
         """
         return range(self.local_num_sims)
 
     @property
-    def range_gid(self) -> Iterable[int]:
+    def range_gid(self) -> Collection[int]:
         """
         Returns an iterator that yields all global IDs.
 
         Returns
         -------
-        gid_range : Iterable[int]
+        gid_range : Collection[int]
             gid iterator
         """
         return range(self.global_num_sims)

--- a/tests/integration/test_unit_cube/micro_dummy.py
+++ b/tests/integration/test_unit_cube/micro_dummy.py
@@ -15,13 +15,13 @@ class MicroSimulation:
         self._sim_id = sim_id
 
         match sim_id:
-            case 0, 4:
+            case 0 | 4:
                 self._this_sim_type = 1
-            case 1, 5:
+            case 1 | 5:
                 self._this_sim_type = 3
-            case 2, 6:
+            case 2 | 6:
                 self._this_sim_type = 6
-            case 3, 7:
+            case 3 | 7:
                 self._this_sim_type = 9
             case _:
                 self._this_sim_type = -1

--- a/tests/integration/test_unit_cube/micro_dummy.py
+++ b/tests/integration/test_unit_cube/micro_dummy.py
@@ -14,14 +14,17 @@ class MicroSimulation:
         """
         self._sim_id = sim_id
 
-        if sim_id == 0 or sim_id == 4:
-            self._this_sim_type = 1
-        elif sim_id == 1 or sim_id == 5:
-            self._this_sim_type = 3
-        elif sim_id == 2 or sim_id == 6:
-            self._this_sim_type = 6
-        elif sim_id == 3 or sim_id == 7:
-            self._this_sim_type = 9
+        match sim_id:
+            case 0, 4:
+                self._this_sim_type = 1
+            case 1, 5:
+                self._this_sim_type = 3
+            case 2, 6:
+                self._this_sim_type = 6
+            case 3, 7:
+                self._this_sim_type = 9
+            case _:
+                self._this_sim_type = -1
 
         # Artificial state
         self._state = [x * 0.1 for x in range(1000)]

--- a/tests/unit/precice.py
+++ b/tests/unit/precice.py
@@ -8,8 +8,8 @@ class Participant:
     def __init__(
         self, solver_name, config_file_name, solver_process_index, solver_process_size
     ):
-        self.read_write_vector_buffer = []
-        self.read_write_scalar_buffer = []
+        self.read_write_vector_buffer = [0] * 4
+        self.read_write_scalar_buffer = [np.zeros(3) for _ in range(4)]
 
     def initialize(self):
         return 0.1  # dt

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -170,7 +170,9 @@ class TestGlobalAdaptivity(TestCase):
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
-        adaptivity_controller.update_buffers(data_for_adaptivity, None, invert=True, alloc=True)
+        adaptivity_controller.update_buffers(
+            data_for_adaptivity, None, invert=True, alloc=True
+        )
         adaptivity_controller.compute(0.1)
 
         self.assertTrue(

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -172,6 +172,7 @@ class TestGlobalAdaptivity(TestCase):
 
         adaptivity_controller.update_buffers(data_for_adaptivity, None, invert=True)
         adaptivity_controller.compute(0.1)
+        # dummy change to trigger CI
 
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -164,11 +164,13 @@ class TestGlobalAdaptivity(TestCase):
             model_manager=ModelManager(),
         )
 
-        adaptivity_controller._adaptivity_data_names = ["data1", "data2"]
+        adaptivity_controller._data_names = ["data1", "data2"]
+        adaptivity_controller._micro_data_names = adaptivity_controller._data_names
 
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
+        adaptivity_controller.update_buffers(data_for_adaptivity, None, invert=True)
         adaptivity_controller.compute(0.1)
 
         self.assertTrue(

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -170,9 +170,8 @@ class TestGlobalAdaptivity(TestCase):
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
-        adaptivity_controller.update_buffers(data_for_adaptivity, None, invert=True)
+        adaptivity_controller.update_buffers(data_for_adaptivity, None, invert=True, alloc=True)
         adaptivity_controller.compute(0.1)
-        # dummy change to trigger CI
 
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -53,7 +53,7 @@ class TestGlobalAdaptivity(TestCase):
             global_ids = [3, 4]
 
         expected_is_sim_active = np.array([True, False, True, True, True])
-        expected_sim_is_associated_to = [-2, 3, -2, -2, -2]
+        expected_sim_is_associated_to = {1: 3}
 
         self._configurator.adaptivity_similarity_measure = MagicMock(return_value="L1")
 
@@ -82,7 +82,7 @@ class TestGlobalAdaptivity(TestCase):
         adaptivity_controller._is_sim_active = np.array(
             [False, False, True, True, False]
         )
-        adaptivity_controller._sim_is_associated_to = [3, 3, -2, -2, 2]
+        adaptivity_controller._sim_is_associated_to = {0: 3, 1: 3, 4: 2}
 
         # Force the activation of sim #0 and #4
         def check_for_activation(i, active):
@@ -101,11 +101,8 @@ class TestGlobalAdaptivity(TestCase):
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)
         )
-        self.assertTrue(
-            np.array_equal(
-                expected_sim_is_associated_to,
-                adaptivity_controller._sim_is_associated_to,
-            )
+        self.assertDictEqual(
+            expected_sim_is_associated_to, adaptivity_controller.get_associated_map()
         )
 
         if self._mpi.rank == 0:
@@ -132,7 +129,7 @@ class TestGlobalAdaptivity(TestCase):
             }
 
         expected_is_sim_active = np.array([False, False, True, False, True])
-        expected_sim_is_associated_to = [4, 2, -2, 2, -2]
+        expected_sim_is_associated_to = {0: 4, 1: 2, 3: 2}
 
         self._configurator.adaptivity_history_param = MagicMock(return_value=0.1)
         self._configurator.adaptivity_refining_constant = MagicMock(return_value=0.5)
@@ -172,20 +169,13 @@ class TestGlobalAdaptivity(TestCase):
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
-        adaptivity_controller.compute_adaptivity(
-            0.1,
-            data_for_adaptivity,
-        )
+        adaptivity_controller.compute(0.1)
 
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)
         )
-
-        self.assertTrue(
-            np.array_equal(
-                expected_sim_is_associated_to,
-                adaptivity_controller._sim_is_associated_to,
-            )
+        self.assertDictEqual(
+            expected_sim_is_associated_to, adaptivity_controller.get_associated_map()
         )
 
     def test_communicate_micro_output(self):
@@ -239,7 +229,7 @@ class TestGlobalAdaptivity(TestCase):
         adaptivity_controller._is_sim_active = np.array(
             [False, False, True, True, False]
         )
-        adaptivity_controller._sim_is_associated_to = [3, 3, -2, -2, 2]
+        adaptivity_controller._sim_is_associated_to = {0: 3, 1: 3, 4: 2}
 
         adaptivity_controller._communicate_micro_output(sim_output)
 

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -466,7 +466,7 @@ class TestLocalAdaptivity(TestCase):
         adaptivity_controller._is_sim_active = np.array(
             [True, False, False, False, False]
         )
-        adaptivity_controller._sim_is_associated_to = expected_sim_is_associated_to
+        adaptivity_controller._sim_is_associated_to = {1: 0, 2: 0, 3: 0, 4: 3}
 
         for i in range(self._number_of_sims):
             container[i] = MicroSimulation(i)

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 import numpy as np
-from mpi4py import MPI
 
 from micro_manager.adaptivity.adaptivity import AdaptivityCalculator
 from micro_manager.adaptivity.local_adaptivity import LocalAdaptivityCalculator

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -1,4 +1,5 @@
 from math import exp
+from typing import List, Dict, Any, Optional
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -38,6 +39,34 @@ class MicroSimulation:
 class ModelManager:
     def get_instance(self, gid, micro_problem_cls):
         return micro_problem_cls(gid)
+
+
+class AdaptivityCalculatorInstantiable(AdaptivityCalculator):
+    """
+    Workaround to bypass ABC instantiation limitations. Only used for testing internals.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_active_lids(self) -> List[int]:
+        return []
+
+    def get_inactive_lids(self) -> List[int]:
+        return []
+
+    def get_active_gids(self) -> List[int]:
+        return []
+
+    def get_inactive_gids(self) -> List[int]:
+        return []
+
+    def get_full_field_micro_output(
+        self,
+        micro_input: List[Dict[str, Any]],
+        micro_output: List[Optional[Dict[str, Any]]],
+    ) -> List[Dict[str, Any]]:
+        return []
 
 
 class TestLocalAdaptivity(TestCase):
@@ -111,7 +140,7 @@ class TestLocalAdaptivity(TestCase):
             [np.zeros(3) for _ in range(self._number_of_sims)],
         )
 
-        adaptivity_controller = AdaptivityCalculator(
+        adaptivity_controller = AdaptivityCalculatorInstantiable(
             configurator,
             nsims=self._number_of_sims,
             sim_container=container,
@@ -201,54 +230,29 @@ class TestLocalAdaptivity(TestCase):
         """
         Test functionality for calculating similarity criteria between pairs of simulations using different norms in class AdaptivityCalculator.
         """
-        configurator = MagicMock()
-        configurator.adaptivity_similarity_measure = MagicMock(return_value="L1")
-        configurator.output_dir = MagicMock(return_value="output_dir")
-        configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
-
-        mpi = MPIHandler()
-        container = SimulationContainer(mpi)
-        container.initialize(
-            self._number_of_sims,
-            self._number_of_sims,
-            list(range(self._number_of_sims)),
-            [np.zeros(3) for _ in range(self._number_of_sims)],
-        )
-
-        adaptivity_controller = AdaptivityCalculator(
-            configurator,
-            nsims=self._number_of_sims,
-            sim_container=container,
-            profiler=MagicMock(),
-            base_logger=MagicMock(),
-            mpi=mpi,
-            micro_problem_cls=MicroSimulation,
-            model_manager=ModelManager(),
-        )
-
         fake_data = np.array([[1], [2], [3]])
         self.assertTrue(
             np.allclose(
-                adaptivity_controller._l1(fake_data),
+                AdaptivityCalculator._l1(fake_data),
                 np.array([[0, 1, 2], [1, 0, 1], [2, 1, 0]]),
             )
         )
         # norm taken over last axis -> same as before
         self.assertTrue(
             np.allclose(
-                adaptivity_controller._l2(fake_data),
+                AdaptivityCalculator._l2(fake_data),
                 np.array([[0, 1, 2], [1, 0, 1], [2, 1, 0]]),
             )
         )
         self.assertTrue(
             np.allclose(
-                adaptivity_controller._l1rel(fake_data),
+                AdaptivityCalculator._l1rel(fake_data),
                 np.array([[0, 0.5, 2 / 3], [0.5, 0, 1 / 3], [2 / 3, 1 / 3, 0]]),
             )
         )
         self.assertTrue(
             np.allclose(
-                adaptivity_controller._l2rel(fake_data),
+                AdaptivityCalculator._l2rel(fake_data),
                 np.array([[0, 0.5, 2 / 3], [0.5, 0, 1 / 3], [2 / 3, 1 / 3, 0]]),
             )
         )
@@ -256,12 +260,12 @@ class TestLocalAdaptivity(TestCase):
         fake_2d_data = np.array([[1, 2], [3, 4]])
         self.assertTrue(
             np.allclose(
-                adaptivity_controller._l1(fake_2d_data), np.array([[0, 4], [4, 0]])
+                AdaptivityCalculator._l1(fake_2d_data), np.array([[0, 4], [4, 0]])
             )
         )
         self.assertTrue(
             np.allclose(
-                adaptivity_controller._l2(fake_2d_data),
+                AdaptivityCalculator._l2(fake_2d_data),
                 np.array(
                     [
                         [0, np.sqrt((1 - 3) ** 2 + (2 - 4) ** 2)],
@@ -272,7 +276,7 @@ class TestLocalAdaptivity(TestCase):
         )
         self.assertTrue(
             np.allclose(
-                adaptivity_controller._l1rel(fake_2d_data),
+                AdaptivityCalculator._l1rel(fake_2d_data),
                 np.array(
                     [
                         [0, abs((1 - 3) / max(1, 3) + (2 - 4) / max(2, 4))],
@@ -283,7 +287,7 @@ class TestLocalAdaptivity(TestCase):
         )
         self.assertTrue(
             np.allclose(
-                adaptivity_controller._l2rel(fake_2d_data),
+                AdaptivityCalculator._l2rel(fake_2d_data),
                 np.array(
                     [
                         [
@@ -325,7 +329,7 @@ class TestLocalAdaptivity(TestCase):
         configurator.adaptivity_similarity_measure = MagicMock(return_value="L2rel")
         configurator.output_dir = MagicMock(return_value="output_dir")
         configurator.micro_file_name = MagicMock(return_value="test_adaptivity_serial")
-        adaptivity_l2rel = AdaptivityCalculator(
+        adaptivity_l2rel = AdaptivityCalculatorInstantiable(
             configurator,
             nsims=3,
             sim_container=container,
@@ -342,7 +346,7 @@ class TestLocalAdaptivity(TestCase):
         configurator_l1.micro_file_name = MagicMock(
             return_value="test_adaptivity_serial"
         )
-        adaptivity_l1rel = AdaptivityCalculator(
+        adaptivity_l1rel = AdaptivityCalculatorInstantiable(
             configurator_l1,
             nsims=3,
             sim_container=container,
@@ -391,7 +395,7 @@ class TestLocalAdaptivity(TestCase):
             [np.zeros(3) for _ in range(self._number_of_sims)],
         )
 
-        adaptivity_controller = AdaptivityCalculator(
+        adaptivity_controller = AdaptivityCalculatorInstantiable(
             configurator,
             nsims=self._number_of_sims,
             sim_container=container,

--- a/tests/unit/test_adaptivity_serial.py
+++ b/tests/unit/test_adaptivity_serial.py
@@ -115,6 +115,7 @@ class TestLocalAdaptivity(TestCase):
             configurator,
             nsims=self._number_of_sims,
             sim_container=container,
+            profiler=MagicMock(),
             micro_problem_cls=MicroSimulation,
             model_manager=ModelManager(),
             base_logger=MagicMock(),
@@ -172,6 +173,7 @@ class TestLocalAdaptivity(TestCase):
         adaptivity_controller = LocalAdaptivityCalculator(
             configurator,
             sim_container=container,
+            profiler=MagicMock(),
             base_logger=MagicMock(),
             mpi=mpi,
             micro_problem_cls=MicroSimulation,
@@ -217,6 +219,7 @@ class TestLocalAdaptivity(TestCase):
             configurator,
             nsims=self._number_of_sims,
             sim_container=container,
+            profiler=MagicMock(),
             base_logger=MagicMock(),
             mpi=mpi,
             micro_problem_cls=MicroSimulation,
@@ -326,6 +329,7 @@ class TestLocalAdaptivity(TestCase):
             configurator,
             nsims=3,
             sim_container=container,
+            profiler=MagicMock(),
             base_logger=MagicMock(),
             mpi=mpi,
             micro_problem_cls=MicroSimulation,
@@ -342,6 +346,7 @@ class TestLocalAdaptivity(TestCase):
             configurator_l1,
             nsims=3,
             sim_container=container,
+            profiler=MagicMock(),
             base_logger=MagicMock(),
             mpi=mpi,
             micro_problem_cls=MicroSimulation,
@@ -390,6 +395,7 @@ class TestLocalAdaptivity(TestCase):
             configurator,
             nsims=self._number_of_sims,
             sim_container=container,
+            profiler=MagicMock(),
             base_logger=MagicMock(),
             mpi=mpi,
             micro_problem_cls=MicroSimulation,
@@ -408,15 +414,11 @@ class TestLocalAdaptivity(TestCase):
         adaptivity_controller._is_sim_active = np.array(
             [True, False, False, True, False]
         )
-        expected_sim_is_associated_to = np.array([-2, 0, 0, -2, 3])
+        expected_sim_is_associated_to = {1: 0, 2: 0, 4: 3}
 
         adaptivity_controller._associate_inactive_to_active()
-
-        self.assertTrue(
-            np.array_equal(
-                expected_sim_is_associated_to,
-                adaptivity_controller._sim_is_associated_to,
-            )
+        self.assertDictEqual(
+            expected_sim_is_associated_to, adaptivity_controller.get_associated_map()
         )
 
     def test_update_inactive_sims_local_adaptivity(self):
@@ -440,6 +442,7 @@ class TestLocalAdaptivity(TestCase):
         adaptivity_controller = LocalAdaptivityCalculator(
             configurator,
             sim_container=container,
+            profiler=MagicMock(),
             base_logger=MagicMock(),
             mpi=mpi,
             micro_problem_cls=MicroSimulation,
@@ -454,13 +457,13 @@ class TestLocalAdaptivity(TestCase):
 
         # Third and fifth micro sim are active, rest are deactivate
         expected_is_sim_active = np.array([True, False, False, True, False])
-        expected_sim_is_associated_to = np.array([-2, 0, 0, -2, 3])
+        expected_sim_is_associated_to = {1: 0, 2: 0, 4: 3}
 
         adaptivity_controller._similarity_dists = self._similarity_dists
         adaptivity_controller._is_sim_active = np.array(
             [True, False, False, False, False]
         )
-        adaptivity_controller._sim_is_associated_to = np.array([-2, 0, 0, 0, 3])
+        adaptivity_controller._sim_is_associated_to = expected_sim_is_associated_to
 
         for i in range(self._number_of_sims):
             container[i] = MicroSimulation(i)
@@ -470,9 +473,6 @@ class TestLocalAdaptivity(TestCase):
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)
         )
-        self.assertTrue(
-            np.array_equal(
-                expected_sim_is_associated_to,
-                adaptivity_controller._sim_is_associated_to,
-            )
+        self.assertDictEqual(
+            expected_sim_is_associated_to, adaptivity_controller.get_associated_map()
         )

--- a/tests/unit/test_load_balancing.py
+++ b/tests/unit/test_load_balancing.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
-from adaptivity.adaptivity_interface import AdaptivityInterface
+from micro_manager.adaptivity.adaptivity_interface import AdaptivityInterface
 from micro_manager.adaptivity.adaptivity import NoOpAdaptivity
 from micro_manager.load_balancing import LoadBalancer, ActiveBalancer
 from micro_manager.micro_simulation import create_simulation_class

--- a/tests/unit/test_load_balancing.py
+++ b/tests/unit/test_load_balancing.py
@@ -347,7 +347,7 @@ class TestLBActive(TestCase):
             global_ids = [1, 3, 4]
             expected_global_ids = [1, 3]
             active_gids = [1]
-        assoc_map = {2: 0, 3: 0, 4: 1}
+        assoc_map = {2: 0, 3: 1, 4: 0}
         expected_ranks_of_sims = {0: 0, 1: 1, 2: 0, 3: 1, 4: 0}
 
         sim_cls = create_simulation_class(

--- a/tests/unit/test_load_balancing.py
+++ b/tests/unit/test_load_balancing.py
@@ -48,7 +48,7 @@ class ModelManager:
         return self._cls(gid, late_init=late_init)
 
 
-class GlobalAdaptivityDummy(AdaptivityInterface):
+class GlobalAdaptivityCalculator(AdaptivityInterface):
     def __init__(
         self,
         active_gids: List[int],
@@ -220,7 +220,7 @@ class TestLBTime(TestCase):
                 sim = sim_cls(gid)
             container[lid] = sim
 
-        adaptivity = GlobalAdaptivityDummy(
+        adaptivity = GlobalAdaptivityCalculator(
             active_gids,
             container,
             assoc_map,
@@ -296,7 +296,7 @@ class TestLBActive(TestCase):
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
-        adaptivity_controller = GlobalAdaptivityDummy(
+        adaptivity_controller = GlobalAdaptivityCalculator(
             active_gids,
             container,
             {4: 0, 5: 1, 6: 2, 7: 3},
@@ -368,7 +368,7 @@ class TestLBActive(TestCase):
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
-        adaptivity_controller = GlobalAdaptivityDummy(
+        adaptivity_controller = GlobalAdaptivityCalculator(
             active_gids,
             container,
             assoc_map,
@@ -451,7 +451,7 @@ class TestLBActive(TestCase):
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
-        adaptivity_controller = GlobalAdaptivityDummy(
+        adaptivity_controller = GlobalAdaptivityCalculator(
             active_gids,
             container,
             assoc_map,
@@ -535,7 +535,7 @@ class TestLBActive(TestCase):
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
 
-        adaptivity_controller = GlobalAdaptivityDummy(
+        adaptivity_controller = GlobalAdaptivityCalculator(
             active_gids,
             container,
             assoc_map,

--- a/tests/unit/test_load_balancing.py
+++ b/tests/unit/test_load_balancing.py
@@ -427,7 +427,7 @@ class TestLBActive(TestCase):
             global_ids = [12, 13, 14]
             expected_global_ids = [13, 14]
             active_gids = [12, 13, 14]
-        assoc_map = defaultdict(lambda: 0)
+        assoc_map = {gid: 0 for gid in [3, 4, 5, 6, 7, 9, 10, 11]}
         expected_ranks_of_sims = [1, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3]
         expected_ranks_of_sims = {
             gid: rnk for gid, rnk in enumerate(expected_ranks_of_sims)
@@ -511,7 +511,7 @@ class TestLBActive(TestCase):
             global_ids = [13, 14]
             expected_global_ids = [13, 14, 5]
             active_gids = [13, 14]
-        assoc_map = defaultdict(lambda: 0)
+        assoc_map = {3: 0, 4: 1, 5: 13, 6: 12, 7: 12, 9: 1, 10: 2, 11: 8}
         expected_ranks_of_sims = [2, 0, 0, 2, 0, 3, 1, 1, 2, 0, 0, 2, 1, 3, 3]
         expected_ranks_of_sims = {
             gid: rnk for gid, rnk in enumerate(expected_ranks_of_sims)

--- a/tests/unit/test_load_balancing.py
+++ b/tests/unit/test_load_balancing.py
@@ -1,9 +1,14 @@
 import unittest
+from collections import defaultdict
+from copy import deepcopy
+from typing import Dict, List, Any, Optional
 from unittest import TestCase
 from unittest.mock import MagicMock
 
 import numpy as np
 
+from adaptivity.adaptivity_interface import AdaptivityInterface
+from micro_manager.adaptivity.adaptivity import NoOpAdaptivity
 from micro_manager.load_balancing import LoadBalancer, ActiveBalancer
 from micro_manager.micro_simulation import create_simulation_class
 from micro_manager.simulation_container import SimulationContainer
@@ -41,6 +46,70 @@ class ModelManager:
 
     def get_instance_by_name(self, gid: int, name: str, *, late_init: bool = False):
         return self._cls(gid, late_init=late_init)
+
+
+class GlobalAdaptivityDummy(AdaptivityInterface):
+    def __init__(
+        self,
+        active_gids: List[int],
+        container: SimulationContainer,
+        assoc: Dict[int, int],
+        mpi: MPIHandler,
+    ):
+        self._mpi = mpi
+        self._container = container
+        self._active_lids = []
+        self._active_gids = active_gids
+        self._inactive_lids = []
+        self._inactive_gids = []
+        self._active_steps = {gid: 0 for gid in container.local_gids}
+        self._assoc = assoc
+        active_gid_set = set(active_gids)
+        for lid, gid in enumerate(container.local_gids):
+            if gid in active_gid_set:
+                self._active_lids.append(lid)
+            else:
+                self._inactive_lids.append(lid)
+                self._inactive_gids.append(gid)
+        assert len(self._inactive_gids) == len(self._inactive_lids)
+        assert all([gid in set(assoc.keys()) for gid in self._inactive_gids])
+
+    def get_active_steps(self) -> Dict[int, int]:
+        return self._active_steps
+
+    def get_active_lids(self) -> List[int]:
+        return self._active_lids
+
+    def get_inactive_lids(self) -> List[int]:
+        return self._inactive_lids
+
+    def get_active_gids(self) -> List[int]:
+        return self._active_gids
+
+    def get_inactive_gids(self) -> List[int]:
+        return self._inactive_gids
+
+    def get_full_field_micro_output(
+        self,
+        micro_input: List[Dict[str, Any]],
+        micro_output: List[Optional[Dict[str, Any]]],
+    ) -> List[Dict[str, Any]]:
+        bcast_out = self._mpi.comm.allgather(
+            list(zip(self._container.local_gids, micro_output))
+        )
+        glob_out = [None] * self._container.global_num_sims
+        for loc_list in bcast_out:
+            for gid, m_out in loc_list:
+                glob_out[gid] = m_out
+        for i_lid, i_gid in zip(self._inactive_lids, self._inactive_gids):
+            micro_output[i_lid] = deepcopy(glob_out[self._assoc[i_gid]])
+        return micro_output
+
+    def get_adaptivity_buffer(self) -> Dict[str, List[Any]]:
+        return {}
+
+    def get_associated_map(self) -> Dict[int, int]:
+        return self._assoc
 
 
 class TestLBTime(TestCase):
@@ -90,7 +159,7 @@ class TestLBTime(TestCase):
         load_balancer = LoadBalancer(
             MagicMock(),
             ModelManager(sim_cls),
-            None,
+            NoOpAdaptivity(container),
             container,
             MagicMock(),
             config,
@@ -118,25 +187,16 @@ class TestLBTime(TestCase):
         """
         global_number_of_sims = 8
 
-        class GlobalAdaptivityCalculator:
-            def __init__(self, active_ids):
-                self._active_ids = active_ids
-
-            def get_active_sim_local_ids(self):
-                return self._active_ids
-
-            def set_is_on_rank(self, *args, **kwargs):
-                pass
-
         # assume lpt partitioning
         if self._mpi.rank == 0:
             global_ids = [2, 3]
             expected_global_ids = [1, 3, 5, 7]
-            adaptivity = GlobalAdaptivityCalculator([1])
+            active_gids = [3]
         else:
             global_ids = [0, 1, 4, 5, 6, 7]
             expected_global_ids = [0, 2, 4, 6]
-            adaptivity = GlobalAdaptivityCalculator([1, 2, 3, 4, 5])
+            active_gids = [1, 4, 5, 6, 7]
+        assoc_map = {0: 1, 2: 3}
         expected_ranks_of_sims = {0: 1, 1: 0, 2: 1, 3: 0, 4: 1, 5: 0, 6: 1, 7: 0}
 
         sim_cls = create_simulation_class(
@@ -160,6 +220,13 @@ class TestLBTime(TestCase):
                 sim = sim_cls(gid)
             container[lid] = sim
 
+        adaptivity = GlobalAdaptivityDummy(
+            active_gids,
+            container,
+            assoc_map,
+            self._mpi,
+        )
+
         config = MagicMock()
         config.enable_load_balancing = MagicMock(return_value=True)
         config.load_balancing_partitioning = MagicMock(return_value="lpt")
@@ -179,20 +246,6 @@ class TestLBTime(TestCase):
 
         actual_ranks_of_sims = container.get_ranks_of_sims()
         self.assertDictEqual(expected_ranks_of_sims, actual_ranks_of_sims)
-
-
-class GlobalAdaptivityCalculator:
-    def __init__(self, is_active, active_lids, active_gids, associated):
-        self._is_sim_active = is_active
-        self._active_lids = active_lids
-        self._active_gids = active_gids
-        self._sim_is_associated_to = associated
-
-    def get_active_sim_local_ids(self):
-        return self._active_lids
-
-    def get_active_sim_global_ids(self):
-        return self._active_gids
 
 
 class TestLBActive(TestCase):
@@ -218,21 +271,12 @@ class TestLBActive(TestCase):
         if self._mpi.rank == 0:
             global_ids = [0, 1, 2, 3]
             expected_global_ids = [2, 3]
-            active_lids = [0, 1, 2, 3]
             active_gids = [0, 1, 2, 3]
         elif self._mpi.rank == 1:
             global_ids = [4, 5, 6, 7]
             expected_global_ids = [4, 5, 6, 7, 0, 1]
-            active_lids = []
             active_gids = []
         expected_ranks_of_sims = {0: 1, 1: 1, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1}
-
-        adaptivity_controller = GlobalAdaptivityCalculator(
-            np.array([True, True, True, True, False, False, False, False]),
-            active_lids,
-            active_gids,
-            [-2] * global_number_of_sims,
-        )
 
         sim_cls = create_simulation_class(
             MagicMock(),
@@ -251,6 +295,13 @@ class TestLBActive(TestCase):
         )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
+
+        adaptivity_controller = GlobalAdaptivityDummy(
+            active_gids,
+            container,
+            {4: 0, 5: 1, 6: 2, 7: 3},
+            self._mpi,
+        )
 
         load_balancer = ActiveBalancer(
             MagicMock(),
@@ -291,21 +342,13 @@ class TestLBActive(TestCase):
         if self._mpi.rank == 0:
             global_ids = [0, 2]
             expected_global_ids = [0, 2, 4]
-            active_lids = [0]
             active_gids = [0]
         elif self._mpi.rank == 1:
             global_ids = [1, 3, 4]
             expected_global_ids = [1, 3]
-            active_lids = [0]
             active_gids = [1]
+        assoc_map = {2: 0, 3: 0, 4: 1}
         expected_ranks_of_sims = {0: 0, 1: 1, 2: 0, 3: 1, 4: 0}
-
-        adaptivity_controller = GlobalAdaptivityCalculator(
-            np.array([True, True, False, False, False]),
-            active_lids,
-            active_gids,
-            [-2, -2, 0, 1, 0],
-        )
 
         sim_cls = create_simulation_class(
             MagicMock(),
@@ -324,6 +367,13 @@ class TestLBActive(TestCase):
         )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
+
+        adaptivity_controller = GlobalAdaptivityDummy(
+            active_gids,
+            container,
+            assoc_map,
+            self._mpi,
+        )
 
         load_balancer = ActiveBalancer(
             MagicMock(),
@@ -364,52 +414,24 @@ class TestLBActive(TestCase):
         if self._mpi.rank == 0:
             global_ids = [0, 1, 2, 3]
             expected_global_ids = [1, 2, 3]
-            active_lids = [0, 1, 2]
             active_gids = [0, 1, 2]
         elif self._mpi.rank == 1:
             global_ids = [4, 5, 6, 7]
             expected_global_ids = [4, 5, 6, 7, 0]
-            active_lids = []
             active_gids = []
         elif self._mpi.rank == 2:
             global_ids = [8, 9, 10, 11]
             expected_global_ids = [8, 9, 10, 11, 12]
-            active_lids = [0]
             active_gids = [8]
         elif self._mpi.rank == 3:
             global_ids = [12, 13, 14]
             expected_global_ids = [13, 14]
-            active_lids = [0, 1, 2]
             active_gids = [12, 13, 14]
+        assoc_map = defaultdict(lambda: 0)
         expected_ranks_of_sims = [1, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3]
         expected_ranks_of_sims = {
             gid: rnk for gid, rnk in enumerate(expected_ranks_of_sims)
         }
-
-        adaptivity_controller = GlobalAdaptivityCalculator(
-            np.array(
-                [
-                    True,
-                    True,
-                    True,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    True,
-                    False,
-                    False,
-                    False,
-                    True,
-                    True,
-                    True,
-                ]
-            ),
-            active_lids,
-            active_gids,
-            [-2] * global_number_of_sims,
-        )
 
         sim_cls = create_simulation_class(
             MagicMock(),
@@ -428,6 +450,13 @@ class TestLBActive(TestCase):
         )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
+
+        adaptivity_controller = GlobalAdaptivityDummy(
+            active_gids,
+            container,
+            assoc_map,
+            self._mpi,
+        )
 
         load_balancer = ActiveBalancer(
             MagicMock(),
@@ -469,52 +498,24 @@ class TestLBActive(TestCase):
         if self._mpi.rank == 0:
             global_ids = [1, 2, 3]
             expected_global_ids = [1, 2, 4, 9, 10]
-            active_lids = [0, 1]
             active_gids = [1, 2]
         elif self._mpi.rank == 1:
             global_ids = [4, 5, 6, 7, 12]
             expected_global_ids = [6, 7, 12]
-            active_lids = [4]
             active_gids = [12]
         elif self._mpi.rank == 2:
             global_ids = [0, 8, 9, 10, 11]
             expected_global_ids = [0, 8, 11, 3]
-            active_lids = [0, 1]
             active_gids = [0, 8]
         elif self._mpi.rank == 3:
             global_ids = [13, 14]
             expected_global_ids = [13, 14, 5]
-            active_lids = [0, 1]
             active_gids = [13, 14]
+        assoc_map = defaultdict(lambda: 0)
         expected_ranks_of_sims = [2, 0, 0, 2, 0, 3, 1, 1, 2, 0, 0, 2, 1, 3, 3]
         expected_ranks_of_sims = {
             gid: rnk for gid, rnk in enumerate(expected_ranks_of_sims)
         }
-
-        adaptivity_controller = GlobalAdaptivityCalculator(
-            np.array(
-                [
-                    True,
-                    True,
-                    True,
-                    False,
-                    False,
-                    False,
-                    False,
-                    False,
-                    True,
-                    False,
-                    False,
-                    False,
-                    True,
-                    True,
-                    True,
-                ]
-            ),
-            active_lids,
-            active_gids,
-            [-2, -2, -2, 0, 1, 13, 12, 12, -2, 1, 2, 8, -2, -2, -2],
-        )
 
         sim_cls = create_simulation_class(
             MagicMock(),
@@ -533,6 +534,13 @@ class TestLBActive(TestCase):
         )
         for lid, gid in enumerate(container.local_gids):
             container[lid] = sim_cls(gid)
+
+        adaptivity_controller = GlobalAdaptivityDummy(
+            active_gids,
+            container,
+            assoc_map,
+            self._mpi,
+        )
 
         load_balancer = ActiveBalancer(
             MagicMock(),

--- a/tests/unit/test_micro_simulation.py
+++ b/tests/unit/test_micro_simulation.py
@@ -43,6 +43,8 @@ class MinimalSim(MicroSimulationInterface):
 
 class SimWithInitialize(MinimalSim):
     def initialize(self, data=None):
+        if data is None:
+            raise TypeError("Init needs args!")
         return {"init": True}
 
 
@@ -469,9 +471,13 @@ class TestMicroSimulationClassMethods(unittest.TestCase):
 
     def test_check_initialize_false(self):
         instance = MinimalSim(0)
-        has_init, has_args = self.sim_cls.check_initialize(instance, {})
+        has_init, has_args, has_return, return_val = self.sim_cls.check_initialize(
+            instance, {}
+        )
         self.assertFalse(has_init)
         self.assertFalse(has_args)
+        self.assertFalse(has_return)
+        self.assertTrue(return_val is None)
 
     def test_check_initialize_true_no_args(self):
         class SimInitNoArgs(MinimalSim):
@@ -481,17 +487,26 @@ class TestMicroSimulationClassMethods(unittest.TestCase):
         log = MagicMock()
         sim_cls = create_simulation_class(log, SimInitNoArgs, "dummy", 1)
         instance = SimInitNoArgs(0)
-        has_init, has_args = sim_cls.check_initialize(instance, {})
+        has_init, has_args, has_return, return_val = sim_cls.check_initialize(
+            instance, {}
+        )
         self.assertTrue(has_init)
         self.assertFalse(has_args)
+        self.assertFalse(has_return)
+        self.assertTrue(return_val is None)
 
     def test_check_initialize_true_with_args(self):
         instance = SimWithInitialize(0)
-        has_init, has_args = self.sim_cls_with_init.check_initialize(
-            instance, {"data": 1}
-        )
+        (
+            has_init,
+            has_args,
+            has_return,
+            return_val,
+        ) = self.sim_cls_with_init.check_initialize(instance, {"data": 1})
         self.assertTrue(has_init)
         self.assertTrue(has_args)
+        self.assertTrue(has_return)
+        self.assertDictEqual(return_val, {"init": True})
 
     def test_call_creates_wrapper(self):
         wrapper = self.sim_cls(0)

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -118,11 +118,13 @@ class TestSimulationCrashHandling(TestCase):
             container[lid] = MicroSimulation(lid)
         manager._sim_container = container
 
+        manager._adaptivity_controller._sim_container = container
         manager._adaptivity_controller._similarity_dists = np.zeros(shape=(5, 5))
         manager._adaptivity_controller._is_sim_active = np.array(
             [True, True, True, True, False]
         )
         manager._adaptivity_controller._sim_is_associated_to = {4: 2}
+        manager._adaptivity_controller.update_buffers(alloc=True)
 
         micro_sims_output = manager._solve_micro_simulations(macro_data, 1.0)
 

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 import numpy as np
 
 import micro_manager
+from adaptivity.adaptivity import NoOpAdaptivity
 from micro_manager.simulation_container import SimulationContainer
 from micro_manager.tools.mpi_handler import MPIHandler, MPI
 
@@ -59,9 +60,8 @@ class TestSimulationCrashHandling(TestCase):
         )
         manager._has_sim_crashed = [False] * 4
         manager._coupling._mesh_vertex_coords = container.local_coords
-        manager._is_adaptivity_on = (
-            False  # make sure adaptivity is off overriding config
-        )
+        # make sure adaptivity is off overriding config
+        manager._adaptivity_controller = NoOpAdaptivity(container)
         for lid in container.range_lid:
             container[lid] = MicroSimulation(lid)
         manager._sim_container = container
@@ -118,17 +118,13 @@ class TestSimulationCrashHandling(TestCase):
             container[lid] = MicroSimulation(lid)
         manager._sim_container = container
 
-        manager._adaptivity_controller._similarity_dists = np.array([0, 0, 0, 0, 0])
+        manager._adaptivity_controller._similarity_dists = np.zeros(shape=(5, 5))
         manager._adaptivity_controller._is_sim_active = np.array(
             [True, True, True, True, False]
         )
-        manager._adaptivity_controller._sim_is_associated_to = np.array(
-            [-2, -2, -2, -2, 2]
-        )
+        manager._adaptivity_controller._sim_is_associated_to = {4: 2}
 
-        micro_sims_output = manager._solve_micro_simulations_with_adaptivity(
-            macro_data, 1.0
-        )
+        micro_sims_output = manager._solve_micro_simulations(macro_data, 1.0)
 
         # Crashed simulation has interpolated value
         data_crashed = micro_sims_output[2]

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -124,6 +124,9 @@ class TestSimulationCrashHandling(TestCase):
             [True, True, True, True, False]
         )
         manager._adaptivity_controller._sim_is_associated_to = {4: 2}
+        manager._adaptivity_controller._sim_active_steps = {
+            gid: 0 for gid in container.local_gids
+        }
         manager._adaptivity_controller.update_buffers(alloc=True)
 
         micro_sims_output = manager._solve_micro_simulations(macro_data, 1.0)

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import numpy as np
 
 import micro_manager
-from adaptivity.adaptivity import NoOpAdaptivity
+from micro_manager.adaptivity.adaptivity import NoOpAdaptivity
 from micro_manager.simulation_container import SimulationContainer
 from micro_manager.tools.mpi_handler import MPIHandler, MPI
 

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
-from adaptivity.adaptivity import NoOpAdaptivity
+from micro_manager.adaptivity.adaptivity import NoOpAdaptivity
 from micro_manager.simulation_container import SimulationContainer
 from micro_manager.adaptivity.model_adaptivity import ModelAdaptivity
 from micro_manager.micro_manager import MicroManagerCoupling

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
+from adaptivity.adaptivity import NoOpAdaptivity
 from micro_manager.simulation_container import SimulationContainer
 from micro_manager.adaptivity.model_adaptivity import ModelAdaptivity
 from micro_manager.micro_manager import MicroManagerCoupling
@@ -169,7 +170,7 @@ class TestModelAdaptivity(TestCase):
         manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
         manager._mpi = mpi
         manager._model_adaptivity_controller = controller
-        manager._is_adaptivity_on = False
+        manager._adaptivity_controller = NoOpAdaptivity(container)
         manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
         manager._t = 1.0
         manager._sim_container = container
@@ -223,7 +224,7 @@ class TestModelAdaptivity(TestCase):
         manager = MicroManagerCoupling.__new__(MicroManagerCoupling)
         manager._mpi = mpi
         manager._model_adaptivity_controller = controller
-        manager._is_adaptivity_on = False
+        manager._adaptivity_controller = NoOpAdaptivity(container)
         manager._mesh_vertex_coords = np.array([[0.0, 0.0, 0.0]])
         manager._t = 1.0
         manager._sim_container = container


### PR DESCRIPTION
This implementation attempts to reduce the number of branching parallel execution paths by merging the adaptivity types into a single interface format. Here, deactivated adaptivity is also covered by the same interface, which should lead to greater clarity.

__Important__: This PR is to be merged after the domain decomposition PR #289 

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
