### PR TITLE
Ensure that user-provided HDF5 file name is used when snapshots are computed in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed use of provided HDF5 output file name when snapshots are computed in parallel. [#315](https://github.com/precice/micro-manager/pull/315)
 - Added various fixes for interpolation, load balancing and adaptivity. Load balancing now balances every N implicit iterations. [#312](https://github.com/precice/micro-manager/pull/312)
 
 ## v0.11.0

--- a/micro_manager/snapshot/dataset.py
+++ b/micro_manager/snapshot/dataset.py
@@ -143,6 +143,7 @@ class ReadWriteHDF:
                     shape=(length, *current_data.shape),
                     chunks=(1, *current_data.shape),
                     fillvalue=np.nan,
+                    dtype="f4",
                 )
             self._has_datasets = True
 

--- a/micro_manager/snapshot/dataset.py
+++ b/micro_manager/snapshot/dataset.py
@@ -34,7 +34,11 @@ class ReadWriteHDF:
         f.close()
 
     def collect_output_files(
-        self, dir_name: str, file_list: list, database_length: int
+        self,
+        dir_name: str,
+        file_list: list,
+        database_length: int,
+        output_file_name: str,
     ) -> None:
         """
         Iterate over a list of HDF5 files in a given directory and copy the content into a single file.
@@ -48,9 +52,11 @@ class ReadWriteHDF:
             List of files to be combined.
         dataset_length : int
             Global number of snapshots.
+        output_file_name : str
+            Name of the merged output HDF5 file.
         """
         # Create a output file
-        main_file = h5py.File(os.path.join(dir_name, "snapshot_data.hdf5"), "w")
+        main_file = h5py.File(os.path.join(dir_name, output_file_name), "w")
         main_file.attrs["status"] = "writing"
         main_file.attrs["MicroManager_version"] = str(
             metadata.version("micro-manager-precice")

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -193,6 +193,7 @@ class MicroManagerSnapshot(MicroManager):
                     self._output_dir,
                     list_of_output_files,
                     self._parameter_space_size,
+                    self._output_file_name + ".hdf5",
                 )
         else:
             self._data_storage.set_status(self._output_file_path, "finished")

--- a/tests/unit/test_hdf5_functionality.py
+++ b/tests/unit/test_hdf5_functionality.py
@@ -64,7 +64,7 @@ class TestHDFFunctionalities(TestCase):
             os.remove(os.path.join(dir_name, "snapshot_data.hdf5"))
         length = 2
         data_manager = ReadWriteHDF(MagicMock())
-        data_manager.collect_output_files(dir_name, files, length)
+        data_manager.collect_output_files(dir_name, files, length, "snapshot_data.hdf5")
         output = h5py.File(os.path.join(dir_name, "snapshot_data.hdf5"), "r")
 
         for i in range(length):


### PR DESCRIPTION
Checklist:

- [ ] ~~I made sure that the CI passed before I ask for a review.~~
- [ ] ~~If this is a use-side change, I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`. If this is a breaking change, I wrote **breaking change** at the end of the changelog entry.~~
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [x] I will remember to squash-and-merge and provide a useful summary of the changes of this PR.
