### PR TITLE
Fixed micro simulation activation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed simulation activation issue of calling `get_state` prior to full initialization [#308](https://github.com/precice/micro-manager/pull/308)
 - Skipped double initialization of sim with id 0 when lazy initialization is used [#307](https://github.com/precice/micro-manager/pull/307)
 - Fixed macro data not populating adaptivity buffers and MPI irecv buffer size [#306](https://github.com/precice/micro-manager/pull/306)
 - Added support for workers in snapshot mode [#296](https://github.com/precice/micro-manager/pull/296)

--- a/micro_manager/adaptivity/global_adaptivity.py
+++ b/micro_manager/adaptivity/global_adaptivity.py
@@ -447,9 +447,6 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
         # Only handle activation of simulations on this rank
         for gid in to_be_activated_gids:
             to_be_activated_lid = self._sim_container.local_gids.index(gid)
-            self._sim_container[to_be_activated_lid] = self._model_manager.get_instance(
-                gid, self._micro_problem_cls
-            )
             assoc_active_gid = self._sim_is_associated_to[gid]
 
             # Associated active simulation is on the same rank
@@ -458,6 +455,9 @@ class GlobalAdaptivityCalculator(AdaptivityCalculator):
                     assoc_active_gid
                 )
                 state = self._sim_container.get_sim_state(assoc_active_lid)
+                self._sim_container[
+                    to_be_activated_lid
+                ] = self._model_manager.get_instance(gid, self._micro_problem_cls)
                 self._sim_container.set_sim_state(to_be_activated_lid, state)
             else:  # Associated active simulation is not on this rank
                 if assoc_active_gid in to_be_activated_map:


### PR DESCRIPTION
Before, all `to be activated` micro simulations were instantiated. However, only the subset with associated simulations on the same rank received their state via `set_state`. The subsequent check for `None` simulations failed to remove the remaining simulations. This led to `get_state` being called before `set_state` or `initialize`.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] If this is a use-side change, I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`. Furthermore, if this ia a breaking change, I wrote **breaking change** at the end of the changelog entry.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge and provide a useful summary of the changes of this PR.
