### PR TITLE
Skip double initialization of sim with id 0 when lazy initialization is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Skipped double initialization of sim with id 0 when lazy initialization is used [#307](https://github.com/precice/micro-manager/pull/307)
 - Fixed macro data not populating adaptivity buffers and MPI irecv buffer size [#306](https://github.com/precice/micro-manager/pull/306)
 - Added support for workers in snapshot mode [#296](https://github.com/precice/micro-manager/pull/296)
 - Added check for number of workers and renamed method in `coupling.py` [#295](https://github.com/precice/micro-manager/pull/295)

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -529,9 +529,9 @@ class MicroManagerCoupling(MicroManager):
                         )
 
                     first_id = active_sim_lids[0]  # First active simulation ID
-                    micro_sims_to_init = (
-                        active_sim_lids  # Only active simulations will be initialized
-                    )
+                    micro_sims_to_init = active_sim_lids[
+                        1:
+                    ]  # Only active simulations will be initialized, skip first as it is initialized separately
                     are_there_sims_to_init = True
 
         test_instance = self._model_manager.get_instance(

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -529,9 +529,8 @@ class MicroManagerCoupling(MicroManager):
                         )
 
                     first_id = active_sim_lids[0]  # First active simulation ID
-                    micro_sims_to_init = active_sim_lids[
-                        1:
-                    ]  # Only active simulations will be initialized, skip first as it is initialized separately
+                    # Only active simulations will be initialized, skip first as it is initialized separately
+                    micro_sims_to_init = active_sim_lids[1:]
                     are_there_sims_to_init = True
 
         test_instance = self._model_manager.get_instance(


### PR DESCRIPTION
The title is self-explanatory.

Checklist:

- [ ] ~~I made sure that the CI passed before I asked for a review.~~
- [x] If this is a use-side change, I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`. Furthermore, if this is a breaking change, I wrote **breaking change** at the end of the changelog entry.
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge and provide a useful summary of the changes of this PR.
