### PR TITLE
Small Fixes: rename coupling method and add check in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Added check for number of workers and renamed method in `coupling.py` [#295](https://github.com/precice/micro-manager/pull/295)
 - Refactored interaction with preCICE and domain decomposition into `CouplingHandler`, `Profiler` and `DomainDecomposition` hierarchy [#289](https://github.com/precice/micro-manager/pull/289)
 - Refactored and generalized the methods in `p2p.py`. Added `MPIHandler` to manage all MPI related aspects. [#287](https://github.com/precice/micro-manager/pull/287)
 - Applied fixes for previously missed test cases due to #290 [#291](https://github.com/precice/micro-manager/pull/291)

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -628,6 +628,9 @@ class Config:
                 "Tasking will use {data} workers",
                 "No tasking worker count defined. Using 1 worker per rank.",
             )
+            if self.tasking_num_workers() < 1:
+                raise RuntimeError("Invalid number of workers. Must be >= 1.")
+
             self.mpi_impl.set = self.json["tasking"]["mpi_impl"].get_with_default(
                 "open",
                 "Tasking using mpi implementation: {data}",

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -257,7 +257,7 @@ class MicroManagerCoupling(MicroManager):
                     )
                     sys.exit()
 
-            self._coupling.write_to_precice(micro_sims_output)
+            self._coupling.write_data_to_precice(micro_sims_output)
             self._coupling.advance(dt)
 
             # Revert micro simulations to their last checkpoints if required

--- a/micro_manager/tools/coupling.py
+++ b/micro_manager/tools/coupling.py
@@ -250,7 +250,7 @@ class CouplingHandler:
 
         return [dict(zip(read_data, t)) for t in zip(*read_data.values())]
 
-    def write_to_precice(self, data: List[Dict[str, Any]]) -> None:
+    def write_data_to_precice(self, data: List[Dict[str, Any]]) -> None:
         """
         Write data to preCICE.
 

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -101,7 +101,7 @@ class TestFunctionCalls(TestCase):
         manager._sim_container = container
         manager._mesh_vertex_ids = container.local_coords
 
-        manager._coupling.write_to_precice(self.fake_write_data)
+        manager._coupling.write_data_to_precice(self.fake_write_data)
         read_data = manager._coupling.read_data_from_precice(1.0)
 
         for data, fake_data in zip(read_data, self.fake_read_data):


### PR DESCRIPTION
Added:
- Check in config to only allow at least 1 for `num_workers`
- Rename method in coupling: `write_to_precice` to `write_data_to_precice` (missed in #289)

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
