### PR TITLE
Fix read data buffer updating and MPI irecv buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-- Fixed macro data not populating adaptivity buffers [#306](https://github.com/precice/micro-manager/pull/306)
+- Fixed macro data not populating adaptivity buffers and MPI irecv buffer size [#306](https://github.com/precice/micro-manager/pull/306)
 - Added support for workers in snapshot mode [#296](https://github.com/precice/micro-manager/pull/296)
 - Added check for number of workers and renamed method in `coupling.py` [#295](https://github.com/precice/micro-manager/pull/295)
 - Refactored interaction with preCICE and domain decomposition into `CouplingHandler`, `Profiler` and `DomainDecomposition` hierarchy [#289](https://github.com/precice/micro-manager/pull/289)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed macro data not populating adaptivity buffers [#306](https://github.com/precice/micro-manager/pull/306)
 - Added support for workers in snapshot mode [#296](https://github.com/precice/micro-manager/pull/296)
 - Added check for number of workers and renamed method in `coupling.py` [#295](https://github.com/precice/micro-manager/pull/295)
 - Refactored interaction with preCICE and domain decomposition into `CouplingHandler`, `Profiler` and `DomainDecomposition` hierarchy [#289](https://github.com/precice/micro-manager/pull/289)

--- a/micro_manager/tools/coupling.py
+++ b/micro_manager/tools/coupling.py
@@ -231,7 +231,7 @@ class CouplingHandler:
         local_read_data : List[Dict[str, Any]]
             List of dicts in which keys are names of data being read and the values are the data from preCICE.
         """
-        read_data: Dict[str, List[Any]] = read_buffer or {}
+        read_data: Dict[str, List[Any]] = {} if read_buffer is None else read_buffer
         read_data.clear()
         read_data.update({name: [] for name in self._read_data_names})
         read_vertex_ids: List[int] = [

--- a/micro_manager/tools/mpi_handler.py
+++ b/micro_manager/tools/mpi_handler.py
@@ -160,8 +160,12 @@ class MPIHandler:
             if glob_send_counts[send_rank][_rank] == 0:
                 continue
             for d_idx in range(glob_send_counts[send_rank][_rank]):
+                # allocate and use a temporary 1 MiB buffer size https://github.com/mpi4py/mpi4py/issues/389
+                bufsize = 1 << 30
                 req = _comm.irecv(
-                    None, source=send_rank, tag=self.create_tag(d_idx, send_rank, _rank)
+                    bufsize,
+                    source=send_rank,
+                    tag=self.create_tag(d_idx, send_rank, _rank),
                 )
                 recv_reqs.append(tuple([send_rank, req]))
 


### PR DESCRIPTION
As mentioned in issue #305, in the current version, the number of active simulations does not change after initialisation.

The underlying issue is that adaptivity provides a `read_buffer` to the `CouplingHandler`, which should be populated with data read from preCICE. However, due to the original handling of `None` values, such empty buffers were always ignored. Instead, a method-local buffer was used. This left the buffer provided by adaptivity empty. Hence, the adaptivity data buffers were not updated, which resulted in the constant number of active simulations.

PS:
Also contains a fix for the MPIHandler. Ran into the issue with insufficient buffer size again.
Added back the 1MB large temporary buffer for MPI `irecv`.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
