### PR TITLE
Unified Interpolation Interface and refactored Crash Interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Refactored interpolation to uniform interface and moved crash handling to dedicated module. [#298](https://github.com/precice/micro-manager/pull/298)
 - Added uniform interface for Adaptivity for all cases [#294](https://github.com/precice/micro-manager/pull/294)
 - Fixed simulation activation issue of calling `get_state` prior to full initialization [#308](https://github.com/precice/micro-manager/pull/308)
 - Skipped double initialization of sim with id 0 when lazy initialization is used [#307](https://github.com/precice/micro-manager/pull/307)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,11 +214,11 @@ of `write_data_names` must be mutually disjunct. Mappings can be defined as:
 ]
 ```
 
-| Parameter       | Description                                      | Default |
-|-----------------|--------------------------------------------------|---------|
-| `src_fields`    | List of entries from `read_data_names`           | `None`  |
-| `dst_fields`    | List of entries from `write_data_names`          | `None`  |
-| `interp_id`     | ID referencing the interpolationo configuration. | `None`  |
+| Parameter       | Description                                     | Default |
+|-----------------|-------------------------------------------------|---------|
+| `src_fields`    | List of entries from `read_data_names`          | `None`  |
+| `dst_fields`    | List of entries from `write_data_names`         | `None`  |
+| `interp_id`     | ID referencing the interpolation configuration. | `None`  |
 
 Example of adaptivity configuration is
 
@@ -351,6 +351,7 @@ assumes Intel MPI.
 ## Interpolate a crashed micro simulation
 
 The Micro Manager can derive the output of a crashed micro simulation by interpolating outputs from similar simulations.
+
 To enable this, set`"interpolate_crash": true` in the `simulation_params` section of the configuration file.
 Further crash handling options can be specified under the `"interpolate_crash_params"` section using `interp_id` and `threshold`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,89 @@ If the parameter `data_from_micro_sims` is set, the data to be output needs to b
 </participant>
 ```
 
+## Interpolation
+
+The subsequent modules may require interpolation to support certain features.
+Therefore, the Micro Manager offers the possibility to configure different interpolation profiles, which may be reused.
+Each profile contains information which interpolation method to use, an unique identifier and the required parameters of the selected interpolation scheme.
+The profiles are referenced in other modules using the provided identifier.
+Profiles can be specified by providing `"interpolation_configs": []` in the `simulation_params`.
+
+Within this list, interpolation configurations are provided. Each configuration must contain a `type` and an `id`.
+Further parameters are `type` dependent. Currently, two types are supported: k-Nearest-Neighbors (KNN) and Radial-Basis-Function (RBF) interpolation.
+
+### k-Nearest-Neighbors (KNN)
+
+KNN requires the optional dependency `sklearn`. If it is not installed, using KNN will raise errors.
+
+Example configuration:
+
+```json
+{
+    "type": "KNN",
+    "id": "test",
+    "k": 4
+}
+```
+
+Description:
+
+| Parameter | Description                                | Default |
+|-----------|--------------------------------------------|---------|
+| `type`    | Interpolation Method: Here KNN.            | `None`  |
+| `id`      | Unique Identifier, may be a string or int. | `None`  |
+| `k`       | Number of nearest neighbors.               | `1`     |
+
+### Radial-Basis-Function (RBF)
+
+Example configuration:
+
+```json
+{
+    "type": "RBF_PU",
+    "id": "dummy",
+    "rbf_config": {
+        "basis": {
+            "type": "gauss",
+            "eps": 0.5
+        },
+        "n_neighbors": 10
+    },
+    "domain_config": {
+        "max_filling": 8,
+        "coarsening_factor": 2,
+        "projection": {
+          "type": "std",
+          "target_dims": 2
+        }
+    }
+}
+```
+
+Description:
+
+| Parameter       | Description                                                         | Default |
+|-----------------|---------------------------------------------------------------------|---------|
+| `type`          | Interpolation Method: Here RBF_PU.                                  | `None`  |
+| `id`            | Unique Identifier, may be a string or int.                          | `None`  |
+| `rbf_config`    | RBF interpolation configuration.                                    | `None`  |
+| `domain_config` | Interpolation source domain. Either `"local"` or decomposed global. |         |
+
+A selection of basis functions is available: `c0`, `c2`, `c4`, `c6`, `gauss`.
+For rank local interpolation `domain_config` can be set to `"local"`.
+If data should be shared across ranks for interpolation, then the domain must be further configured.
+Towards this, spatial discretization techniques are used. For better performance, data can be projected to a lower dimensional space
+using the fields with the highest standard deviation.
+
+| Parameter           | Description                                                               | Default    |
+|---------------------|---------------------------------------------------------------------------|------------|
+| `basis/type`        | RBF basis function: `c0`, `c2`, `c4`, `c6`, `gauss`                       | `None`     |
+| `basis/eps`         | Parameter if basis type is `gauss`                                        | `None`     |
+| `max_filling`       | Tunes maximum filling of tree nodes used during decomposition.            | `8`        |
+| `coarsening_factor` | Adjusts the fidelity of the discretized domain. Only integer values >= 1. | `2`        |
+| `projection`        | Either `std` or `identity`.                                               | `identity` |
+| `target_dims`       | Only if `std` is used. Denotes the target dimension after projection.     | `None`     |
+
 ## Adaptivity
 
 See the [adaptivity](tooling-micro-manager-adaptivity.html) documentation for a detailed explanation about the algorithm and variants.
@@ -126,46 +209,16 @@ of `write_data_names` must be mutually disjunct. Mappings can be defined as:
     {
         "src_fields": ["input1", "input2"],
         "dst_fields": ["output1", "output2"],
-        "n_neighbors": 50,
-        "rbf_config": {
-            "basis": {
-                "type": "c6"
-            }
-        },
-        "domain_config": {
-            "max_filling": 8,
-            "coarsening_factor": 2,
-            "projection": {
-                "type": "std",
-                "target_dims": 3
-            }
-        }
+        "interp_id": "id_used_in_interpolation_config"
     },
 ]
 ```
 
-| Parameter       | Description                             | Default |
-|-----------------|-----------------------------------------|---------|
-| `src_fields`    | List of entries from `read_data_names`  | `None`  |
-| `dst_fields`    | List of entries from `write_data_names` | `None`  |
-| `n_neighbours`  | The minimum amount of support points.   | `50`    |
-| `rbf_config`    | RBF interpolation configuration.        | `None`  |
-| `domain_config` | Function source domain description.     |         |
-
-A selection of basis functions is available: `c0`, `c2`, `c4`, `c6`.
-The domain must be described/further configured as input data is shared across ranks and must be redistributed for interpolation.
-Towards this, spatial discretization techniques are used. For better performance, data can be projected to a lower dimensional space
-using the fields with the highest standard deviation.
-
-| Parameter           | Description                                                               | Default    |
-|---------------------|---------------------------------------------------------------------------|------------|
-| `use_pu`            | Enables PU-RBF. (currently not supported)                                 | `False`    |
-| `pu_overlap`        | Controlls overlap radius for PU decomposition.                            | `0.1`      |
-| `basis`             | RBF basis function: `c0`, `c2`, `c4`, `c6`                                | `None`     |
-| `max_filling`       | Tunes maximum filling of tree nodes used during decomposition.            | `8`        |
-| `coarsening_factor` | Adjusts the fidelity of the discretized domain. Only integer values >= 1. | `2`        |
-| `projection`        | Either `std` or `identity`.                                               | `identity` |
-| `target_dims`       | Only if `std` is used. Denotes the target dimension after projection.     | `None`     |
+| Parameter       | Description                                      | Default |
+|-----------------|--------------------------------------------------|---------|
+| `src_fields`    | List of entries from `read_data_names`           | `None`  |
+| `dst_fields`    | List of entries from `write_data_names`          | `None`  |
+| `interp_id`     | ID referencing the interpolationo configuration. | `None`  |
 
 Example of adaptivity configuration is
 
@@ -297,8 +350,14 @@ assumes Intel MPI.
 
 ## Interpolate a crashed micro simulation
 
-If the optional dependency `sklearn` is installed, the Micro Manager will derive the output of a crashed micro simulation by interpolating outputs from similar simulations. To enable this, set
-`"interpolate_crash": true` in the `simulation_params` section of the configuration file.
+The Micro Manager can derive the output of a crashed micro simulation by interpolating outputs from similar simulations.
+To enable this, set`"interpolate_crash": true` in the `simulation_params` section of the configuration file.
+Further crash handling options can be specified under the `"interpolate_crash_params"` section using `interp_id` and `threshold`.
+
+| Parameter   | Description                                                                    | Default |
+|-------------|--------------------------------------------------------------------------------|---------|
+| `interp_id` | ID referencing the interpolationo configuration.                               | `None`  |
+| `threshold` | Threshold of simulation crashes beyond which the Micro Manager will terminate. | `0.2`   |
 
 For more details on the interpolation see the [crash handling documentation](tooling-micro-manager-running.html#what-happens-when-a-micro-simulation-crashes).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,16 +97,16 @@ If the parameter `data_from_micro_sims` is set, the data to be output needs to b
 
 ## Interpolation
 
-The subsequent modules may require interpolation to support certain features.
-Therefore, the Micro Manager offers the possibility to configure different interpolation profiles, which may be reused.
-Each profile contains information which interpolation method to use, an unique identifier and the required parameters of the selected interpolation scheme.
+The Micro Manager allows configuring different interpolation profiles that can be reused by other modules such as adaptivity or crash interpolation.
+Each profile contains information on which interpolation method to use, a unique identifier, and the required parameters of the selected interpolation scheme.
 The profiles are referenced in other modules using the provided identifier.
 Profiles can be specified by providing `"interpolation_configs": []` in the `simulation_params`.
 
-Within this list, interpolation configurations are provided. Each configuration must contain a `type` and an `id`.
-Further parameters are `type` dependent. Currently, two types are supported: k-Nearest-Neighbors (KNN) and Radial-Basis-Function (RBF) interpolation.
+This list provides interpolation configurations. Each configuration must contain a `type` and an `id`.
+Further parameters are `type` dependent. Currently, two types are supported: k-Nearest Neighbors (KNN) and Radial Basis Function (RBF) interpolation.
+The unique `id` is required to load the respective interpolation configuration. Other modules can specify such via the field `interp_id`.
 
-### k-Nearest-Neighbors (KNN)
+### k-Nearest Neighbors (KNN)
 
 KNN requires the optional dependency `sklearn`. If it is not installed, using KNN will raise errors.
 
@@ -128,13 +128,13 @@ Description:
 | `id`      | Unique Identifier, may be a string or int. | `None`  |
 | `k`       | Number of nearest neighbors.               | `1`     |
 
-### Radial-Basis-Function (RBF)
+### Radial Basis Function (RBF)
 
 Example configuration:
 
 ```json
 {
-    "type": "RBF_PU",
+    "type": "RBF",
     "id": "dummy",
     "rbf_config": {
         "basis": {
@@ -158,15 +158,15 @@ Description:
 
 | Parameter       | Description                                                         | Default |
 |-----------------|---------------------------------------------------------------------|---------|
-| `type`          | Interpolation Method: Here RBF_PU.                                  | `None`  |
+| `type`          | Interpolation Method: Here RBF.                                     | `None`  |
 | `id`            | Unique Identifier, may be a string or int.                          | `None`  |
 | `rbf_config`    | RBF interpolation configuration.                                    | `None`  |
 | `domain_config` | Interpolation source domain. Either `"local"` or decomposed global. |         |
 
 A selection of basis functions is available: `c0`, `c2`, `c4`, `c6`, `gauss`.
-For rank local interpolation `domain_config` can be set to `"local"`.
+For rank local interpolation, `domain_config` can be set to `"local"`.
 If data should be shared across ranks for interpolation, then the domain must be further configured.
-Towards this, spatial discretization techniques are used. For better performance, data can be projected to a lower dimensional space
+To this end, spatial discretization techniques are used. For better performance, data can be projected to a lower-dimensional space
 using the fields with the highest standard deviation.
 
 | Parameter           | Description                                                               | Default    |

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -3,7 +3,7 @@ Functionality for adaptive initialization and control of micro simulations
 """
 from collections import defaultdict
 from math import exp
-from typing import Callable, Dict, Optional, List, Any, Union, Tuple
+from typing import Callable, Dict, Optional, List, Any, Union, Tuple, Hashable
 from abc import ABC
 
 from micro_manager.config import Config
@@ -11,6 +11,7 @@ from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.model_manager import ModelManager
 from micro_manager.simulation_container import SimulationContainer
 from micro_manager.adaptivity.adaptivity_interface import AdaptivityInterface
+from micro_manager.interpolation import Interpolator
 from micro_manager.tools.profiling import Profiler
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.mpi_handler import MPIHandler
@@ -105,12 +106,9 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
         self._base_logger: Logger = base_logger
         self._logger_global_metrics: Optional[Logger] = None
         self._logger_local_metrics: Optional[Logger] = None
-        self._interpolation = (
-            None  # to be init by inheriting class (TODO needs interface)
-        )
-        self._interp_min: int = -1
+        self._interp_min: Optional[int] = None
+        self._interp_ids: List[Hashable] = []
         self._mappings: List[Tuple[List[str], List[str]]] = []
-        self._mapping_configs: List[Dict[str, Any]] = []
 
         self._refine_const: float = config.adaptivity_refining_constant()
         self._coarse_const: float = config.adaptivity_coarsening_constant()
@@ -326,48 +324,17 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
         for mapping in mappings:
             src_fields = mapping["src_fields"]
             dst_fields = mapping["dst_fields"]
-            n_neighbors = mapping["n_neighbors"]
-            if self._interp_min == -1:
-                self._interp_min = n_neighbors
-            else:
-                self._interp_min = min(n_neighbors, self._interp_min)
-
             self._mappings.append((src_fields, dst_fields))
-            config = {}
-            if "use_pu" in mapping["rbf_config"]:
-                config["use_pu"] = mapping["rbf_config"]["use_pu"]
-            if "pu_overlap" in mapping["rbf_config"]:
-                config["pu_overlap"] = mapping["rbf_config"]["pu_overlap"]
-            config["pu_cluster_size"] = n_neighbors
-            if "basis" in mapping["rbf_config"]:
-                if "type" in mapping["rbf_config"]["basis"]:
-                    config["basis"] = mapping["rbf_config"]["basis"]["type"]
-                if (
-                    config["basis"] == "gauss"
-                    and "eps" in mapping["rbf_config"]["basis"]
-                ):
-                    config["gauss_eps"] = mapping["rbf_config"]["basis"]["eps"]
 
-            dom_config = {}
-            dom_config["n_neighbors"] = n_neighbors
-            if "max_filling" in mapping["domain_config"]:
-                dom_config["max_filling"] = mapping["domain_config"]["max_filling"]
-            if "coarsening_factor" in mapping["domain_config"]:
-                dom_config["coarsening_factor"] = mapping["domain_config"][
-                    "coarsening_factor"
-                ]
-            if "projection" in mapping["domain_config"]:
-                if "type" in mapping["domain_config"]["projection"]:
-                    dom_config["projection_type"] = mapping["domain_config"][
-                        "projection"
-                    ]["type"]
-                if "target_dims" in mapping["domain_config"]["projection"]:
-                    dom_config["projection_std_dims"] = mapping["domain_config"][
-                        "projection"
-                    ]["target_dims"]
+            interp_id = mapping["interp_id"]
+            self._interp_ids.append(interp_id)
+            if not Interpolator.is_id_valid(interp_id):
+                raise ValueError(f"Unknown Interpolation config ID: {interp_id}")
+            interp = Interpolator.get_instance(interp_id)
+            interp_min = interp.get_min_support_size()
 
-            config["domain_config"] = dom_config
-            self._mapping_configs.append(config)
+            self._interp_min = self._interp_min or interp_min
+            self._interp_min = min(interp_min, self._interp_min)
 
     def _update_similarity_dists(self, dt: float, data: dict) -> None:
         """
@@ -532,11 +499,9 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
                     offset += arg_sizes[src_arg]
 
             # use interpolant
-            self._interpolation.configure(self._mappings[m_idx])
-            self._interpolation.set_local_data(
-                input_data, input_data_inactive, output_data
-            )
-            output_data_inactive = self._interpolation.interpolate()
+            interp = Interpolator.get_instance(self._interp_ids[m_idx])
+            interp.set_local_data(input_data, input_data_inactive, output_data)
+            output_data_inactive = interp.interpolate()
 
             for idx, lid in enumerate(inactive_lids):
                 offset = 0

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -211,7 +211,6 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
 
             # update counters
             active_gids = self.get_active_gids()
-
             for gid in active_gids:
                 self._sim_active_steps[gid] += 1
             # Write a checkpoint if a simulation is just activated.

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -502,6 +502,8 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
             interp = Interpolator.get_instance(self._interp_ids[m_idx])
             interp.set_local_data(input_data, input_data_inactive, output_data)
             output_data_inactive = interp.interpolate()
+            if output_data_inactive is None:
+                continue
 
             for idx, lid in enumerate(inactive_lids):
                 offset = 0
@@ -511,7 +513,9 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
                     ]
                     # unwrap array of size 1
                     if arg_sizes[dst_arg] == 1:
-                        micro_sims_output[lid][dst_arg] = micro_sims_output[lid][dst_arg][0]
+                        micro_sims_output[lid][dst_arg] = micro_sims_output[lid][
+                            dst_arg
+                        ][0]
                     offset += arg_sizes[dst_arg]
 
     @staticmethod

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -509,6 +509,9 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
                     micro_sims_output[lid][dst_arg] = output_data_inactive[
                         idx, offset : offset + arg_sizes[dst_arg]
                     ]
+                    # unwrap array of size 1
+                    if arg_sizes[dst_arg] == 1:
+                        micro_sims_output[lid][dst_arg] = micro_sims_output[lid][dst_arg][0]
                     offset += arg_sizes[dst_arg]
 
     @staticmethod

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -230,7 +230,7 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                 return micro_sims_output
 
             self._communicate_micro_output(micro_sims_output)
-            if num_active <= self._interp_min:
+            if self._interp_min is not None and num_active <= self._interp_min:
                 return micro_sims_output
 
             self._interpolate_output(micro_input, micro_sims_output)

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -17,7 +17,6 @@ from micro_manager.tools.mpi_handler import MPIHandler, MPI
 from micro_manager.tools.profiling import Profiler
 from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.model_manager import ModelManager
-from micro_manager.interpolation import RBF_PU
 from micro_manager.simulation_container import SimulationContainer
 
 
@@ -62,8 +61,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
             base_logger,
             mpi,
         )
-
-        self._interpolation = RBF_PU(base_logger, mpi)
 
         buffer_size = self._sim_container.global_num_sims**2
         array_buffer, mpi_node = self._mpi.create_node_buffer(MPI.FLOAT, buffer_size)

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -12,10 +12,10 @@ from .adaptivity import AdaptivityCalculator
 from micro_manager.config import Config
 from micro_manager.micro_simulation import MicroSimulationClass
 from micro_manager.tools.logging_wrapper import Logger
-from micro_manager.tools.mpi_handler import MPIHandler, MPI, MPIHandlerRankLocal
+from micro_manager.tools.mpi_handler import MPIHandler, MPI
 from micro_manager.tools.profiling import Profiler
 from micro_manager.model_manager import ModelManager
-from micro_manager.interpolation import RBF_PU, Interpolator
+from micro_manager.interpolation import Interpolator
 from micro_manager.simulation_container import SimulationContainer
 
 
@@ -59,11 +59,6 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             model_manager,
             base_logger,
             mpi,
-        )
-        # using local handler to only perform local interpolation
-        self._interpolation = RBF_PU(
-            base_logger,
-            MPIHandlerRankLocal,
         )
 
         # similarity_dists: 2D array having similarity distances between each micro simulation pair

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -15,7 +15,7 @@ from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.mpi_handler import MPIHandler, MPI, MPIHandlerRankLocal
 from micro_manager.tools.profiling import Profiler
 from micro_manager.model_manager import ModelManager
-from micro_manager.interpolation import RBF_PU
+from micro_manager.interpolation import RBF_PU, Interpolator
 from micro_manager.simulation_container import SimulationContainer
 
 
@@ -72,6 +72,14 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             (sim_container.local_num_sims, sim_container.local_num_sims)
         )
         self._max_similarity_dist_local: float = 0.0
+
+        # make sure that the loaded interpolation schemes are local
+        for interp_id in self._interp_ids:
+            interp = Interpolator.get_instance(interp_id)
+            if not interp.is_local():
+                raise RuntimeError(
+                    f"Interpolation Config {interp_id} must be local for Local Adaptivity."
+                )
 
     def compute(self, dt: float) -> None:
         """
@@ -184,6 +192,8 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
         micro_sims_output = deepcopy(micro_output)
 
         inactive_lids = self.get_inactive_lids()
+        if len(inactive_lids) == 0:
+            return micro_sims_output
 
         for inactive_lid in inactive_lids:
             micro_sims_output[inactive_lid] = deepcopy(

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -8,7 +8,7 @@ import os
 import importlib.metadata
 import string
 from collections import defaultdict
-from typing import Optional, Type, List, Dict, Any, Callable
+from typing import Optional, Type, List, Dict, Any, Callable, Hashable
 import inspect
 from .tools.logging_wrapper import Logger
 
@@ -916,8 +916,15 @@ class Config:
             ]["model_adaptivity_settings"]["switching_function"].get_or_raise()
 
         # ======================================================
-        #          Crash Interpolation and Diagnostics
+        #              Interpolation and Diagnostics
         # ======================================================
+        self.interpolation_configs.set = self.json["simulation_params"][
+            "interpolation_configs"
+        ].get_with_default(
+            [],
+            None,
+            "Failed to load interpolation configs.",
+        )
 
         self.enable_crashed_sim_interpolation.set = self.json["simulation_params"][
             "interpolate_crash"
@@ -925,6 +932,28 @@ class Config:
         if self.enable_crashed_sim_interpolation():
             self._logger.log_info_rank_zero(
                 "Micro Manager will interpolate output of crashed micro simulations from its neighbors."
+            )
+        if (
+            self.enable_crashed_sim_interpolation()
+            and not self.json["simulation_params"]["interpolate_crash_params"].exists()
+        ):
+            self.enable_crashed_sim_interpolation.set = False
+            self._logger.log_info_rank_zero(
+                "Crash Interpolation is turned on but no settings are provided."
+            )
+        with self.show_log_if(self.enable_crashed_sim_interpolation()):
+            self.crashed_sim_interpolation_id.set = self.json["simulation_params"][
+                "interpolate_crash_params"
+            ]["interp_id"].get_with_default(
+                None,
+                "Crash Interpolation interpolates with config {data}.",
+                "No interpolation config provided for Crash Interpolation.",
+            )
+            self.crashed_sim_interpolation_threshold.set = self.json[
+                "simulation_params"
+            ]["interpolate_crash_params"]["threshold"].get_with_default(
+                0.2,
+                "Crash Interpolation threshold: {data}.",
             )
 
         # TODO what? this is not being saved nor used
@@ -1422,6 +1451,17 @@ class Config:
         pass
 
     @config_entry
+    def interpolation_configs(self) -> List[Dict[str, Any]]:
+        """
+        Gets the provided interpolation configurations.
+
+        Returns
+        interp_configs : List[Dict[str, Any]]
+            Interpolation configurations.
+        """
+        pass
+
+    @config_entry
     def enable_crashed_sim_interpolation(self) -> bool:
         """
         Check if user wants crashed micro simulations to be interpolated.
@@ -1430,6 +1470,30 @@ class Config:
         -------
         interpolate_crash : bool
             True if crashed micro simulations need to be interpolated, False otherwise.
+        """
+        pass
+
+    @config_entry
+    def crashed_sim_interpolation_id(self) -> Hashable:
+        """
+        Gets the associated interpolation config id used for crash interpolation.
+
+        Returns
+        -------
+        interp_id : Hashable
+            Interpolation config id.
+        """
+        pass
+
+    @config_entry
+    def crashed_sim_interpolation_threshold(self) -> float:
+        """
+        Gets the crash interpolation threshold.
+
+        Returns
+        -------
+        threshold : float
+            Threshold beyond which crashes are not recovered.
         """
         pass
 

--- a/micro_manager/crash_handler.py
+++ b/micro_manager/crash_handler.py
@@ -10,17 +10,20 @@ from micro_manager.config import Config
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.mpi_handler import MPIHandler, MPI
 
+
 class CrashHandler:
-    def __init__(self, logger: Logger, mpi: MPIHandler, sim_container: SimulationContainer):
-        self._logger : Logger = logger
-        self._mpi : MPIHandler = mpi
-        self._sim_container : SimulationContainer = sim_container
-        self._interp_id : Hashable = 0
+    def __init__(
+        self, logger: Logger, mpi: MPIHandler, sim_container: SimulationContainer
+    ):
+        self._logger: Logger = logger
+        self._mpi: MPIHandler = mpi
+        self._sim_container: SimulationContainer = sim_container
+        self._interp_id: Hashable = 0
 
-        self._enable_interp : bool = False
-        self._crashed_sims : Set[int] = set()
+        self._enable_interp: bool = False
+        self._crashed_sims: Set[int] = set()
 
-        self._crash_threshold : float = 0.2
+        self._crash_threshold: float = 0.2
 
     def initialize(self, config: Config) -> None:
         self._interp_id = config.crashed_sim_interpolation_id()
@@ -32,13 +35,13 @@ class CrashHandler:
                 raise ValueError("Invalid interpolation id in CrashHandler.")
 
     def solve_micro_safe(
-            self,
-            lid: int,
-            sim: MicroSimulationInterface,
-            micro_input: Dict[str, Any],
-            dt: float,
+        self,
+        lid: int,
+        sim: MicroSimulationInterface,
+        micro_input: Dict[str, Any],
+        dt: float,
     ) -> Optional[Dict[str, Any]]:
-        result : Optional[Dict[str, Any]] = None
+        result: Optional[Dict[str, Any]] = None
 
         try:
             result = sim.solve(micro_input, dt)
@@ -61,7 +64,7 @@ class CrashHandler:
 
     def _conv_to_ndarray(self, data_list: List[Optional[Dict[str, Any]]]) -> np.ndarray:
         # collect output dimensions, assuming each dict follows the same structure
-        entry : Dict[str, Any] = next(d for d in data_list if d is not None)
+        entry: Dict[str, Any] = next(d for d in data_list if d is not None)
         entry_size = sum([self._load_size(val) for val in entry.values()])
         entry_count = len(data_list)
 
@@ -74,15 +77,15 @@ class CrashHandler:
             offset = 0
             for val in entry.values():
                 size = self._load_size(val)
-                buffer[d_idx, offset:offset + size] = val
+                buffer[d_idx, offset : offset + size] = val
                 offset += size
         return buffer
 
     def interpolate_outputs(
-            self,
-            unset_output_lids: List[int],
-            sim_inputs: List[Dict[str, Any]],
-            sim_outputs: List[Optional[Dict[str, Any]]],
+        self,
+        unset_output_lids: List[int],
+        sim_inputs: List[Dict[str, Any]],
+        sim_outputs: List[Optional[Dict[str, Any]]],
     ) -> None:
         if not self._enable_interp:
             if self.get_glob_num_crashes() > 0:
@@ -103,7 +106,9 @@ class CrashHandler:
 
         np_inputs = self._conv_to_ndarray(sim_inputs)
         np_outputs = self._conv_to_ndarray(sim_outputs)
-        set_output_lids = list(set(self._sim_container.range_lid).difference(unset_output_lids))
+        set_output_lids = list(
+            set(self._sim_container.range_lid).difference(unset_output_lids)
+        )
         interp.set_local_data(
             np_inputs[set_output_lids, :],
             np_inputs[unset_output_lids, :],
@@ -116,7 +121,7 @@ class CrashHandler:
             offset = 0
             for key, val in result.items():
                 size = self._load_size(val)
-                extracted_val = interp_outputs[lid, offset:offset + size]
+                extracted_val = interp_outputs[lid, offset : offset + size]
                 if size == 1:
                     extracted_val = type(val)(extracted_val[0])
                 result[key] = extracted_val
@@ -135,9 +140,7 @@ class CrashHandler:
 
     def get_glob_num_crashes(self) -> int:
         crashed_sims_on_all_ranks = np.zeros(self._mpi.size, dtype=np.int64)
-        self._mpi.comm.Allgather(
-            len(self._crashed_sims), crashed_sims_on_all_ranks
-        )
+        self._mpi.comm.Allgather(len(self._crashed_sims), crashed_sims_on_all_ranks)
         return np.sum(crashed_sims_on_all_ranks)
 
     def check_crash_ratio(self):

--- a/micro_manager/crash_handler.py
+++ b/micro_manager/crash_handler.py
@@ -1,0 +1,153 @@
+from copy import deepcopy
+from typing import Hashable, Set, Dict, Any, Optional, List
+import sys
+import numpy as np
+
+from micro_manager.simulation_container import SimulationContainer
+from micro_manager.micro_simulation import MicroSimulationInterface
+from micro_manager.interpolation import Interpolator
+from micro_manager.config import Config
+from micro_manager.tools.logging_wrapper import Logger
+from micro_manager.tools.mpi_handler import MPIHandler, MPI
+
+class CrashHandler:
+    def __init__(self, logger: Logger, mpi: MPIHandler, sim_container: SimulationContainer):
+        self._logger : Logger = logger
+        self._mpi : MPIHandler = mpi
+        self._sim_container : SimulationContainer = sim_container
+        self._interp_id : Hashable = 0
+
+        self._enable_interp : bool = False
+        self._crashed_sims : Set[int] = set()
+
+        self._crash_threshold : float = 0.2
+
+    def initialize(self, config: Config) -> None:
+        self._interp_id = config.crashed_sim_interpolation_id()
+        self._crash_threshold = config.crashed_sim_interpolation_threshold()
+        self._enable_interp = config.enable_crashed_sim_interpolation()
+
+        if self._enable_interp:
+            if not Interpolator.is_id_valid(self._interp_id):
+                raise ValueError("Invalid interpolation id in CrashHandler.")
+
+    def solve_micro_safe(
+            self,
+            lid: int,
+            sim: MicroSimulationInterface,
+            micro_input: Dict[str, Any],
+            dt: float,
+    ) -> Optional[Dict[str, Any]]:
+        result : Optional[Dict[str, Any]] = None
+
+        try:
+            result = sim.solve(micro_input, dt)
+        except Exception as e:
+            self._logger.log_error(
+                "Micro simulation at macro coordinates {} has experienced an error. "
+                "See next entry on this rank for error message.".format(
+                    self._sim_container.local_coords[lid]
+                )
+            )
+            self._logger.log_error(e)
+            self.register_sim_crash(self._sim_container.local_gids[lid])
+
+        return result
+
+    def _load_size(self, val):
+        if isinstance(val, np.ndarray) or isinstance(val, list):
+            return len(val)
+        return 1
+
+    def _conv_to_ndarray(self, data_list: List[Optional[Dict[str, Any]]]) -> np.ndarray:
+        # collect output dimensions, assuming each dict follows the same structure
+        entry : Dict[str, Any] = next(d for d in data_list if d is not None)
+        entry_size = sum([self._load_size(val) for val in entry.values()])
+        entry_count = len(data_list)
+
+        # alloc buffer and populate
+        buffer = np.zeros(shape=(entry_count, entry_size), dtype=np.float64)
+        for d_idx in range(entry_count):
+            if data_list[d_idx] is None:
+                continue
+            entry = data_list[d_idx]
+            offset = 0
+            for val in entry.values():
+                size = self._load_size(val)
+                buffer[d_idx, offset:offset + size] = val
+                offset += size
+        return buffer
+
+    def interpolate_outputs(
+            self,
+            unset_output_lids: List[int],
+            sim_inputs: List[Dict[str, Any]],
+            sim_outputs: List[Optional[Dict[str, Any]]],
+    ) -> None:
+        if not self._enable_interp:
+            if self.get_glob_num_crashes() > 0:
+                self._logger.log_error(
+                    "Exiting simulation after micro simulation crash."
+                )
+                sys.exit()
+            return
+
+        interp = Interpolator.get_instance(self._interp_id)
+        avail_count = self._sim_container.local_num_sims - len(unset_output_lids)
+        req_count = interp.get_min_support_size()
+        if avail_count <= req_count:
+            self._logger.log_error(
+                "Exiting simulation after micro simulation crash. Not enough data for interpolation."
+            )
+            sys.exit()
+
+        np_inputs = self._conv_to_ndarray(sim_inputs)
+        np_outputs = self._conv_to_ndarray(sim_outputs)
+        set_output_lids = list(set(self._sim_container.range_lid).difference(unset_output_lids))
+        interp.set_local_data(
+            np_inputs[set_output_lids, :],
+            np_inputs[unset_output_lids, :],
+            np_outputs[set_output_lids, :],
+        )
+        interp_outputs = interp.interpolate()
+
+        for lid in unset_output_lids:
+            result = deepcopy(sim_outputs[set_output_lids[0]])
+            offset = 0
+            for key, val in result.items():
+                size = self._load_size(val)
+                extracted_val = interp_outputs[lid, offset:offset + size]
+                if size == 1:
+                    extracted_val = type(val)(extracted_val[0])
+                result[key] = extracted_val
+                offset += size
+
+            sim_outputs[lid] = result
+
+    def has_sim_crashed(self, gid: int) -> bool:
+        return gid in self._crashed_sims
+
+    def register_sim_crash(self, gid: int) -> None:
+        self._crashed_sims.add(gid)
+
+    def reset(self):
+        self._crashed_sims.clear()
+
+    def get_glob_num_crashes(self) -> int:
+        crashed_sims_on_all_ranks = np.zeros(self._mpi.size, dtype=np.int64)
+        self._mpi.comm.Allgather(
+            len(self._crashed_sims), crashed_sims_on_all_ranks
+        )
+        return np.sum(crashed_sims_on_all_ranks)
+
+    def check_crash_ratio(self):
+        if not self._enable_interp:
+            return
+
+        crash_ratio = self.get_glob_num_crashes() / self._sim_container.global_num_sims
+        if crash_ratio > self._crash_threshold:
+            self._logger.log_info(
+                "{:.1%} of the micro simulations have crashed exceeding the threshold of {:.1%}. "
+                "Exiting simulation.".format(crash_ratio, self._crash_threshold)
+            )
+            sys.exit()

--- a/micro_manager/crash_handler.py
+++ b/micro_manager/crash_handler.py
@@ -209,7 +209,9 @@ class CrashHandler:
             Global number of simulation crashes.
         """
         crashed_sims_on_all_ranks = np.zeros(self._mpi.size, dtype=np.int64)
-        self._mpi.comm.Allgather(len(self._crashed_sims), crashed_sims_on_all_ranks)
+        self._mpi.comm.Allgather(
+            np.int64(len(self._crashed_sims)), crashed_sims_on_all_ranks
+        )
         return np.sum(crashed_sims_on_all_ranks)
 
     def check_crash_ratio(self) -> None:

--- a/micro_manager/crash_handler.py
+++ b/micro_manager/crash_handler.py
@@ -124,9 +124,10 @@ class CrashHandler:
             List of simulation outputs. (of all local simulations)
         """
         if not self._enable_interp:
-            if self.get_glob_num_crashes() > 0:
+            glob_crashes: int = self.get_glob_num_crashes()
+            if glob_crashes > 0:
                 self._logger.log_error(
-                    "Exiting simulation after micro simulation crash."
+                    f"Exiting simulation because {glob_crashes} simulations have crashed."
                 )
                 sys.exit()
             return

--- a/micro_manager/crash_handler.py
+++ b/micro_manager/crash_handler.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Hashable, Set, Dict, Any, Optional, List
+from typing import Hashable, Set, Dict, Any, Optional, List, Union
 import sys
 import numpy as np
 
@@ -8,13 +8,30 @@ from micro_manager.micro_simulation import MicroSimulationInterface
 from micro_manager.interpolation import Interpolator
 from micro_manager.config import Config
 from micro_manager.tools.logging_wrapper import Logger
-from micro_manager.tools.mpi_handler import MPIHandler, MPI
+from micro_manager.tools.mpi_handler import MPIHandler
 
 
 class CrashHandler:
+    """
+    CrashHandler manages and tracks simulation crashes.
+    If enabled, it can interpolate results of crashed simulations.
+    """
+
     def __init__(
         self, logger: Logger, mpi: MPIHandler, sim_container: SimulationContainer
     ):
+        """
+        Constructs an empty crash handler.
+
+        Parameters
+        ----------
+        logger : Logger
+            Logger object.
+        mpi : MPIHandler
+            MPIHandler object.
+        sim_container : SimulationContainer
+            Simulation container object.
+        """
         self._logger: Logger = logger
         self._mpi: MPIHandler = mpi
         self._sim_container: SimulationContainer = sim_container
@@ -26,6 +43,14 @@ class CrashHandler:
         self._crash_threshold: float = 0.2
 
     def initialize(self, config: Config) -> None:
+        """
+        Initializes crash interpolation.
+
+        Parameters
+        ----------
+        config : Config
+            Configuration object.
+        """
         self._interp_id = config.crashed_sim_interpolation_id()
         self._crash_threshold = config.crashed_sim_interpolation_threshold()
         self._enable_interp = config.enable_crashed_sim_interpolation()
@@ -41,6 +66,25 @@ class CrashHandler:
         micro_input: Dict[str, Any],
         dt: float,
     ) -> Optional[Dict[str, Any]]:
+        """
+        Provides a safe environment and attempts to solve the provided micro simulation.
+
+        Parameters
+        ----------
+        lid : int
+            LID of the micro simulation.
+        sim : MicroSimulationInterface
+            Micro Simulation object to be solved.
+        micro_input : Dict[str, Any]
+            Input to solve method.
+        dt : float
+            Current delta time.
+
+        Returns
+        -------
+        solve_result : Optional[Dict[str, Any]]
+            Micro Simulation solve call result. None on failure.
+        """
         result: Optional[Dict[str, Any]] = None
 
         try:
@@ -57,36 +101,28 @@ class CrashHandler:
 
         return result
 
-    def _load_size(self, val):
-        if isinstance(val, np.ndarray) or isinstance(val, list):
-            return len(val)
-        return 1
-
-    def _conv_to_ndarray(self, data_list: List[Optional[Dict[str, Any]]]) -> np.ndarray:
-        # collect output dimensions, assuming each dict follows the same structure
-        entry: Dict[str, Any] = next(d for d in data_list if d is not None)
-        entry_size = sum([self._load_size(val) for val in entry.values()])
-        entry_count = len(data_list)
-
-        # alloc buffer and populate
-        buffer = np.zeros(shape=(entry_count, entry_size), dtype=np.float64)
-        for d_idx in range(entry_count):
-            if data_list[d_idx] is None:
-                continue
-            entry = data_list[d_idx]
-            offset = 0
-            for val in entry.values():
-                size = self._load_size(val)
-                buffer[d_idx, offset : offset + size] = val
-                offset += size
-        return buffer
-
     def interpolate_outputs(
         self,
-        unset_output_lids: List[int],
+        selected_lids: List[int],
+        query_lids: Set[int],
         sim_inputs: List[Dict[str, Any]],
         sim_outputs: List[Optional[Dict[str, Any]]],
     ) -> None:
+        """
+        If interpolation is enabled, interpolates outputs for crashed simulations.
+        Otherwise, only checks if crashed have occurred.
+
+        Parameters
+        ----------
+        selected_lids : List[int]
+            LIDs that may be considered as interpolation support points.
+        query_lids : List[int]
+            LIDs for which outputs should be interpolated.
+        sim_inputs : List[Dict[str, Any]]
+            List of simulation inputs. (of all local simulations)
+        sim_outputs : List[Optional[Dict[str, Any]]]
+            List of simulation outputs. (of all local simulations)
+        """
         if not self._enable_interp:
             if self.get_glob_num_crashes() > 0:
                 self._logger.log_error(
@@ -96,9 +132,12 @@ class CrashHandler:
             return
 
         interp = Interpolator.get_instance(self._interp_id)
-        avail_count = self._sim_container.local_num_sims - len(unset_output_lids)
-        req_count = interp.get_min_support_size()
-        if avail_count <= req_count:
+        support_lids: List[int] = [
+            lid
+            for lid in selected_lids
+            if lid not in query_lids and sim_outputs[lid] is not None
+        ]
+        if len(support_lids) <= interp.get_min_support_size():
             self._logger.log_error(
                 "Exiting simulation after micro simulation crash. Not enough data for interpolation."
             )
@@ -106,18 +145,15 @@ class CrashHandler:
 
         np_inputs = self._conv_to_ndarray(sim_inputs)
         np_outputs = self._conv_to_ndarray(sim_outputs)
-        set_output_lids = list(
-            set(self._sim_container.range_lid).difference(unset_output_lids)
-        )
         interp.set_local_data(
-            np_inputs[set_output_lids, :],
-            np_inputs[unset_output_lids, :],
-            np_outputs[set_output_lids, :],
+            np_inputs[support_lids, :],
+            np_inputs[list(query_lids), :],
+            np_outputs[support_lids, :],
         )
         interp_outputs = interp.interpolate()
 
-        for lid in unset_output_lids:
-            result = deepcopy(sim_outputs[set_output_lids[0]])
+        for lid in query_lids:
+            result = deepcopy(sim_outputs[support_lids[0]])
             offset = 0
             for key, val in result.items():
                 size = self._load_size(val)
@@ -130,20 +166,57 @@ class CrashHandler:
             sim_outputs[lid] = result
 
     def has_sim_crashed(self, gid: int) -> bool:
+        """
+        Checks if the simulation given by its GID has crashed.
+
+        Parameters
+        ----------
+        gid : int
+            GID of simulation.
+
+        Returns
+        -------
+        has_sim_crashed : bool
+            True if simulation has crashed, False otherwise.
+        """
         return gid in self._crashed_sims
 
     def register_sim_crash(self, gid: int) -> None:
+        """
+        Marks the simulation given by its GID as crashed.
+
+        Parameters
+        ----------
+        gid : int
+            GID of simulation.
+        """
         self._crashed_sims.add(gid)
 
-    def reset(self):
+    def reset(self) -> None:
+        """
+        Resets the crash information.
+        Sets all simulations as not crashed.
+        """
         self._crashed_sims.clear()
 
     def get_glob_num_crashes(self) -> int:
+        """
+        Gets the global amount of crashed simulations.
+
+        Returns
+        -------
+        global_num_crashes : int
+            Global number of simulation crashes.
+        """
         crashed_sims_on_all_ranks = np.zeros(self._mpi.size, dtype=np.int64)
         self._mpi.comm.Allgather(len(self._crashed_sims), crashed_sims_on_all_ranks)
         return np.sum(crashed_sims_on_all_ranks)
 
-    def check_crash_ratio(self):
+    def check_crash_ratio(self) -> None:
+        """
+        Checks if the ratio of crashed simulations is within the valid range.
+        If not, then the Micro Manager is terminated.
+        """
         if not self._enable_interp:
             return
 
@@ -154,3 +227,58 @@ class CrashHandler:
                 "Exiting simulation.".format(crash_ratio, self._crash_threshold)
             )
             sys.exit()
+
+    @staticmethod
+    def _load_size(val: Union[np.ndarray, List, float, int]) -> int:
+        """
+        Returns the vector size of the provided value.
+        Scalars are interpreted as a vector of size 1.
+
+        Parameters
+        ----------
+        val : Union[np.ndarray, List, float, int]
+            Value to be checked.
+
+        Returns
+        -------
+        size : int
+            vector size of the provided value.
+        """
+        if isinstance(val, np.ndarray) or isinstance(val, list):
+            return len(val)
+        return 1
+
+    @staticmethod
+    def _conv_to_ndarray(data_list: List[Optional[Dict[str, Any]]]) -> np.ndarray:
+        """
+        Converts the list of length N containing data dicts into a np.ndarray of shape NxM
+        by merging all entries of the respective dicts into a vector of length M.
+        Missing dicts, i.e. None values, are converted to a zero vector.
+
+        Parameters
+        ----------
+        data_list : List[Optional[Dict[str, Any]]]
+            Data to be converted
+
+        Returns
+        -------
+        np_data : np.ndarray
+            Data as np.ndarray.
+        """
+        # collect output dimensions, assuming each dict follows the same structure
+        entry: Dict[str, Any] = next(d for d in data_list if d is not None)
+        entry_size = sum([CrashHandler._load_size(val) for val in entry.values()])
+        entry_count = len(data_list)
+
+        # alloc buffer and populate
+        buffer = np.zeros(shape=(entry_count, entry_size), dtype=np.float64)
+        for d_idx in range(entry_count):
+            if data_list[d_idx] is None:
+                continue
+            entry = data_list[d_idx]
+            offset = 0
+            for val in entry.values():
+                size = CrashHandler._load_size(val)
+                buffer[d_idx, offset : offset + size] = val
+                offset += size
+        return buffer

--- a/micro_manager/crash_handler.py
+++ b/micro_manager/crash_handler.py
@@ -152,13 +152,15 @@ class CrashHandler:
         )
         interp_outputs = interp.interpolate()
 
-        for lid in query_lids:
+        for interp_idx, lid in enumerate(query_lids):
             result = deepcopy(sim_outputs[support_lids[0]])
             offset = 0
             for key, val in result.items():
                 size = self._load_size(val)
-                extracted_val = interp_outputs[lid, offset : offset + size]
-                if size == 1:
+                extracted_val = interp_outputs[interp_idx, offset : offset + size]
+                if size == 1 and not (
+                    isinstance(val, np.ndarray) or isinstance(val, list)
+                ):
                     extracted_val = type(val)(extracted_val[0])
                 result[key] = extracted_val
                 offset += size

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -78,14 +78,15 @@ class Interpolator(ABC):
         """
         pass
 
-    def interpolate(self) -> np.ndarray:
+    def interpolate(self) -> Optional[np.ndarray]:
         """
         Interpolates the function values at the set query points.
+        Returns None on interpolation failure.
 
         Returns
         -------
-        interp_result : np.ndarray
-            Interpolated function values.
+        interp_result : Optional[np.ndarray]
+            Interpolated function values. None, if unsuccessful.
         """
         pass
 
@@ -274,10 +275,13 @@ class KNN(Interpolator):
         self._x_query = x_
         self._f = f
 
-    def interpolate(self) -> np.ndarray:
+    def interpolate(self) -> Optional[np.ndarray]:
         assert self._x is not None
         assert self._x_query is not None
         assert self._f is not None
+
+        if self._x.shape[0] == 0:
+            return None
 
         f_query = np.zeros(shape=(self._x_query.shape[0], self._f.shape[-1]))
         for idx_query in range(self._x_query.shape[0]):
@@ -484,13 +488,13 @@ class RBF(Interpolator):
         """
         self._domain.set_local_data(x, x_, f)
 
-    def interpolate(self) -> np.ndarray:
+    def interpolate(self) -> Optional[np.ndarray]:
         """
         Interpolates the function values at the set query points.
 
         Returns
         -------
-        interp_result : np.ndarray
+        interp_result : Optional[np.ndarray]
             Interpolated function values.
         """
         self._x, self._x_query, self._f = self._domain.decompose()
@@ -499,7 +503,8 @@ class RBF(Interpolator):
         xq, fq = self.evaluate_interpolant(interp, self._x_query)
 
         fq_local = self._domain.reassemble(xq, fq)
-
+        if fq_local.shape[0] == 0:
+            return None
         return fq_local
 
     @classmethod

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -285,7 +285,6 @@ class KNN(Interpolator):
             nearest_neighbors = self._get_nearest_neighbor_indices(
                 self._x,
                 inter_point,
-                self._k,
             )
             f_query[idx_query, :] = self._interpolate_impl(
                 self._x[nearest_neighbors, :],

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -504,21 +504,22 @@ class RBF_PU(Interpolator):
         dom_config["n_neighbors"] = config["rbf_config"]["n_neighbors"]
         if "local" == config["domain_config"]:
             conf["mpi"] = MPIHandlerRankLocal
-        if "max_filling" in config["domain_config"]:
-            dom_config["max_filling"] = config["domain_config"]["max_filling"]
-        if "coarsening_factor" in config["domain_config"]:
-            dom_config["coarsening_factor"] = config["domain_config"][
-                "coarsening_factor"
-            ]
-        if "projection" in config["domain_config"]:
-            if "type" in config["domain_config"]["projection"]:
-                dom_config["projection_type"] = config["domain_config"]["projection"][
-                    "type"
+        else:
+            if "max_filling" in config["domain_config"]:
+                dom_config["max_filling"] = config["domain_config"]["max_filling"]
+            if "coarsening_factor" in config["domain_config"]:
+                dom_config["coarsening_factor"] = config["domain_config"][
+                    "coarsening_factor"
                 ]
-            if "target_dims" in config["domain_config"]["projection"]:
-                dom_config["projection_std_dims"] = config["domain_config"][
-                    "projection"
-                ]["target_dims"]
+            if "projection" in config["domain_config"]:
+                if "type" in config["domain_config"]["projection"]:
+                    dom_config["projection_type"] = config["domain_config"][
+                        "projection"
+                    ]["type"]
+                if "target_dims" in config["domain_config"]["projection"]:
+                    dom_config["projection_std_dims"] = config["domain_config"][
+                        "projection"
+                    ]["target_dims"]
 
         conf["domain_config"] = dom_config
         return conf

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -91,19 +91,55 @@ class Interpolator(ABC):
 
     @abstractmethod
     def get_min_support_size(self) -> int:
+        """
+        Gets the minimum number of support points for interpolation to be possible.
+
+        Returns
+        -------
+        min_support_size : int
+            Minimum number of support points.
+        """
         pass
 
     @abstractmethod
     def is_local(self) -> bool:
+        """
+        Checks if the interpolation scheme is local or global.
+
+        Returns
+        -------
+        Returns True if interpolation operates locally, else False.
+        """
         pass
 
     @classmethod
     @abstractmethod
     def load_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Loads and optionally transforms the configuration dict as provided in the input file.
+
+        Returns
+        -------
+        config_dict : Dict[str, Any]
+            Configuration dict for this interpolation class.
+        """
         pass
 
     @staticmethod
-    def initialize(config: Config, logger: Logger, mpi: MPIHandler):
+    def initialize(config: Config, logger: Logger, mpi: MPIHandler) -> None:
+        """
+        Initializes all interpolation schemes.
+        Loads the required configurations and constructs instances for all specified interpolation types.
+
+        Parameters
+        ----------
+        config : Config
+            Configuration object.
+        logger : Logger
+            Logger object.
+        mpi : MPIHandler
+            MPIHandler object.
+        """
         interp_configs: List[Dict[str, Any]] = config.interpolation_configs()
 
         for interp_config in interp_configs:
@@ -143,14 +179,37 @@ class Interpolator(ABC):
 
     @staticmethod
     def is_id_valid(config_id: Hashable) -> bool:
+        """
+        Checks if the provided interpolation config ID is valid.
+
+        Parameters
+        ----------
+        config_id : Hashable
+            ID to be checked.
+
+        Returns
+        -------
+        is_valid : bool
+            True if the ID is known, else False.
+        """
         return config_id in Interpolator._registered_configs
 
     @staticmethod
-    def get_interp_config(id: Hashable) -> Dict[str, Any]:
-        return Interpolator._registered_configs[id]
-
-    @staticmethod
     def get_instance(id: Hashable) -> "Interpolator":
+        """
+        Gets a configured interpolation instance.
+        The configuration is determined by the provided interpolation configuration ID.
+
+        Parameters
+        ----------
+        id : Hashable
+            Interpolation Configuration ID.
+
+        Returns
+        -------
+        interp : Interpolator
+            Configured interpolation instance.
+        """
         cls_name, config = Interpolator._registered_configs[id]
         inst = Interpolator._instances[cls_name]
         inst.configure(config)
@@ -158,11 +217,19 @@ class Interpolator(ABC):
 
     @staticmethod
     def register_impl(cls):
+        """
+        Registers an implementation of the Interpolator interface.
+        Note: should be used as a class annotation.
+        """
         Interpolator._implementations[cls.__name__] = cls
 
 
 @Interpolator.register_impl
 class KNN(Interpolator):
+    """
+    Implements a k-Nearest-Neighbors interpolation scheme using sklearn.
+    """
+
     def __init__(self, logger: Logger, mpi: MPIHandler):
         super().__init__(logger, mpi)
 

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -1,7 +1,12 @@
+from abc import ABC, abstractmethod
 from functools import partial
-from typing import Tuple
+from typing import Tuple, Dict, Any, Optional, Hashable, Callable, List
 
 import numpy as np
+
+# handle compatibility issue between np version 1 and 2
+if int(np.version.version.split(".")[0]) > 1:
+    np.alltrue = np.all
 
 try:
     from sklearn.neighbors import NearestNeighbors
@@ -19,22 +24,200 @@ except ImportError:
 
     NearestNeighbors = Dummy
 
-from micro_manager.tools.mpi_handler import MPIHandler
+from micro_manager.config import Config
+from micro_manager.tools.mpi_handler import MPIHandler, MPIHandlerRankLocal
 from micro_manager.tools.logging_wrapper import Logger
 from micro_manager.tools.spatial_methods import InterleavedDomain
 
 
-# handle compat issue between np version 1 and 2
-if int(np.version.version.split(".")[0]) > 1:
-    np.alltrue = np.all
+class Interpolator(ABC):
+    # Associates Interpolator configuration IDs with the according config
+    _registered_configs: Dict[Hashable, Tuple[str, Dict[str, Any]]] = dict()
+    # Associates the respective class names of the used Interpolator implementations with their instances
+    _instances: Dict[str, "Interpolator"]
+    # Associates the respective class names of the Interpolator implementations with their classes
+    _implementations: Dict[str, Callable[[Logger, MPIHandler], "Interpolator"]] = dict()
+
+    def __init__(self, logger: Logger, mpi: MPIHandler):
+        """
+        Constructs the base interpolator.
+
+        Parameters
+        ----------
+        logger : Logger
+            Logger object.
+        mpi : MPIHandler
+            MPI handler object.
+        """
+        self._logger: Logger = logger
+        self._mpi: MPIHandler = mpi
+
+    def configure(self, interp_config: Dict[str, Any]) -> None:
+        """
+        Configures the current state of the interpolator to the specified settings.
+
+        Parameters
+        ----------
+        interp_config : Dict[str, Any]
+            Dict containing settings for interpolation.
+        """
+        pass
+
+    def set_local_data(self, x: np.ndarray, x_: np.ndarray, f: np.ndarray) -> None:
+        """
+        Sets the rank local data for the next interpolation.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Support points.
+        x_ : np.ndarray
+            Query points.
+        f : np.ndarray
+            Support point function values.
+        """
+        pass
+
+    def interpolate(self) -> np.ndarray:
+        """
+        Interpolates the function values at the set query points.
+
+        Returns
+        -------
+        interp_result : np.ndarray
+            Interpolated function values.
+        """
+        pass
+
+    @abstractmethod
+    def get_min_support_size(self) -> int:
+        pass
+
+    @abstractmethod
+    def is_local(self) -> bool:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def load_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
+        pass
+
+    @staticmethod
+    def initialize(config: Config, logger: Logger, mpi: MPIHandler):
+        interp_configs: List[Dict[str, Any]] = config.interpolation_configs()
+
+        for interp_config in interp_configs:
+            if "type" not in interp_config:
+                logger.log_error("Interpolation type is missing.")
+                raise ValueError("Provide interpolation type in configuration.")
+
+            cls_name = interp_config["type"]
+            if cls_name not in Interpolator._implementations.keys():
+                logger.log_error(
+                    f"Unknown Implementation type {cls_name}.\n"
+                    f"Valid options are: {list(Interpolator._implementations.keys())}"
+                )
+                raise ValueError("Invalid Implementation type.")
+
+            if "id" not in interp_config:
+                logger.log_error("Interpolation config id is missing.")
+                raise ValueError("Provide interpolation config id in configuration.")
+
+            cls = Interpolator._implementations[cls_name]
+            config_id = interp_config["id"]
+
+            if config_id in Interpolator._registered_configs:
+                logger.log_error(f"Interpolation config id:{config_id} already exists.")
+                raise ValueError(
+                    "Provide distinct interpolation config ids in configuration."
+                )
+
+            Interpolator._registered_configs[config_id] = cls.__name__, cls.load_config(
+                interp_config
+            )
+
+            if cls_name in Interpolator._instances:
+                continue
+
+            Interpolator._instances[cls_name] = cls(logger, mpi)
+
+    @staticmethod
+    def is_id_valid(config_id: Hashable) -> bool:
+        return config_id in Interpolator._registered_configs
+
+    @staticmethod
+    def get_interp_config(id: Hashable) -> Dict[str, Any]:
+        return Interpolator._registered_configs[id]
+
+    @staticmethod
+    def get_instance(id: Hashable) -> "Interpolator":
+        cls_name, config = Interpolator._registered_configs[id]
+        inst = Interpolator._instances[cls_name]
+        inst.configure(config)
+        return inst
+
+    @staticmethod
+    def register_impl(cls):
+        Interpolator._implementations[cls.__name__] = cls
 
 
-class Interpolation:
-    def __init__(self, logger):
+@Interpolator.register_impl
+class KNN(Interpolator):
+    def __init__(self, logger: Logger, mpi: MPIHandler):
+        super().__init__(logger, mpi)
 
-        self._logger = logger
+        self._k = 1
+        self._x: Optional[np.ndarray] = None
+        self._x_query: Optional[np.ndarray] = None
+        self._f: Optional[np.ndarray] = None
 
-    def get_nearest_neighbor_indices(
+    def configure(self, interp_config: Dict[str, Any]) -> None:
+        self._k = 1 if "k" not in interp_config else interp_config["k"]
+
+    def get_min_support_size(self) -> int:
+        return 1
+
+    def is_local(self) -> bool:
+        return True
+
+    def set_local_data(self, x: np.ndarray, x_: np.ndarray, f: np.ndarray) -> None:
+        assert x.shape[:-1] == x_.shape[:-1]
+        assert x.shape[0] == f.shape[0]
+
+        self._x = x
+        self._x_query = x_
+        self._f = f
+
+    def interpolate(self) -> np.ndarray:
+        assert self._x is not None
+        assert self._x_query is not None
+        assert self._f is not None
+
+        f_query = np.zeros(shape=(self._x_query.shape[0], self._f.shape[-1]))
+        for idx_query in range(self._x_query.shape[0]):
+            inter_point = self._x_query[idx_query]
+            nearest_neighbors = self._get_nearest_neighbor_indices(
+                self._x,
+                inter_point,
+                self._k,
+            )
+            f_query[idx_query, :] = self._interpolate_impl(
+                self._x[nearest_neighbors, :],
+                self._x_query[idx_query, :],
+                self._f[nearest_neighbors, :],
+            )
+        return f_query
+
+    @classmethod
+    def load_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
+        conf = config.copy()
+        if "type" in conf:
+            del conf["type"]
+        if "id" in conf:
+            del conf["id"]
+        return conf
+
+    def _get_nearest_neighbor_indices(
         self,
         coords: np.ndarray,
         inter_point: np.ndarray,
@@ -74,7 +257,8 @@ class Interpolation:
 
         return neighbor_indices
 
-    def interpolate(self, neighbors: np.ndarray, point: np.ndarray, values):
+    @staticmethod
+    def _interpolate_impl(neighbors: np.ndarray, point: np.ndarray, values):
         r"""
             Interpolate a value at a point using inverse distance weighting. (https://en.wikipedia.org/wiki/Inverse_distance_weighting)
             .. math::
@@ -112,7 +296,8 @@ class Interpolation:
         return interpol_val / summed_weights
 
 
-class RBF_PU:
+@Interpolator.register_impl
+class RBF_PU(Interpolator):
     """
     Interpolates f(x) for f: R^n -> R^m using partition of unity RBF interpolant.
 
@@ -131,8 +316,7 @@ class RBF_PU:
         mpi : MPIHandler
             mpi handler object
         """
-        self._logger = logger
-        self._mpi = mpi
+        super().__init__(logger, mpi)
 
         self._domain = InterleavedDomain(mpi)
         self._use_pu = False
@@ -154,10 +338,14 @@ class RBF_PU:
         interp_config : dict
             Interpolator configuration.
         """
+        if "mpi" in interp_config:
+            self._mpi = interp_config["mpi"]
+
         self._domain.configure(
             {}
             if "domain_config" not in interp_config
-            else interp_config["domain_config"]
+            else interp_config["domain_config"],
+            self._mpi,
         )
         self._use_pu = (
             False if "use_pu" not in interp_config else interp_config["use_pu"]
@@ -192,6 +380,12 @@ class RBF_PU:
                 )
                 self._phi = partial(RBF_PU.basis_gauss, eps=eps)
 
+    def get_min_support_size(self) -> int:
+        return self._domain.get_group_size()
+
+    def is_local(self) -> bool:
+        return self._mpi.size == 1
+
     def set_local_data(self, x: np.ndarray, x_: np.ndarray, f: np.ndarray) -> None:
         """
         Sets local data for interleaved domain.
@@ -224,6 +418,43 @@ class RBF_PU:
         fq_local = self._domain.reassemble(xq, fq)
 
         return fq_local
+
+    @classmethod
+    def load_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
+        conf: Dict[str, Any] = dict()
+        if "use_pu" in config["rbf_config"]:
+            conf["use_pu"] = config["rbf_config"]["use_pu"]
+        if "pu_overlap" in config["rbf_config"]:
+            conf["pu_overlap"] = config["rbf_config"]["pu_overlap"]
+        conf["pu_cluster_size"] = config["rbf_config"]["n_neighbors"]
+        if "basis" in config["rbf_config"]:
+            if "type" in config["rbf_config"]["basis"]:
+                conf["basis"] = config["rbf_config"]["basis"]["type"]
+            if config["basis"] == "gauss" and "eps" in config["rbf_config"]["basis"]:
+                conf["gauss_eps"] = config["rbf_config"]["basis"]["eps"]
+
+        dom_config = {}
+        dom_config["n_neighbors"] = config["rbf_config"]["n_neighbors"]
+        if "local" == config["domain_config"]:
+            conf["mpi"] = MPIHandlerRankLocal
+        if "max_filling" in config["domain_config"]:
+            dom_config["max_filling"] = config["domain_config"]["max_filling"]
+        if "coarsening_factor" in config["domain_config"]:
+            dom_config["coarsening_factor"] = config["domain_config"][
+                "coarsening_factor"
+            ]
+        if "projection" in config["domain_config"]:
+            if "type" in config["domain_config"]["projection"]:
+                dom_config["projection_type"] = config["domain_config"]["projection"][
+                    "type"
+                ]
+            if "target_dims" in config["domain_config"]["projection"]:
+                dom_config["projection_std_dims"] = config["domain_config"][
+                    "projection"
+                ]["target_dims"]
+
+        conf["domain_config"] = dom_config
+        return conf
 
     # ================================
     #              RBF

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -295,12 +295,12 @@ class KNN(Interpolator):
 
     @classmethod
     def load_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
-        conf = config.copy()
-        if "type" in conf:
-            del conf["type"]
-        if "id" in conf:
-            del conf["id"]
-        return conf
+        internal_config = config.copy()
+        if "type" in internal_config:
+            del internal_config["type"]
+        if "id" in internal_config:
+            del internal_config["id"]
+        return internal_config
 
     def _get_nearest_neighbor_indices(
         self,
@@ -504,22 +504,25 @@ class RBF_PU(Interpolator):
 
     @classmethod
     def load_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
-        conf: Dict[str, Any] = dict()
+        internal_config: Dict[str, Any] = dict()
         if "use_pu" in config["rbf_config"]:
-            conf["use_pu"] = config["rbf_config"]["use_pu"]
+            internal_config["use_pu"] = config["rbf_config"]["use_pu"]
         if "pu_overlap" in config["rbf_config"]:
-            conf["pu_overlap"] = config["rbf_config"]["pu_overlap"]
-        conf["pu_cluster_size"] = config["rbf_config"]["n_neighbors"]
+            internal_config["pu_overlap"] = config["rbf_config"]["pu_overlap"]
+        internal_config["pu_cluster_size"] = config["rbf_config"]["n_neighbors"]
         if "basis" in config["rbf_config"]:
             if "type" in config["rbf_config"]["basis"]:
-                conf["basis"] = config["rbf_config"]["basis"]["type"]
-            if config["basis"] == "gauss" and "eps" in config["rbf_config"]["basis"]:
-                conf["gauss_eps"] = config["rbf_config"]["basis"]["eps"]
+                internal_config["basis"] = config["rbf_config"]["basis"]["type"]
+            if (
+                internal_config["basis"] == "gauss"
+                and "eps" in config["rbf_config"]["basis"]
+            ):
+                internal_config["gauss_eps"] = config["rbf_config"]["basis"]["eps"]
 
         dom_config = {}
         dom_config["n_neighbors"] = config["rbf_config"]["n_neighbors"]
         if "local" == config["domain_config"]:
-            conf["mpi"] = MPIHandlerRankLocal
+            internal_config["mpi"] = MPIHandlerRankLocal
         else:
             if "max_filling" in config["domain_config"]:
                 dom_config["max_filling"] = config["domain_config"]["max_filling"]
@@ -537,8 +540,8 @@ class RBF_PU(Interpolator):
                         "projection"
                     ]["target_dims"]
 
-        conf["domain_config"] = dom_config
-        return conf
+        internal_config["domain_config"] = dom_config
+        return internal_config
 
     # ================================
     #              RBF

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -240,6 +240,7 @@ class Interpolator(ABC):
         Note: should be used as a class annotation.
         """
         Interpolator._implementations[cls.__name__] = cls
+        return cls
 
 
 @Interpolator.register_impl

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -216,6 +216,24 @@ class Interpolator(ABC):
         return inst
 
     @staticmethod
+    def get_config(id: Hashable) -> Dict[str, Any]:
+        """
+        Gets an interpolation configuration by its ID.
+
+        Parameters
+        ----------
+        id : Hashable
+            Interpolation Configuration ID.
+
+        Returns
+        -------
+        config : Dict[str, Any]
+            Interpolation configuration dict.
+        """
+        _, config = Interpolator._registered_configs[id]
+        return config
+
+    @staticmethod
     def register_impl(cls):
         """
         Registers an implementation of the Interpolator interface.
@@ -288,7 +306,6 @@ class KNN(Interpolator):
         self,
         coords: np.ndarray,
         inter_point: np.ndarray,
-        k: int,
     ) -> np.ndarray:
         """
         Get local indices of the k nearest neighbors of a point.
@@ -299,14 +316,13 @@ class KNN(Interpolator):
             List of coordinates of all points.
         inter_point : list | np.ndarray
             Coordinates of the point for which the neighbors are to be found.
-        k : int
-            Number of neighbors to consider.
 
         Returns
         ------
         neighbor_indices : np.ndarray
             Local indices of the k nearest neighbors in all local points.
         """
+        k = self._k
         if len(coords) < k:
             self._logger.log_info(
                 "Number of desired neighbors k = {} is larger than the number of available neighbors {}. Resetting k = {}.".format(

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -267,7 +267,7 @@ class KNN(Interpolator):
         return True
 
     def set_local_data(self, x: np.ndarray, x_: np.ndarray, f: np.ndarray) -> None:
-        assert x.shape[:-1] == x_.shape[:-1]
+        assert x.shape[1:] == x_.shape[1:]
         assert x.shape[0] == f.shape[0]
 
         self._x = x

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -34,7 +34,7 @@ class Interpolator(ABC):
     # Associates Interpolator configuration IDs with the according config
     _registered_configs: Dict[Hashable, Tuple[str, Dict[str, Any]]] = dict()
     # Associates the respective class names of the used Interpolator implementations with their instances
-    _instances: Dict[str, "Interpolator"]
+    _instances: Dict[str, "Interpolator"] = dict()
     # Associates the respective class names of the Interpolator implementations with their classes
     _implementations: Dict[str, Callable[[Logger, MPIHandler], "Interpolator"]] = dict()
 

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -246,7 +246,7 @@ class Interpolator(ABC):
 @Interpolator.register_impl
 class KNN(Interpolator):
     """
-    Implements a k-Nearest-Neighbors interpolation scheme using sklearn.
+    Implements a k-Nearest Neighbors interpolation scheme using sklearn.
     """
 
     def __init__(self, logger: Logger, mpi: MPIHandler):
@@ -380,7 +380,7 @@ class KNN(Interpolator):
 
 
 @Interpolator.register_impl
-class RBF_PU(Interpolator):
+class RBF(Interpolator):
     """
     Interpolates f(x) for f: R^n -> R^m using partition of unity RBF interpolant.
 
@@ -407,7 +407,7 @@ class RBF_PU(Interpolator):
         self._pu_cluster_size = 50
 
         # RBF data
-        self._phi = RBF_PU.basis_c6
+        self._phi = RBF.basis_c6
         self._x = None
         self._x_query = None
         self._f = None
@@ -448,20 +448,20 @@ class RBF_PU(Interpolator):
             return
         match interp_config["basis"]:
             case "c0":
-                self._phi = RBF_PU.basis_c0
+                self._phi = RBF.basis_c0
             case "c2":
-                self._phi = RBF_PU.basis_c2
+                self._phi = RBF.basis_c2
             case "c4":
-                self._phi = RBF_PU.basis_c4
+                self._phi = RBF.basis_c4
             case "c6":
-                self._phi = RBF_PU.basis_c6
+                self._phi = RBF.basis_c6
             case "gauss":
                 eps = (
                     1.0
                     if "gauss_eps" not in interp_config
                     else interp_config["gauss_eps"]
                 )
-                self._phi = partial(RBF_PU.basis_gauss, eps=eps)
+                self._phi = partial(RBF.basis_gauss, eps=eps)
 
     def get_min_support_size(self) -> int:
         return self._domain.get_group_size()

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -21,8 +21,8 @@ import csv
 import subprocess
 from functools import partial
 
-from crash_handler import CrashHandler
-from interpolation import Interpolator
+from .crash_handler import CrashHandler
+from .interpolation import Interpolator
 from .simulation_container import SimulationContainer
 from .model_manager import ModelManager
 from .micro_manager_base import MicroManager
@@ -39,11 +39,6 @@ from .load_balancing import create_load_balancer
 from .tools.mpi_handler import MPIHandler, MPI
 from .tools.coupling import CouplingHandler
 from .tools.profiling import Profiler
-
-try:
-    from .interpolation import Interpolation
-except ImportError:
-    Interpolation = None
 
 sys.path.append(os.getcwd())
 

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -21,6 +21,8 @@ import csv
 import subprocess
 from functools import partial
 
+from crash_handler import CrashHandler
+from interpolation import Interpolator
 from .simulation_container import SimulationContainer
 from .model_manager import ModelManager
 from .micro_manager_base import MicroManager
@@ -85,17 +87,11 @@ class MicroManagerCoupling(MicroManager):
         self._profiler: Profiler = Profiler(self._coupling.participant)
 
         # Parameter for interpolation in case of a simulation crash
-        self._interpolate_crashed_sims = self._config.enable_crashed_sim_interpolation()
-        if self._interpolate_crashed_sims:
-            if Interpolation is None:
-                self._logger.log_info_rank_zero(
-                    "Interpolation is turned off as the required package is not installed."
-                )
-                self._interpolate_crashed_sims = False
-            else:
-                # TODO: Make these parameters configurable
-                self._crash_threshold = 0.2
-                self._number_of_nearest_neighbors = 4
+        self._crash_handler: CrashHandler = CrashHandler(
+            self._logger,
+            self._mpi,
+            self._sim_container,
+        )
 
         self._lazy_init = self._config.enable_adaptivity_lazy_init()
 
@@ -156,7 +152,7 @@ class MicroManagerCoupling(MicroManager):
                 self._sim_container.clear_checkpoints()
                 self._adaptivity_controller.update_buffers(alloc=True)
                 # Reset simulation crash state information after load balancing
-                self._has_sim_crashed = [False] * self._sim_container.local_num_sims
+                self._crash_handler.reset()
                 # self._participant.stop_last_profiling_section()
                 performed_lb = True
             lb_counter += 1
@@ -179,28 +175,7 @@ class MicroManagerCoupling(MicroManager):
                     micro_sims_output[i]["rank_of_sim"] = self._mpi.rank
 
             # Check if more than a certain percentage of the micro simulations have crashed and terminate if threshold is exceeded
-            if self._interpolate_crashed_sims:
-                crashed_sims_on_all_ranks = np.zeros(self._mpi.size, dtype=np.int64)
-                self._mpi.comm.Allgather(
-                    np.sum(self._has_sim_crashed), crashed_sims_on_all_ranks
-                )
-
-                if self._mpi.is_parallel():
-                    crash_ratio = (
-                        np.sum(crashed_sims_on_all_ranks)
-                        / self._sim_container.global_num_sims
-                    )
-                else:
-                    crash_ratio = np.sum(self._has_sim_crashed) / len(
-                        self._has_sim_crashed
-                    )
-
-                if crash_ratio > self._crash_threshold:
-                    self._logger.log_info(
-                        "{:.1%} of the micro simulations have crashed exceeding the threshold of {:.1%}. "
-                        "Exiting simulation.".format(crash_ratio, self._crash_threshold)
-                    )
-                    sys.exit()
+            self._crash_handler.check_crash_ratio()
 
             self._coupling.write_data_to_precice(micro_sims_output)
             self._coupling.advance(dt)
@@ -353,10 +328,14 @@ class MicroManagerCoupling(MicroManager):
             local_coords=local_macro_coords,
         )
 
+        Interpolator.initialize(
+            config=self._config,
+            logger=self._logger,
+            mpi=self._mpi,
+        )
+
         # Setup for simulation crashes
-        self._has_sim_crashed = [False] * self._sim_container.local_num_sims
-        if self._interpolate_crashed_sims:
-            self._interpolant = Interpolation(self._logger)
+        self._crash_handler.initialize(self._config)
 
         # Setup remote workers
         base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -546,59 +525,33 @@ class MicroManagerCoupling(MicroManager):
                 continue
 
             # If micro simulation has not crashed in a previous iteration, attempt to solve it
-            if not self._has_sim_crashed[lid]:
-                try:
-                    self.load_balancing.pre_sim_solve(gid)
-                    micro_sims_output[lid] = self._sim_container[lid].solve(
-                        micro_sims_input[lid], dt
-                    )
-                    self.load_balancing.post_sim_solve(gid)
-                    self._adaptivity_controller.postprocess_active_output(
-                        micro_sims_output[lid], gid
-                    )
-
-                # If simulation crashes, log the error and keep the output constant at the previous iteration's output
-                except Exception as error_message:
-                    self._logger.log_error(
-                        "Micro simulation at macro coordinates {} has experienced an error. "
-                        "See next entry on this rank for error message.".format(
-                            self._sim_container.local_coords[lid]
-                        )
-                    )
-                    self._logger.log_error(error_message)
-                    self._has_sim_crashed[lid] = True
-
-        # If interpolate is off, terminate after crash
-        if not self._interpolate_crashed_sims:
-            crashed_sims_on_all_ranks = np.zeros(self._mpi.size, dtype=np.int64)
-            self._mpi.comm.Allgather(
-                np.sum(self._has_sim_crashed), crashed_sims_on_all_ranks
-            )
-            if sum(crashed_sims_on_all_ranks) > 0:
-                self._logger.log_error(
-                    "Exiting simulation after micro simulation crash."
+            if not self._crash_handler.has_sim_crashed(gid):
+                self.load_balancing.pre_sim_solve(gid)
+                micro_sims_output[lid] = self._crash_handler.solve_micro_safe(
+                    lid,
+                    self._sim_container[lid],
+                    micro_sims_input[lid],
+                    dt,
                 )
-                sys.exit()
+                self.load_balancing.post_sim_solve(gid)
 
-        # Interpolate result for crashed simulation
-        unset_sims = []
+        # If interpolate is off, terminates after crash
+        unset_sims = [
+            lid_ for lid_ in active_sim_lids if micro_sims_output[lid_] is None
+        ]
+        self._crash_handler.interpolate_outputs(
+            unset_sims,
+            micro_sims_input,
+            micro_sims_output,
+        )
+        for lid in unset_sims:
+            gid = self._sim_container.local_gids[lid]
+            self.load_balancing.pre_sim_solve(gid)
+            self.load_balancing.post_sim_solve(gid)
         for lid in active_sim_lids:
-            if micro_sims_output[lid] is None:
-                unset_sims.append(lid)
-
-        # Iterate over all crashed simulations to interpolate output
-        if self._interpolate_crashed_sims:
-            for lid in unset_sims:
-                self._logger.log_info(
-                    "Interpolating output for crashed simulation at macro vertex {}.".format(
-                        self._sim_container.local_coords[lid]
-                    )
-                )
-                self.load_balancing.pre_sim_solve(self._sim_container.local_gids[lid])
-                micro_sims_output[lid] = self._interpolate_output_for_crashed_sim(
-                    micro_sims_input, micro_sims_output, lid, active_sim_lids
-                )
-                self.load_balancing.post_sim_solve(self._sim_container.local_gids[lid])
+            self._adaptivity_controller.postprocess_active_output(
+                micro_sims_output[lid] or {}, self._sim_container.local_gids[lid]
+            )
 
         micro_sims_output: List[
             Dict[str, Any]
@@ -607,16 +560,11 @@ class MicroManagerCoupling(MicroManager):
         )
 
         inactive_sim_lids = self._adaptivity_controller.get_inactive_lids()
-
         # Resolve micro sim output data for inactive simulations
         for inactive_lid in inactive_sim_lids:
-            self.load_balancing.pre_sim_solve(
-                self._sim_container.local_gids[inactive_lid]
-            )
             gid = self._sim_container.local_gids[inactive_lid]
-            self.load_balancing.post_sim_solve(
-                self._sim_container.local_gids[inactive_lid]
-            )
+            self.load_balancing.pre_sim_solve(gid)
+            self.load_balancing.post_sim_solve(gid)
             self._adaptivity_controller.postprocess_inactive_output(
                 micro_sims_output[inactive_lid], gid
             )
@@ -684,96 +632,3 @@ class MicroManagerCoupling(MicroManager):
             )
         else:
             return self._solve_micro_simulations
-
-    def _interpolate_output_for_crashed_sim(
-        self,
-        micro_sims_input: list,
-        micro_sims_output: list,
-        unset_sim_lid: int,
-        active_sim_ids: List[int],
-    ) -> dict:
-        """
-        Using the output of neighboring simulations, interpolate the output for a crashed simulation.
-
-        Parameters
-        ----------
-        micro_sims_input : list
-            List of dicts in which keys are names of data and the values are the data which are required inputs to
-            solve a micro simulation.
-        micro_sims_output : list
-            List dicts containing output of local micro simulations.
-        unset_sim_lid : int
-            Index of the crashed simulation in the list of all local simulations currently interpolating.
-        active_sim_ids : List[int]
-            Array of active simulation IDs.
-
-        Returns
-        -------
-        output_interpol : dict
-            Result of the interpolation in which keys are names of data and the values are the data.
-        """
-        # Find neighbors of the crashed simulation in active and non-crashed simulations
-        # Set iteration length to only iterate over active simulations
-        iter_length = active_sim_ids
-        micro_sims_active_input_lists = []
-        micro_sims_active_values = []
-        # Turn crashed simulation macro parameters into list to use as coordinate for interpolation
-        crashed_position = []
-        for value in micro_sims_input[unset_sim_lid].values():
-            if isinstance(value, np.ndarray) or isinstance(value, list):
-                crashed_position.extend(value)
-            else:
-                crashed_position.append(value)
-        # Turn active simulation macro parameters into lists to use as coordinates for interpolation based on parameters
-        for i in iter_length:
-            if not self._has_sim_crashed[i]:
-                # Collect macro data at one macro vertex
-                intermediate_list = []
-                for value in micro_sims_input[i].values():
-                    if isinstance(value, np.ndarray) or isinstance(value, list):
-                        intermediate_list.extend(value)
-                    else:
-                        intermediate_list.append(value)
-                # Create lists of macro data for interpolation
-                micro_sims_active_input_lists.append(intermediate_list)
-                micro_sims_active_values.append(micro_sims_output[i].copy())
-        # Find nearest neighbors
-        if len(micro_sims_active_input_lists) == 0:
-            self._logger.log_error(
-                "No active neighbors available for interpolation at macro vertex {}. Value cannot be interpolated".format(
-                    self._sim_container.local_coords[unset_sim_lid]
-                )
-            )
-            return None
-        else:
-            nearest_neighbors = self._interpolant.get_nearest_neighbor_indices(
-                micro_sims_active_input_lists,
-                crashed_position,
-                self._number_of_nearest_neighbors,
-            )
-        # Interpolate
-        interpol_space = []
-        interpol_values = []
-        # Collect neighbor vertices for interpolation
-        for neighbor in nearest_neighbors:
-            # Remove data not required for interpolation from values
-            interpol_space.append(micro_sims_active_input_lists[neighbor].copy())
-            interpol_values.append(micro_sims_active_values[neighbor].copy())
-            self._adaptivity_controller.postprocess_remove(interpol_values[-1])
-
-        # Interpolate for each parameter
-        output_interpol = dict()
-        for key in interpol_values[0].keys():
-            key_values = []  # DECLARATION
-            # Collect values of current parameter from neighboring simulations
-            for elems in range(len(interpol_values)):
-                key_values.append(interpol_values[elems][key])
-            output_interpol[key] = self._interpolant.interpolate(
-                interpol_space, crashed_position, key_values
-            )
-        # Reintroduce removed information
-        self._adaptivity_controller.postprocess_active_output(
-            output_interpol,
-            self._sim_container.local_gids[unset_sim_lid],
-        )
-        return output_interpol

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -536,13 +536,14 @@ class MicroManagerCoupling(MicroManager):
                 self.load_balancing.post_sim_solve(gid)
 
         # If interpolate is off, terminates after crash
-        unset_sims = [
-            lid_ for lid_ in active_sim_lids if micro_sims_output[lid_] is None
-        ]
+        unset_sims = set(
+            [lid_ for lid_ in active_sim_lids if micro_sims_output[lid_] is None]
+        )
         self._crash_handler.interpolate_outputs(
-            unset_sims,
-            micro_sims_input,
-            micro_sims_output,
+            selected_lids=active_sim_lids,
+            query_lids=unset_sims,
+            sim_inputs=micro_sims_input,
+            sim_outputs=micro_sims_output,
         )
         for lid in unset_sims:
             gid = self._sim_container.local_gids[lid]

--- a/micro_manager/tools/spatial_methods.py
+++ b/micro_manager/tools/spatial_methods.py
@@ -820,7 +820,7 @@ class InterleavedDomain:
 
         self._query_rank_mapping = None
 
-    def configure(self, domain_config: dict) -> None:
+    def configure(self, domain_config: dict, mpi: Optional[MPIHandler] = None) -> None:
         """
         Configures InterleavedDomain object to the provided settings.
 
@@ -828,7 +828,12 @@ class InterleavedDomain:
         ----------
         domain_config : dict
             Target configuration.
+        mpi : Optional[MPIHandler]
+            MPIHandler object.
         """
+        if mpi is not None:
+            self._mpi = mpi
+
         self._max_filling = (
             8 if "max_filling" not in domain_config else domain_config["max_filling"]
         )
@@ -913,6 +918,9 @@ class InterleavedDomain:
             Maximum filling of the tree.
         """
         return self._max_depth, self._max_filling
+
+    def get_group_size(self) -> int:
+        return self._n_neighbors
 
     def reassemble(self, x_query: np.ndarray, f_query: np.ndarray) -> np.ndarray:
         """

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -31,7 +31,7 @@
                 "k": 4
             },
             {
-                "type": "RBF_PU",
+                "type": "RBF",
                 "id": "dummy",
                 "rbf_config": {
                     "basis": {

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -10,6 +10,10 @@
         "micro_dt": 1.0,
         "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
         "interpolate_crash": true,
+        "interpolate_crash_params": {
+            "interp_id": "crash",
+            "threshold": 0.2
+        },
         "adaptivity": true,
         "adaptivity_settings": {
             "type": "local",
@@ -19,7 +23,26 @@
             "refining_constant": 0.4,
             "every_implicit_iteration": false,
             "similarity_measure": "L1"
-        }
+        },
+        "interpolation_configs": [
+            {
+                "type": "KNN",
+                "id": "crash",
+                "k": 4
+            },
+            {
+                "type": "RBF_PU",
+                "id": "dummy",
+                "rbf_config": {
+                    "basis": {
+                        "type": "gauss",
+                        "eps": 0.5
+                    },
+                    "n_neighbors": 10
+                },
+                "domain_config": "local"
+            }
+        ]
     },
     "diagnostics": {
         "output_micro_sim_solve_time": true,

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -174,6 +174,7 @@ class TestGlobalAdaptivity(TestCase):
             data_for_adaptivity, None, invert=True, alloc=True
         )
         adaptivity_controller.compute(0.1)
+        # dummy change to trigger CI
 
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)

--- a/tests/unit/test_adaptivity_parallel.py
+++ b/tests/unit/test_adaptivity_parallel.py
@@ -174,7 +174,6 @@ class TestGlobalAdaptivity(TestCase):
             data_for_adaptivity, None, invert=True, alloc=True
         )
         adaptivity_controller.compute(0.1)
