### PR TITLE
Minor fixes for load balancing and stateless simulations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-- Various fixes for interpolation, load balancing and adaptivity. Load balancing now balances every N implicit iterations. [#312](https://github.com/precice/micro-manager/pull/312)
+- Added various fixes for interpolation, load balancing and adaptivity. Load balancing now balances every N implicit iterations. [#312](https://github.com/precice/micro-manager/pull/312)
 
 ## v0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## latest
 
+- Various fixes for interpolation, load balancing and adaptivity. Load balancing now balances every N implicit iterations. [#312](https://github.com/precice/micro-manager/pull/312)
+
 ## v0.11.0
 
 - Refactored LoadBalancing into an interface for more clarity [#300](https://github.com/precice/micro-manager/pull/300)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -458,14 +458,26 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
         active_lids = self.get_active_lids()
         inactive_lids = self.get_inactive_lids()
         arg_sizes = {}
-        for name, value in micro_input[-1].items():
-            arg_sizes[name] = (
-                1 if type(value) != np.ndarray and type(value) != list else len(value)
-            )
-        for name, value in micro_sims_output[-1].items():
-            arg_sizes[name] = (
-                1 if type(value) != np.ndarray and type(value) != list else len(value)
-            )
+        rank_input_counts = self._mpi.comm.allgather(len(micro_input))
+        rank_output_counts = self._mpi.comm.allgather(len(micro_sims_output))
+        input_handler_rank = [r for r, c in enumerate(rank_input_counts) if c > 0][0]
+        output_handler_rank = [r for r, c in enumerate(rank_output_counts) if c > 0][0]
+        if self._mpi.rank == input_handler_rank:
+            for name, value in micro_input[-1].items():
+                arg_sizes[name] = (
+                    1
+                    if type(value) != np.ndarray and type(value) != list
+                    else len(value)
+                )
+        arg_sizes = self._mpi.comm.bcast(arg_sizes, root=input_handler_rank)
+        if self._mpi.rank == output_handler_rank:
+            for name, value in micro_sims_output[-1].items():
+                arg_sizes[name] = (
+                    1
+                    if type(value) != np.ndarray and type(value) != list
+                    else len(value)
+                )
+        arg_sizes = self._mpi.comm.bcast(arg_sizes, root=output_handler_rank)
 
         # create interpolation data structures
         n_points = len(active_lids)

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -454,14 +454,22 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
             targets.extend(target_args)
         assert len(targets) == len(set(targets))
 
-        # precompute arg sizes
+        # Precompute arg sizes
         active_lids = self.get_active_lids()
         inactive_lids = self.get_inactive_lids()
         arg_sizes = {}
+
+        # Some ranks may hold no local simulations at all, so len(micro_input)/
+        # len(micro_sims_output) can be 0 on those ranks. Gather the local counts
+        # from every rank so we can identify one rank that actually has data and
+        # can safely index into micro_input[-1] / micro_sims_output[-1] below.
         rank_input_counts = self._mpi.comm.allgather(len(micro_input))
         rank_output_counts = self._mpi.comm.allgather(len(micro_sims_output))
         input_handler_rank = [r for r, c in enumerate(rank_input_counts) if c > 0][0]
         output_handler_rank = [r for r, c in enumerate(rank_output_counts) if c > 0][0]
+
+        # Only the chosen "handler" rank computes the arg sizes (by inspecting the
+        # shape/type of one sample entry), since it is guaranteed to have data.
         if self._mpi.rank == input_handler_rank:
             for name, value in micro_input[-1].items():
                 arg_sizes[name] = (
@@ -469,7 +477,11 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
                     if type(value) != np.ndarray and type(value) != list
                     else len(value)
                 )
+        # Broadcast the computed sizes so every rank ends up with the same arg_sizes.
         arg_sizes = self._mpi.comm.bcast(arg_sizes, root=input_handler_rank)
+
+        # Repeat the same handler-rank-computes/broadcast pattern for the output
+        # fields, merging their sizes into the same arg_sizes dict.
         if self._mpi.rank == output_handler_rank:
             for name, value in micro_sims_output[-1].items():
                 arg_sizes[name] = (

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -194,6 +194,14 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             micro_sims_output[inactive_lid] = deepcopy(
                 micro_sims_output[self._sim_is_associated_to[inactive_lid]]
             )
+
+        # Skip interpolation if there are not enough active simulations to build a
+        # well-posed interpolant (mirrors the check in GlobalAdaptivityCalculator).
+        # Otherwise, e.g. RBF interpolation can produce a singular collocation matrix.
+        num_active = len(self.get_active_lids())
+        if self._interp_min is not None and num_active <= self._interp_min:
+            return micro_sims_output
+
         self._interpolate_output(micro_input, micro_sims_output)
 
         return micro_sims_output

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -712,17 +712,17 @@ class RBF(Interpolator):
 
     @staticmethod
     def basis_c4(r):
-        return (
-            np.maximum(0.0, np.power(1.0 - r, 6)
-            * (35.0 * np.power(r, 2) + 18.0 * r + 3.0)
-            / 3.0
-        ))
+        return np.maximum(
+            0.0, np.power(1.0 - r, 6) * (35.0 * np.power(r, 2) + 18.0 * r + 3.0) / 3.0
+        )
 
     @staticmethod
     def basis_c6(r):
-        return np.maximum(0.0, np.power(1.0 - r, 8) * (
-            32.0 * np.power(r, 3) + 25.0 * np.power(r, 2) + 8.0 * r + 1.0
-        ))
+        return np.maximum(
+            0.0,
+            np.power(1.0 - r, 8)
+            * (32.0 * np.power(r, 3) + 25.0 * np.power(r, 2) + 8.0 * r + 1.0),
+        )
 
     @staticmethod
     def basis_gauss(r, eps):

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -708,21 +708,21 @@ class RBF(Interpolator):
 
     @staticmethod
     def basis_c2(r):
-        return np.maximum(0.0, np.power(1.0 - r, 4)) * (4.0 * r + 1)
+        return np.maximum(0.0, np.power(1.0 - r, 4) * (4.0 * r + 1))
 
     @staticmethod
     def basis_c4(r):
         return (
-            np.maximum(0.0, np.power(1.0 - r, 6))
+            np.maximum(0.0, np.power(1.0 - r, 6)
             * (35.0 * np.power(r, 2) + 18.0 * r + 3.0)
             / 3.0
-        )
+        ))
 
     @staticmethod
     def basis_c6(r):
-        return np.maximum(0.0, np.power(1.0 - r, 8)) * (
+        return np.maximum(0.0, np.power(1.0 - r, 8) * (
             32.0 * np.power(r, 3) + 25.0 * np.power(r, 2) + 8.0 * r + 1.0
-        )
+        ))
 
     @staticmethod
     def basis_gauss(r, eps):

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -313,6 +313,7 @@ class TimeBalancer(LoadBalancer):
         self._partition_impl = self.get_partition_impl(
             config.load_balancing_partitioning()
         )
+        self.iter_counter: int = 0
 
     def initialize(self, profiler: Profiler, adaptivity: AdaptivityInterface):
         super().initialize(profiler, adaptivity)
@@ -342,10 +343,10 @@ class TimeBalancer(LoadBalancer):
         performed_lb : bool
             Did the load balancing perform any changes?
         """
+        iter = self.iter_counter
+        self.iter_counter += 1
         # balance in first and second step, then every M steps
-        if n > 0:
-            n -= 1
-        if n % self._load_balancing_n != 0:
+        if iter > 1 and (iter % self._load_balancing_n) != 0:
             return False
 
         if np.allclose(self._balance_metric_global, 0):

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -46,6 +46,10 @@ class ModelWrapper(MicroSimulationInterface):
     def __class__(self):
         return self._backend.__class__
 
+    @property
+    def name(self):
+        return self._backend.name
+
 
 class ModelManager:
     """

--- a/micro_manager/tools/spatial_methods.py
+++ b/micro_manager/tools/spatial_methods.py
@@ -1009,6 +1009,7 @@ class InterleavedDomain:
                     np.alltrue(self._x_query_local < 1.0),
                 ]
             )
+
         increment = 1e-10 * self._normalization
         glob_cond = self._mpi.comm.allgather(eval_cond())
         while any(glob_cond):

--- a/micro_manager/tools/spatial_methods.py
+++ b/micro_manager/tools/spatial_methods.py
@@ -899,8 +899,14 @@ class InterleavedDomain:
         f : np.ndarray
             Assigned support point function values.
         """
-        # if not parallel, no work to be done
+        # if not parallel, no partitioning across ranks is required, but the
+        # support/query points still need to be normalized to fit within [-1, 1].
+        # This is required since the compactly supported RBF basis functions
+        # (c0, c2, c4, c6) assume a support radius of 1 in the normalized space.
+        # Skipping this step can lead to a singular RBF collocation matrix if the
+        # physical spread of the points is much smaller (or larger) than 1.
         if not self._mpi.is_parallel():
+            self._normalize_x()
             return self._x_local, self._x_query_local, self._f_local
 
         self._generate_trees()

--- a/micro_manager/tools/spatial_methods.py
+++ b/micro_manager/tools/spatial_methods.py
@@ -1009,14 +1009,14 @@ class InterleavedDomain:
                     np.alltrue(self._x_query_local < 1.0),
                 ]
             )
-
+        increment = 1e-10 * self._normalization
         glob_cond = self._mpi.comm.allgather(eval_cond())
         while any(glob_cond):
             # undo prev norm
             self._x_local = self._x_local * self._normalization[None, :]
             self._x_query_local = self._x_query_local * self._normalization[None, :]
             # retry with larger norm
-            self._normalization += 1e-10
+            self._normalization += increment
             self._x_local = self._x_local / self._normalization[None, :]
             self._x_query_local = self._x_query_local / self._normalization[None, :]
             glob_cond = self._mpi.comm.allgather(eval_cond())

--- a/micro_manager/tools/spatial_methods.py
+++ b/micro_manager/tools/spatial_methods.py
@@ -1095,9 +1095,10 @@ class InterleavedDomain:
         r_m_depth = self._tree.find_min_depth_for_n_neighbors(
             self._n_neighbors, self._proj_x_query_local
         )
-        r_m_depth = self._mpi.comm.allreduce(r_m_depth, op=MPI.MAX)
-        r_m_cells = np.power(2, r_m_depth)
-        grid_resolution = self._tree.get_height()
+        height = self._tree.get_height()
+        r_m_height = self._mpi.comm.allreduce(height - r_m_depth, op=MPI.MAX)
+        r_m_cells = np.power(2, r_m_height)
+        grid_resolution = height
         hMap = HilbertDirect(self._proj_x_local.shape[-1], grid_resolution)
 
         # index query points
@@ -1113,7 +1114,6 @@ class InterleavedDomain:
                 np.zeros((0, self._x_query_local.shape[-1])),
                 np.zeros((0, self._f_local.shape[-1])),
             )
-
         # partition based on query points
         target_point_per_rank = max(
             (len(sorted_1d_query_indices) + 1) // self._mpi.size, 16
@@ -1166,7 +1166,6 @@ class InterleavedDomain:
         ):
             partitions[part_idx][0] = part_begin
             partitions[part_idx][1] = len(sorted_1d_query_indices) - 1
-
         # assign surrounding src domain to rank local query points
         src_domains = {r: [None, None] for r in range(self._mpi.size)}
         for rank, p_range in partitions.items():


### PR DESCRIPTION
### Load Balancing:

Added an implicit coupling iteration counter to determine the frequency of load balancing.

### ModelManager:

Fixed the `ModelWrapper` for stateless simulations. Without the name property, it would return an incorrect class name during lookups. 

### Interpolation:

Fixed RBF basis functions. (brackets were placed incorrectly)
Fixed RBF interpolation domain selection. (mixed up tree height and depth)
Fixed interpolation normalization. Normalization scaling is now based on a fraction of the input and not constant.

### Adaptivity:

Fixed data size extraction of micro simulation input and output during adaptivity interpolation for empty micro manager ranks. 

Checklist:

- [ ] I made sure that the CI passed before I ask for a review.
- [ ] If this is a use-side change, I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`. If this is a breaking change, I wrote **breaking change** at the end of the changelog entry.
- [ ] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge and provide a useful summary of the changes of this PR.
