### PR TITLE
Fixed stateless wrapper

### DIFF
--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -23,6 +23,15 @@ class ModelWrapper(MicroSimulationInterface):
     def __getattr__(self, name):
         return getattr(self._backend, name)
 
+    def get_state(self):
+        return self._backend.get_state()
+
+    def set_state(self, state):
+        self._backend.set_state(state)
+
+    def solve(self, micro_sim_input: dict, dt: float) -> dict:
+        return self._backend.solve(micro_sim_input, dt)
+
     def set_global_id(self, global_id: int):
         self._global_id = global_id
 


### PR DESCRIPTION
The stateless wrapper was broken during refactoring. 
No instances could be created as not all abstract methods were implemented.

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] If this is a use-side change, I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`. If this is a breaking change, I wrote **breaking change** at the end of the changelog entry.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [x] I will remember to squash-and-merge and provide a useful summary of the changes of this PR.