-        # dummy change to trigger CI
 
         self.assertTrue(
             np.array_equal(expected_is_sim_active, adaptivity_controller._is_sim_active)

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 from micro_manager.interpolation import (
     Interpolator,
     KNN,
-    RBF_PU,
+    RBF,
 )
 from micro_manager.tools.spatial_methods import (
     NDtree,
@@ -524,7 +524,7 @@ def f_ana(x):
 
 
 rbf_input_config = {
-    "type": "RBF_PU",
+    "type": "RBF",
     "id": 0,
     "domain_config": {
         "max_filling": 8,
@@ -585,7 +585,7 @@ class TestInterleavedDomain(TestCase):
     def setUp(self):
         self._mpi = MPIHandler(MPI.COMM_WORLD)
         self._domain = InterleavedDomain(self._mpi)
-        self._domain.configure(RBF_PU.load_config(rbf_input_config)["domain_config"])
+        self._domain.configure(RBF.load_config(rbf_input_config)["domain_config"])
         self._ordered_global_x = ordered_global_x
         self._ordered_global_f = ordered_global_f
         self._reordering = reordering
@@ -785,8 +785,8 @@ class TestKNN(TestCase):
 class TestRBF(TestCase):
     def setUp(self):
         self._mpi = MPIHandler(MPI.COMM_WORLD)
-        self._rbf = RBF_PU(MagicMock(), self._mpi)
-        internal_config = RBF_PU.load_config(rbf_input_config)
+        self._rbf = RBF(MagicMock(), self._mpi)
+        internal_config = RBF.load_config(rbf_input_config)
         self._rbf.configure(internal_config)
 
     @unittest.skipUnless(

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -40,6 +40,7 @@ class TestInterpolator(TestCase):
         def is_local(self) -> bool:
             return True
 
+        @classmethod
         def load_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
             return {"val": config["val"]}
 

--- a/tests/unit/test_interpolation.py
+++ b/tests/unit/test_interpolation.py
@@ -1,9 +1,12 @@
+from typing import Dict, Any
+
 import numpy as np
 import unittest
 from unittest import TestCase
 from unittest.mock import MagicMock
 from micro_manager.interpolation import (
-    Interpolation,
+    Interpolator,
+    KNN,
     RBF_PU,
 )
 from micro_manager.tools.spatial_methods import (
@@ -19,76 +22,78 @@ from micro_manager.tools.projection import (
 from micro_manager.tools.mpi_handler import MPIHandler, MPI, MPIHandlerRankLocal
 
 
-class TestInterpolation(TestCase):
-    def test_local_interpolation(self):
-        """
-        Test if local interpolation works as expected.
-        """
-        coords = [[-2, 0, 0], [-1, 0, 0], [2, 0, 0]]
-        inter_point = [1, 0, 0]
-        vector_data = [[-2, -2, -2], [-1, -1, -1], [2, 2, 2]]
-        scalar_data = [[-2], [-1], [2]]
-        expected_vector_interpolation_output = [55 / 49, 55 / 49, 55 / 49]
-        expected_scalar_interpolation_output = 55 / 49
+class TestInterpolator(TestCase):
+    @Interpolator.register_impl
+    class DummyInterpolator(Interpolator):
+        def configure(self, interp_config: Dict[str, Any]) -> None:
+            pass
 
-        interpolation = Interpolation(MagicMock())
-        interpolated_vector_data = interpolation.interpolate(
-            coords, inter_point, vector_data
+        def set_local_data(self, x: np.ndarray, x_: np.ndarray, f: np.ndarray) -> None:
+            pass
+
+        def interpolate(self) -> np.ndarray:
+            pass
+
+        def get_min_support_size(self) -> int:
+            return 0
+
+        def is_local(self) -> bool:
+            return True
+
+        def load_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
+            return {"val": config["val"]}
+
+    def test_initialize_valid_configs(self):
+        """
+        Test if interpolation configurations are loaded properly.
+        """
+        interp_configs = [
+            {"type": "DummyInterpolator", "id": "key0", "val": 0},
+            {"type": "DummyInterpolator", "id": "key1", "val": 1},
+        ]
+        config = MagicMock()
+        config.interpolation_configs = MagicMock(return_value=interp_configs)
+        logger = MagicMock()
+        mpi = MagicMock()
+        mpi.rank = 0
+        mpi.size = 1
+
+        Interpolator.initialize(config, logger, mpi)
+
+        self.assertTrue(Interpolator.is_id_valid("key0"))
+        self.assertTrue(Interpolator.is_id_valid("key1"))
+        self.assertFalse(Interpolator.is_id_valid(0))
+        self.assertDictEqual(Interpolator.get_config("key0"), {"val": 0})
+        self.assertDictEqual(Interpolator.get_config("key1"), {"val": 1})
+        self.assertEqual(
+            "DummyInterpolator", type(Interpolator.get_instance("key0")).__name__
         )
-        interpolated_scalar_data = interpolation.interpolate(
-            coords, inter_point, scalar_data
-        )
-        self.assertTrue(
-            np.allclose(interpolated_vector_data, expected_vector_interpolation_output)
-        )
-        self.assertAlmostEqual(
-            interpolated_scalar_data, expected_scalar_interpolation_output
+        self.assertEqual(
+            "DummyInterpolator", type(Interpolator.get_instance("key1")).__name__
         )
 
-    def test_nearest_neighbor(self):
+    def test_initialize_invalid_config(self):
         """
-        Test if finding nearest neighbor works as expected if interpolation point
-        itself is not part of neighbor coordinates.
-        Note: running this test requires the sci-kit learn package to be installed.
+        Test if errors are raised when config is invalid.
         """
-        neighbors = [[0, 2, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0], [0, 0, 0]]
-        inter_coord = [0, 0, 0]
-        expected_nearest_neighbor_index = [4, 0, 1]
-        k = 3
+        config = MagicMock()
+        logger = MagicMock()
+        mpi = MagicMock()
+        mpi.rank = 0
+        mpi.size = 1
 
-        interpolation = Interpolation(MagicMock())
-        nearest_neighbor_index = interpolation.get_nearest_neighbor_indices(
-            neighbors, inter_coord, k
-        )
-        self.assertListEqual(
-            nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
-        )
-
-    def test_interpolation_exact_point(self):
-        """
-        Test that if interpolation point exactly matches a neighbor, that value is returned.
-        """
-        coords = [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
-        point = [1, 0, 0]
-        values = [10, 20, 30]
-
-        interpolation = Interpolation(MagicMock())
-        result = interpolation.interpolate(coords, point, values)
-        self.assertEqual(result, 20)
-
-    def test_nearest_neighbor_k_larger_than_coords(self):
-        """
-        Test that k is reset when larger than number of available neighbors.
-        """
-        coords = [[0, 0, 0], [1, 0, 0]]
-        inter_point = [0.5, 0, 0]
-        k = 5  # larger than len(coords)
-
-        mock_logger = MagicMock()
-        interpolation = Interpolation(mock_logger)
-        indices = interpolation.get_nearest_neighbor_indices(coords, inter_point, k)
-        self.assertEqual(len(indices), 2)
-        mock_logger.log_info.assert_called_once()
+        # Missing type
+        interp_configs = [{"id": "key0", "val": 0}]
+        config.interpolation_configs = MagicMock(return_value=interp_configs)
+        self.assertRaises(ValueError, Interpolator.initialize, config, logger, mpi)
+        # Unknown type
+        interp_configs = [{"type": "Dummy", "id": "key0", "val": 0}]
+        config.interpolation_configs = MagicMock(return_value=interp_configs)
+        self.assertRaises(ValueError, Interpolator.initialize, config, logger, mpi)
+        # Missing ID
+        interp_configs = [{"type": "DummyInterpolator", "val": 0}]
+        config.interpolation_configs = MagicMock(return_value=interp_configs)
+        self.assertRaises(ValueError, Interpolator.initialize, config, logger, mpi)
 
 
 class TestNDtree(TestCase):
@@ -517,16 +522,19 @@ def f_ana(x):
     return 1 + 2 * x[:, 0] + 1 * x[:, 1] + 0.1 * x[:, 2]
 
 
-rbf_config = {
+rbf_input_config = {
+    "type": "RBF_PU",
+    "id": 0,
     "domain_config": {
         "max_filling": 8,
         "coarsening_factor": 2,
-        "n_neighbors": 10,
-        "projection_type": "std",
-        "projection_std_dims": 2,
+        "projection": {"type": "std", "target_dims": 2},
     },
-    "use_pu": False,
-    "basis": "c6",
+    "rbf_config": {
+        "use_pu": False,
+        "basis": {"type": "c6"},
+        "n_neighbors": 10,
+    },
 }
 # we have 2 clusters, centered around -1/-1/0 and 1/1/0
 ordered_global_x = np.array(
@@ -576,7 +584,7 @@ class TestInterleavedDomain(TestCase):
     def setUp(self):
         self._mpi = MPIHandler(MPI.COMM_WORLD)
         self._domain = InterleavedDomain(self._mpi)
-        self._domain.configure(rbf_config["domain_config"])
+        self._domain.configure(RBF_PU.load_config(rbf_input_config)["domain_config"])
         self._ordered_global_x = ordered_global_x
         self._ordered_global_f = ordered_global_f
         self._reordering = reordering
@@ -666,11 +674,119 @@ class TestInterleavedDomain(TestCase):
                 self.assertTrue(tuple(xq[i].tolist()) in expected_xq_set)
 
 
+class TestKNN(TestCase):
+    def test_with_interface(self):
+        """
+        Test KNN interpolation using Interpolator loading and interface.
+        """
+        logger = MagicMock()
+        mpi = MagicMock()
+        mpi.rank = 0
+        mpi.size = 1
+
+        configs = [{"type": "KNN", "id": 0, "k": 4}]
+        config = MagicMock()
+        config.interpolation_configs = MagicMock(return_value=configs)
+        Interpolator.initialize(config, logger, mpi)
+        interp = Interpolator.get_instance(0)
+
+        coords = [[-2, 0, 0], [-1, 0, 0], [2, 0, 0]]
+        inter_point = [[1, 0, 0]]
+        vector_data = [[-2, -2, -2], [-1, -1, -1], [2, 2, 2]]
+        expected_output = [55 / 49, 55 / 49, 55 / 49]
+
+        interp.set_local_data(
+            x=np.array(coords),
+            x_=np.array(inter_point),
+            f=np.array(vector_data),
+        )
+        interp_result = interp.interpolate()
+        self.assertListEqual(expected_output, interp_result.flatten().tolist())
+
+    def test_local_interpolation(self):
+        """
+        Test if local interpolation works as expected.
+        """
+        coords = [[-2, 0, 0], [-1, 0, 0], [2, 0, 0]]
+        inter_point = [1, 0, 0]
+        vector_data = [[-2, -2, -2], [-1, -1, -1], [2, 2, 2]]
+        scalar_data = [[-2], [-1], [2]]
+        expected_vector_interpolation_output = [55 / 49, 55 / 49, 55 / 49]
+        expected_scalar_interpolation_output = 55 / 49
+
+        interpolated_vector_data = KNN._interpolate_impl(
+            coords, inter_point, vector_data
+        )
+        interpolated_scalar_data = KNN._interpolate_impl(
+            coords, inter_point, scalar_data
+        )
+        self.assertTrue(
+            np.allclose(interpolated_vector_data, expected_vector_interpolation_output)
+        )
+        self.assertAlmostEqual(
+            interpolated_scalar_data, expected_scalar_interpolation_output
+        )
+
+    def test_nearest_neighbor(self):
+        """
+        Test if finding nearest neighbor works as expected if interpolation point
+        itself is not part of neighbor coordinates.
+        Note: running this test requires the sci-kit learn package to be installed.
+        """
+        neighbors = [[0, 2, 0], [0, 3, 0], [0, 0, 4], [-5, 0, 0], [0, 0, 0]]
+        inter_coord = [0, 0, 0]
+        expected_nearest_neighbor_index = [4, 0, 1]
+        k = 3
+
+        logger = MagicMock()
+        mpi = MagicMock()
+        mpi.rank = 0
+        mpi.size = 1
+        knn = KNN(logger, mpi)
+        knn.configure({"k": k})
+        nearest_neighbor_index = knn._get_nearest_neighbor_indices(
+            neighbors, inter_coord
+        )
+        self.assertListEqual(
+            nearest_neighbor_index.tolist(), expected_nearest_neighbor_index
+        )
+
+    def test_interpolation_exact_point(self):
+        """
+        Test that if interpolation point exactly matches a neighbor, that value is returned.
+        """
+        coords = [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
+        point = [1, 0, 0]
+        values = [10, 20, 30]
+
+        result = KNN._interpolate_impl(coords, point, values)
+        self.assertEqual(result, 20)
+
+    def test_nearest_neighbor_k_larger_than_coords(self):
+        """
+        Test that k is reset when larger than number of available neighbors.
+        """
+        coords = [[0, 0, 0], [1, 0, 0]]
+        inter_point = [0.5, 0, 0]
+        k = 5  # larger than len(coords)
+
+        logger = MagicMock()
+        mpi = MagicMock()
+        mpi.rank = 0
+        mpi.size = 1
+        knn = KNN(logger, mpi)
+        knn.configure({"k": k})
+        indices = knn._get_nearest_neighbor_indices(coords, inter_point)
+        self.assertEqual(len(indices), 2)
+        logger.log_info.assert_called_once()
+
+
 class TestRBF(TestCase):
     def setUp(self):
         self._mpi = MPIHandler(MPI.COMM_WORLD)
         self._rbf = RBF_PU(MagicMock(), self._mpi)
-        self._rbf.configure(rbf_config)
+        internal_config = RBF_PU.load_config(rbf_input_config)
+        self._rbf.configure(internal_config)
 
     @unittest.skipUnless(
         MPI.COMM_WORLD.Get_size() == 2, "This test only works with 2 ranks."

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -126,7 +126,9 @@ class TestFunctionCalls(TestCase):
         manager._sim_container = container
         for lid in container.range_lid:
             container[lid] = MicroSimulation(lid)
-        manager._micro_sims_active_steps = np.zeros(4, dtype=np.int32)
+        manager._adaptivity_controller._sim_active_steps = {
+            gid: 0 for gid in container.local_gids
+        }
 
         micro_sims_output = manager._solve_micro_simulations(self.fake_read_data, 1.0)
 

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -35,6 +35,9 @@ class MicroSimulation:
 
 
 class TestSimulationCrashHandling(TestCase):
+    def setUp(self):
+        Interpolator._registered_configs.clear()
+
     def test_crash_handling(self):
         """
         Test if the Micro Manager catches a simulation crash and handles it adequately.

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -5,7 +5,7 @@ import numpy as np
 import micro_manager
 from micro_manager.adaptivity.adaptivity import NoOpAdaptivity
 from micro_manager.simulation_container import SimulationContainer
-from micro_manager.tools.mpi_handler import MPIHandler, MPI
+from micro_manager.interpolation import Interpolator
 
 
 class MicroSimulation:
@@ -58,7 +58,6 @@ class TestSimulationCrashHandling(TestCase):
         container.initialize(
             4, 4, [0, 1, 2, 3], np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]])
         )
-        manager._has_sim_crashed = [False] * 4
         manager._coupling._mesh_vertex_coords = container.local_coords
         # make sure adaptivity is off overriding config
         manager._adaptivity_controller = NoOpAdaptivity(container)
@@ -110,9 +109,8 @@ class TestSimulationCrashHandling(TestCase):
             [0, 1, 2, 3, 4],
             np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0], [1, 1, 0]]),
         )
-        manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
-        manager._micro_sims_active_steps = np.zeros(5, dtype=np.int32)
-        manager._has_sim_crashed = [False] * 5
+        Interpolator.get_config("crash")["k"] = 3  # reduce number of neighbors to 3
+        manager._crash_handler.reset()
         manager._coupling._mesh_vertex_coords = container.local_coords
         for lid in container.range_lid:
             container[lid] = MicroSimulation(lid)

--- a/tests/unit/test_micro_simulation_crash_handling.py
+++ b/tests/unit/test_micro_simulation_crash_handling.py
@@ -53,7 +53,7 @@ class TestSimulationCrashHandling(TestCase):
         manager = micro_manager.MicroManagerCoupling("micro-manager-config_crash.json")
         manager.initialize()
 
-        manager._number_of_nearest_neighbors = 3  # reduce number of neighbors to 3
+        Interpolator.get_config("crash")["k"] = 3  # reduce number of neighbors to 3
         container = SimulationContainer(manager._mpi)
         container.initialize(
             4, 4, [0, 1, 2, 3], np.array([[-2, 0, 0], [-1, 0, 0], [1, 0, 0], [2, 0, 0]])


### PR DESCRIPTION
Created a uniform interface for the interpolation methods.
Now, a series of interpolation configurations may be added globally in the configuration.
These can be referenced in other modules to load the desired interpolation method.

Refactored the crash interpolation into a dedicated module.

__NOTE__ : This should be merged after #294 

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
