### PR TITLE
Bugfix release v0.11.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
       - run: pip install --upgrade build

--- a/.github/workflows/test-formatting.yml
+++ b/.github/workflows/test-formatting.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
           check-latest: true

--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -1,5 +1,8 @@
 {
-  "aliveStatusCodes": [429, 200],
+  "aliveStatusCodes": [
+    429,
+    200
+  ],
   "ignorePatterns": [
     {
       "pattern": "*.html"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,4 @@
 {
-    "MD013": false,
-    "MD033": false
+  "MD013": false,
+  "MD033": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+- Fixed use of provided HDF5 output file name when snapshots are computed in parallel. [#315](https://github.com/precice/micro-manager/pull/315)
 - Added various fixes for interpolation, load balancing and adaptivity. Load balancing now balances every N implicit iterations. [#312](https://github.com/precice/micro-manager/pull/312)
 
 ## v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## latest
 
+- Added various fixes for interpolation, load balancing and adaptivity. Load balancing now balances every N implicit iterations. [#312](https://github.com/precice/micro-manager/pull/312)
+
 ## v0.11.0
 
 - Refactored LoadBalancing into an interface for more clarity [#300](https://github.com/precice/micro-manager/pull/300)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Micro Manager changelog
 
+## latest
+
 ## v0.11.0
 
 - Refactored LoadBalancing into an interface for more clarity [#300](https://github.com/precice/micro-manager/pull/300)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Micro Manager changelog
 
-## latest
+## v0.11.2
 
 - Fixed use of provided HDF5 output file name when snapshots are computed in parallel. [#315](https://github.com/precice/micro-manager/pull/315)
 - Added various fixes for interpolation, load balancing and adaptivity. Load balancing now balances every N implicit iterations. [#312](https://github.com/precice/micro-manager/pull/312)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,10 +98,11 @@ If the parameter `data_from_micro_sims` is set, the data to be output needs to b
 ## Interpolation
 
 The Micro Manager allows configuring different interpolation profiles that can be reused by other modules such as adaptivity or crash interpolation.
-Each profile contains information on which interpolation method to use, a unique identifier, and the required parameters of the selected interpolation scheme.
+The solutions of inactive or crashed micro simulations are computed by interpolating the solutions of active problems.
+The interpolation is done in the parameter space of the provided source and destination fields.
+Each profile contains information on which interpolation method to use, a unique identifier, and the required parameters of the selected method.
 The profiles are referenced in other modules using the provided identifier.
 Profiles can be specified by providing `"interpolation_configs": []` in the `simulation_params`.
-
 This list provides interpolation configurations. Each configuration must contain a `type` and an `id`.
 Further parameters are `type` dependent. Currently, two types are supported: k-Nearest Neighbors (KNN) and Radial Basis Function (RBF) interpolation.
 The unique `id` is required to load the respective interpolation configuration. Other modules can specify such via the field `interp_id`.
@@ -161,9 +162,10 @@ Description:
 | `type`          | Interpolation Method: Here RBF.                                     | `None`  |
 | `id`            | Unique Identifier, may be a string or int.                          | `None`  |
 | `rbf_config`    | RBF interpolation configuration.                                    | `None`  |
+| `n_neighbors`   | Number of neighboring micro simulations to use in interpolation.    |         |
 | `domain_config` | Interpolation source domain. Either `"local"` or decomposed global. |         |
 
-A selection of basis functions is available: `c0`, `c2`, `c4`, `c6`, `gauss`.
+A selection of basis functions is available, the Wendland functions: `c0`, `c2`, `c4`, `c6`, and the Gaussian function: `gauss`.
 For rank local interpolation, `domain_config` can be set to `"local"`.
 If data should be shared across ranks for interpolation, then the domain must be further configured.
 To this end, spatial discretization techniques are used. For better performance, data can be projected to a lower-dimensional space
@@ -171,8 +173,8 @@ using the fields with the highest standard deviation.
 
 | Parameter           | Description                                                               | Default    |
 |---------------------|---------------------------------------------------------------------------|------------|
-| `basis/type`        | RBF basis function: `c0`, `c2`, `c4`, `c6`, `gauss`                       | `None`     |
-| `basis/eps`         | Parameter if basis type is `gauss`                                        | `None`     |
+| `basis/type`        | RBF basis function: `c0`, `c2`, `c4`, `c6`, `gauss`.                      | `None`     |
+| `basis/eps`         | Variance of the Gaussian function if the basis type is `gauss`.           | `None`     |
 | `max_filling`       | Tunes maximum filling of tree nodes used during decomposition.            | `8`        |
 | `coarsening_factor` | Adjusts the fidelity of the discretized domain. Only integer values >= 1. | `2`        |
 | `projection`        | Either `std` or `identity`.                                               | `identity` |

--- a/examples/micro-manager-cpp-adaptivity-config.json
+++ b/examples/micro-manager-cpp-adaptivity-config.json
@@ -1,26 +1,26 @@
 {
-    "micro_file_names": ["cpp-dummy/micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config-adaptivity.xml",
-        "macro_mesh_name": "Macro-Mesh",
-        "read_data_names": ["Macro-Scalar", "Macro-Vector"],
-        "write_data_names": ["Micro-Scalar", "Micro-Vector"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "adaptivity": true,
-        "adaptivity_settings": {
-            "type": "local",
-            "data": ["Macro-Scalar", "Macro-Vector"],
-            "history_param": 0.5,
-            "coarsening_constant": 0.3,
-            "refining_constant": 0.4,
-            "every_implicit_iteration": true,
-            "output_cpu_time": true
-        }
-    },
-    "diagnostics": {
-      "output_micro_sim_solve_time": true
+  "micro_file_names": ["cpp-dummy/micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config-adaptivity.xml",
+    "macro_mesh_name": "Macro-Mesh",
+    "read_data_names": ["Macro-Scalar", "Macro-Vector"],
+    "write_data_names": ["Micro-Scalar", "Micro-Vector"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+    "adaptivity": true,
+    "adaptivity_settings": {
+      "type": "local",
+      "data": ["Macro-Scalar", "Macro-Vector"],
+      "history_param": 0.5,
+      "coarsening_constant": 0.3,
+      "refining_constant": 0.4,
+      "every_implicit_iteration": true,
+      "output_cpu_time": true
     }
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/examples/micro-manager-cpp-config.json
+++ b/examples/micro-manager-cpp-config.json
@@ -1,16 +1,16 @@
 {
-    "micro_file_names": ["cpp-dummy/micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Mesh",
-        "read_data_names": ["Macro-Scalar", "Macro-Vector"],
-        "write_data_names": ["Micro-Scalar", "Micro-Vector"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]
-    },
-    "diagnostics": {
-      "output_micro_sim_solve_time": true
-    }
+  "micro_file_names": ["cpp-dummy/micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Mesh",
+    "read_data_names": ["Macro-Scalar", "Macro-Vector"],
+    "write_data_names": ["Micro-Scalar", "Micro-Vector"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/examples/micro-manager-python-adaptivity-config.json
+++ b/examples/micro-manager-python-adaptivity-config.json
@@ -1,26 +1,26 @@
 {
-    "micro_file_names": ["python-dummy/micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config-adaptivity.xml",
-        "macro_mesh_name": "Macro-Mesh",
-        "read_data_names": ["Macro-Scalar", "Macro-Vector"],
-        "write_data_names": ["Micro-Scalar", "Micro-Vector"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "adaptivity": true,
-        "adaptivity_settings": {
-            "type": "local",
-            "data": ["Macro-Scalar", "Macro-Vector"],
-            "history_param": 0.5,
-            "coarsening_constant": 0.3,
-            "refining_constant": 0.4,
-            "every_implicit_iteration": true,
-            "output_cpu_time": true
-        }
-    },
-    "diagnostics": {
-      "output_micro_sim_solve_time": true
+  "micro_file_names": ["python-dummy/micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config-adaptivity.xml",
+    "macro_mesh_name": "Macro-Mesh",
+    "read_data_names": ["Macro-Scalar", "Macro-Vector"],
+    "write_data_names": ["Micro-Scalar", "Micro-Vector"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+    "adaptivity": true,
+    "adaptivity_settings": {
+      "type": "local",
+      "data": ["Macro-Scalar", "Macro-Vector"],
+      "history_param": 0.5,
+      "coarsening_constant": 0.3,
+      "refining_constant": 0.4,
+      "every_implicit_iteration": true,
+      "output_cpu_time": true
     }
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/examples/micro-manager-python-config.json
+++ b/examples/micro-manager-python-config.json
@@ -1,16 +1,16 @@
 {
-    "micro_file_names": ["python-dummy/micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Mesh",
-        "read_data_names": ["Macro-Scalar", "Macro-Vector"],
-        "write_data_names": ["Micro-Scalar", "Micro-Vector"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]
-    },
-    "diagnostics": {
-      "output_micro_sim_solve_time": true
-    }
+  "micro_file_names": ["python-dummy/micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Mesh",
+    "read_data_names": ["Macro-Scalar", "Macro-Vector"],
+    "write_data_names": ["Micro-Scalar", "Micro-Vector"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0]
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/examples/micro-manager-python-mada-config.json
+++ b/examples/micro-manager-python-mada-config.json
@@ -1,20 +1,20 @@
 {
-    "micro_file_names": ["python-dummy/micro_dummy", "python-dummy/micro_dummy", "python-dummy/micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Mesh",
-        "read_data_names": ["Macro-Scalar", "Macro-Vector"],
-        "write_data_names": ["Micro-Scalar", "Micro-Vector"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "model_adaptivity": true,
-        "model_adaptivity_settings": {
-            "switching_function": "mada_switcher"
-        }
-    },
-    "diagnostics": {
-      "output_micro_sim_solve_time": true
+  "micro_file_names": ["python-dummy/micro_dummy", "python-dummy/micro_dummy", "python-dummy/micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Mesh",
+    "read_data_names": ["Macro-Scalar", "Macro-Vector"],
+    "write_data_names": ["Micro-Scalar", "Micro-Vector"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+    "model_adaptivity": true,
+    "model_adaptivity_settings": {
+      "switching_function": "mada_switcher"
     }
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/examples/snapshot-config.json
+++ b/examples/snapshot-config.json
@@ -1,14 +1,14 @@
 {
-    "micro_file_name": "python-dummy/micro_dummy",
-    "coupling_params": {
-        "parameter_file_name": "parameter.hdf5",
-        "read_data_names": ["Macro-Scalar", "Macro-Vector"],
-        "write_data_names": ["Micro-Scalar", "Micro-Vector"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0
-    },
-    "snapshot_params": {
-        "post_processing_file_name": "snapshot_postprocessing"
-    }
+  "micro_file_name": "python-dummy/micro_dummy",
+  "coupling_params": {
+    "parameter_file_name": "parameter.hdf5",
+    "read_data_names": ["Macro-Scalar", "Macro-Vector"],
+    "write_data_names": ["Micro-Scalar", "Micro-Vector"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0
+  },
+  "snapshot_params": {
+    "post_processing_file_name": "snapshot_postprocessing"
+  }
 }

--- a/micro_manager/adaptivity/adaptivity.py
+++ b/micro_manager/adaptivity/adaptivity.py
@@ -454,18 +454,42 @@ class AdaptivityCalculator(AdaptivityInterface, ABC):
             targets.extend(target_args)
         assert len(targets) == len(set(targets))
 
-        # precompute arg sizes
+        # Precompute arg sizes
         active_lids = self.get_active_lids()
         inactive_lids = self.get_inactive_lids()
         arg_sizes = {}
-        for name, value in micro_input[-1].items():
-            arg_sizes[name] = (
-                1 if type(value) != np.ndarray and type(value) != list else len(value)
-            )
-        for name, value in micro_sims_output[-1].items():
-            arg_sizes[name] = (
-                1 if type(value) != np.ndarray and type(value) != list else len(value)
-            )
+
+        # Some ranks may hold no local simulations at all, so len(micro_input)/
+        # len(micro_sims_output) can be 0 on those ranks. Gather the local counts
+        # from every rank so we can identify one rank that actually has data and
+        # can safely index into micro_input[-1] / micro_sims_output[-1] below.
+        rank_input_counts = self._mpi.comm.allgather(len(micro_input))
+        rank_output_counts = self._mpi.comm.allgather(len(micro_sims_output))
+        input_handler_rank = [r for r, c in enumerate(rank_input_counts) if c > 0][0]
+        output_handler_rank = [r for r, c in enumerate(rank_output_counts) if c > 0][0]
+
+        # Only the chosen "handler" rank computes the arg sizes (by inspecting the
+        # shape/type of one sample entry), since it is guaranteed to have data.
+        if self._mpi.rank == input_handler_rank:
+            for name, value in micro_input[-1].items():
+                arg_sizes[name] = (
+                    1
+                    if type(value) != np.ndarray and type(value) != list
+                    else len(value)
+                )
+        # Broadcast the computed sizes so every rank ends up with the same arg_sizes.
+        arg_sizes = self._mpi.comm.bcast(arg_sizes, root=input_handler_rank)
+
+        # Repeat the same handler-rank-computes/broadcast pattern for the output
+        # fields, merging their sizes into the same arg_sizes dict.
+        if self._mpi.rank == output_handler_rank:
+            for name, value in micro_sims_output[-1].items():
+                arg_sizes[name] = (
+                    1
+                    if type(value) != np.ndarray and type(value) != list
+                    else len(value)
+                )
+        arg_sizes = self._mpi.comm.bcast(arg_sizes, root=output_handler_rank)
 
         # create interpolation data structures
         n_points = len(active_lids)

--- a/micro_manager/adaptivity/local_adaptivity.py
+++ b/micro_manager/adaptivity/local_adaptivity.py
@@ -194,6 +194,14 @@ class LocalAdaptivityCalculator(AdaptivityCalculator):
             micro_sims_output[inactive_lid] = deepcopy(
                 micro_sims_output[self._sim_is_associated_to[inactive_lid]]
             )
+
+        # Skip interpolation if there are not enough active simulations to build a
+        # well-posed interpolant (mirrors the check in GlobalAdaptivityCalculator).
+        # Otherwise, e.g. RBF interpolation can produce a singular collocation matrix.
+        num_active = len(self.get_active_lids())
+        if self._interp_min is not None and num_active <= self._interp_min:
+            return micro_sims_output
+
         self._interpolate_output(micro_input, micro_sims_output)
 
         return micro_sims_output

--- a/micro_manager/adaptivity/model_adaptivity.py
+++ b/micro_manager/adaptivity/model_adaptivity.py
@@ -270,7 +270,7 @@ class ModelAdaptivity:
         cur_res : np.ndarray
             Current resolutions, from _gather_current_resolutions.
         locations : List[np.ndarray]
-            Array with gaussian points for all sims. D is the mesh dimension.
+            Coordinates of all macro-scale integration points in a 2D array of shape [N x D] on this rank, where N is the number of local simulations and D is the mesh dimension.
         t : float
             Current time in simulation.
         inputs : List[Dict[str, Any]]

--- a/micro_manager/interpolation.py
+++ b/micro_manager/interpolation.py
@@ -708,20 +708,20 @@ class RBF(Interpolator):
 
     @staticmethod
     def basis_c2(r):
-        return np.maximum(0.0, np.power(1.0 - r, 4)) * (4.0 * r + 1)
+        return np.maximum(0.0, np.power(1.0 - r, 4) * (4.0 * r + 1))
 
     @staticmethod
     def basis_c4(r):
-        return (
-            np.maximum(0.0, np.power(1.0 - r, 6))
-            * (35.0 * np.power(r, 2) + 18.0 * r + 3.0)
-            / 3.0
+        return np.maximum(
+            0.0, np.power(1.0 - r, 6) * (35.0 * np.power(r, 2) + 18.0 * r + 3.0) / 3.0
         )
 
     @staticmethod
     def basis_c6(r):
-        return np.maximum(0.0, np.power(1.0 - r, 8)) * (
-            32.0 * np.power(r, 3) + 25.0 * np.power(r, 2) + 8.0 * r + 1.0
+        return np.maximum(
+            0.0,
+            np.power(1.0 - r, 8)
+            * (32.0 * np.power(r, 3) + 25.0 * np.power(r, 2) + 8.0 * r + 1.0),
         )
 
     @staticmethod

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -313,6 +313,7 @@ class TimeBalancer(LoadBalancer):
         self._partition_impl = self.get_partition_impl(
             config.load_balancing_partitioning()
         )
+        self.iter_counter: int = 0
 
     def initialize(self, profiler: Profiler, adaptivity: AdaptivityInterface):
         super().initialize(profiler, adaptivity)
@@ -342,10 +343,10 @@ class TimeBalancer(LoadBalancer):
         performed_lb : bool
             Did the load balancing perform any changes?
         """
+        iter = self.iter_counter
+        self.iter_counter += 1
         # balance in first and second step, then every M steps
-        if n > 0:
-            n -= 1
-        if n % self._load_balancing_n != 0:
+        if iter > 1 and (iter % self._load_balancing_n) != 0:
             return False
 
         if np.allclose(self._balance_metric_global, 0):

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -46,6 +46,10 @@ class ModelWrapper(MicroSimulationInterface):
     def __class__(self):
         return self._backend.__class__
 
+    @property
+    def name(self):
+        return self._backend.name
+
 
 class ModelManager:
     """

--- a/micro_manager/model_manager.py
+++ b/micro_manager/model_manager.py
@@ -23,6 +23,15 @@ class ModelWrapper(MicroSimulationInterface):
     def __getattr__(self, name):
         return getattr(self._backend, name)
 
+    def get_state(self):
+        return self._backend.get_state()
+
+    def set_state(self, state):
+        self._backend.set_state(state)
+
+    def solve(self, micro_sim_input: dict, dt: float) -> dict:
+        return self._backend.solve(micro_sim_input, dt)
+
     def set_global_id(self, global_id: int):
         self._global_id = global_id
 

--- a/micro_manager/snapshot/dataset.py
+++ b/micro_manager/snapshot/dataset.py
@@ -34,7 +34,11 @@ class ReadWriteHDF:
         f.close()
 
     def collect_output_files(
-        self, dir_name: str, file_list: list, database_length: int
+        self,
+        dir_name: str,
+        file_list: list,
+        database_length: int,
+        output_file_name: str,
     ) -> None:
         """
         Iterate over a list of HDF5 files in a given directory and copy the content into a single file.
@@ -48,9 +52,11 @@ class ReadWriteHDF:
             List of files to be combined.
         dataset_length : int
             Global number of snapshots.
+        output_file_name : str
+            Name of the merged output HDF5 file.
         """
         # Create a output file
-        main_file = h5py.File(os.path.join(dir_name, "snapshot_data.hdf5"), "w")
+        main_file = h5py.File(os.path.join(dir_name, output_file_name), "w")
         main_file.attrs["status"] = "writing"
         main_file.attrs["MicroManager_version"] = str(
             metadata.version("micro-manager-precice")
@@ -137,6 +143,7 @@ class ReadWriteHDF:
                     shape=(length, *current_data.shape),
                     chunks=(1, *current_data.shape),
                     fillvalue=np.nan,
+                    dtype="f4",
                 )
             self._has_datasets = True
 

--- a/micro_manager/snapshot/snapshot.py
+++ b/micro_manager/snapshot/snapshot.py
@@ -193,6 +193,7 @@ class MicroManagerSnapshot(MicroManager):
                     self._output_dir,
                     list_of_output_files,
                     self._parameter_space_size,
+                    self._output_file_name + ".hdf5",
                 )
         else:
             self._data_storage.set_status(self._output_file_path, "finished")

--- a/micro_manager/tools/spatial_methods.py
+++ b/micro_manager/tools/spatial_methods.py
@@ -899,8 +899,14 @@ class InterleavedDomain:
         f : np.ndarray
             Assigned support point function values.
         """
-        # if not parallel, no work to be done
+        # if not parallel, no partitioning across ranks is required, but the
+        # support/query points still need to be normalized to fit within [-1, 1].
+        # This is required since the compactly supported RBF basis functions
+        # (c0, c2, c4, c6) assume a support radius of 1 in the normalized space.
+        # Skipping this step can lead to a singular RBF collocation matrix if the
+        # physical spread of the points is much smaller (or larger) than 1.
         if not self._mpi.is_parallel():
+            self._normalize_x()
             return self._x_local, self._x_query_local, self._f_local
 
         self._generate_trees()
@@ -1010,13 +1016,14 @@ class InterleavedDomain:
                 ]
             )
 
+        increment = 1e-10 * self._normalization
         glob_cond = self._mpi.comm.allgather(eval_cond())
         while any(glob_cond):
             # undo prev norm
             self._x_local = self._x_local * self._normalization[None, :]
             self._x_query_local = self._x_query_local * self._normalization[None, :]
             # retry with larger norm
-            self._normalization += 1e-10
+            self._normalization += increment
             self._x_local = self._x_local / self._normalization[None, :]
             self._x_query_local = self._x_query_local / self._normalization[None, :]
             glob_cond = self._mpi.comm.allgather(eval_cond())
@@ -1095,9 +1102,10 @@ class InterleavedDomain:
         r_m_depth = self._tree.find_min_depth_for_n_neighbors(
             self._n_neighbors, self._proj_x_query_local
         )
-        r_m_depth = self._mpi.comm.allreduce(r_m_depth, op=MPI.MAX)
-        r_m_cells = np.power(2, r_m_depth)
-        grid_resolution = self._tree.get_height()
+        height = self._tree.get_height()
+        r_m_height = self._mpi.comm.allreduce(height - r_m_depth, op=MPI.MAX)
+        r_m_cells = np.power(2, r_m_height)
+        grid_resolution = height
         hMap = HilbertDirect(self._proj_x_local.shape[-1], grid_resolution)
 
         # index query points
@@ -1113,7 +1121,6 @@ class InterleavedDomain:
                 np.zeros((0, self._x_query_local.shape[-1])),
                 np.zeros((0, self._f_local.shape[-1])),
             )
-
         # partition based on query points
         target_point_per_rank = max(
             (len(sorted_1d_query_indices) + 1) // self._mpi.size, 16
@@ -1166,7 +1173,6 @@ class InterleavedDomain:
         ):
             partitions[part_idx][0] = part_begin
             partitions[part_idx][1] = len(sorted_1d_query_indices) - 1
-
         # assign surrounding src domain to rank local query points
         src_domains = {r: [None, None] for r in range(self._mpi.size)}
         for rank, p_range in partitions.items():

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity-parallel.json
@@ -1,28 +1,28 @@
 {
-    "micro_file_names": ["micro_dummy"],
-    "output_dir": "adaptivity_output",
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Cube-Mesh",
-        "write_data_names": ["Micro-1", "Micro-2"],
-        "read_data_names": ["Macro-1"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-        "decomposition": [2, 1, 1],
-        "adaptivity": true,
-        "adaptivity_settings": {
-            "type": "global",
-            "data": ["Micro-1", "Micro-2"],
-            "history_param": 1.0,
-            "coarsening_constant": 0.3,
-            "refining_constant": 0.4,
-            "every_implicit_iteration": false,
-            "output_cpu_time": true
-        }
-    },
-    "diagnostics": {
-        "output_micro_sim_solve_time": true
+  "micro_file_names": ["micro_dummy"],
+  "output_dir": "adaptivity_output",
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Cube-Mesh",
+    "write_data_names": ["Micro-1", "Micro-2"],
+    "read_data_names": ["Macro-1"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
+    "decomposition": [2, 1, 1],
+    "adaptivity": true,
+    "adaptivity_settings": {
+      "type": "global",
+      "data": ["Micro-1", "Micro-2"],
+      "history_param": 1.0,
+      "coarsening_constant": 0.3,
+      "refining_constant": 0.4,
+      "every_implicit_iteration": false,
+      "output_cpu_time": true
     }
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-global-adaptivity.json
@@ -1,22 +1,22 @@
 {
-    "micro_file_names": ["micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Cube-Mesh",
-        "write_data_names": ["Micro-1", "Micro-2"],
-        "read_data_names": ["Macro-1"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-        "adaptivity": true,
-        "adaptivity_settings": {
-            "type": "global",
-            "data": ["Micro-1", "Micro-2"],
-            "history_param": 0.5,
-            "coarsening_constant": 0.3,
-            "refining_constant": 0.4,
-            "every_implicit_iteration": true
-        }
+  "micro_file_names": ["micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Cube-Mesh",
+    "write_data_names": ["Micro-1", "Micro-2"],
+    "read_data_names": ["Macro-1"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
+    "adaptivity": true,
+    "adaptivity_settings": {
+      "type": "global",
+      "data": ["Micro-1", "Micro-2"],
+      "history_param": 0.5,
+      "coarsening_constant": 0.3,
+      "refining_constant": 0.4,
+      "every_implicit_iteration": true
     }
+  }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-load-balancing.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-load-balancing.json
@@ -1,35 +1,35 @@
 {
-    "micro_file_names": ["micro_dummy"],
-    "output_dir": "adaptivity_output",
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Cube-Mesh",
-        "write_data_names": ["Micro-1", "Micro-2"],
-        "read_data_names": ["Macro-1"]
+  "micro_file_names": ["micro_dummy"],
+  "output_dir": "adaptivity_output",
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Cube-Mesh",
+    "write_data_names": ["Micro-1", "Micro-2"],
+    "read_data_names": ["Macro-1"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
+    "decomposition": [2, 1, 1],
+    "adaptivity": true,
+    "adaptivity_settings": {
+      "type": "global",
+      "data": ["Micro-1", "Micro-2"],
+      "history_param": 0.1,
+      "coarsening_constant": 0.2,
+      "refining_constant": 0.05,
+      "similarity_measure": "L2rel",
+      "every_implicit_iteration": false,
+      "output_cpu_time": true
     },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-        "decomposition": [2, 1, 1],
-        "adaptivity": true,
-        "adaptivity_settings": {
-            "type": "global",
-            "data": ["Micro-1", "Micro-2"],
-            "history_param": 0.1,
-            "coarsening_constant": 0.2,
-            "refining_constant": 0.05,
-            "similarity_measure": "L2rel",
-            "every_implicit_iteration": false,
-            "output_cpu_time": true
-        },
-        "load_balancing": true,
-        "load_balancing_settings": {
-            "every_n_time_windows": 2,
-            "two_step_load_balancing": true,
-            "balance_inactive_sims": true
-        }
-    },
-    "diagnostics": {
-        "output_micro_sim_solve_time": true
+    "load_balancing": true,
+    "load_balancing_settings": {
+      "every_n_time_windows": 2,
+      "two_step_load_balancing": true,
+      "balance_inactive_sims": true
     }
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-local-adaptivity.json
@@ -1,22 +1,22 @@
 {
-    "micro_file_names": ["micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Cube-Mesh",
-        "write_data_names": ["Micro-1", "Micro-2"],
-        "read_data_names": ["Macro-1"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-        "adaptivity": true,
-        "adaptivity_settings": {
-            "type": "local",
-            "data": ["Micro-1", "Micro-2"],
-            "history_param": 0.5,
-            "coarsening_constant": 0.3,
-            "refining_constant": 0.4,
-            "every_implicit_iteration": true
-        }
+  "micro_file_names": ["micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Cube-Mesh",
+    "write_data_names": ["Micro-1", "Micro-2"],
+    "read_data_names": ["Macro-1"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
+    "adaptivity": true,
+    "adaptivity_settings": {
+      "type": "local",
+      "data": ["Micro-1", "Micro-2"],
+      "history_param": 0.5,
+      "coarsening_constant": 0.3,
+      "refining_constant": 0.4,
+      "every_implicit_iteration": true
     }
+  }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-1.json
@@ -1,17 +1,17 @@
 {
-    "micro_file_names": ["micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Cube-Mesh",
-        "write_data_names": ["Micro-1", "Micro-2"],
-        "read_data_names": ["Macro-1"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-	    "decomposition": [1, 1, 2]
-    },
-    "diagnostics": {
-        "output_micro_sim_solve_time": true
-    }
+  "micro_file_names": ["micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Cube-Mesh",
+    "write_data_names": ["Micro-1", "Micro-2"],
+    "read_data_names": ["Macro-1"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
+    "decomposition": [1, 1, 2]
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
+++ b/tests/integration/test_unit_cube/micro-manager-config-parallel-2.json
@@ -1,17 +1,17 @@
 {
-    "micro_file_names": ["micro_dummy"],
-    "coupling_params": {
-        "precice_config_file_name": "precice-config.xml",
-        "macro_mesh_name": "Macro-Cube-Mesh",
-        "write_data_names": ["Micro-1", "Micro-2"],
-        "read_data_names": ["Macro-1"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
-	    "decomposition": [1, 2, 3]
-    },
-    "diagnostics": {
-        "output_micro_sim_solve_time": true
-    }
+  "micro_file_names": ["micro_dummy"],
+  "coupling_params": {
+    "precice_config_file_name": "precice-config.xml",
+    "macro_mesh_name": "Macro-Cube-Mesh",
+    "write_data_names": ["Micro-1", "Micro-2"],
+    "read_data_names": ["Macro-1"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0, 1, 0, 1, 0, 1],
+    "decomposition": [1, 2, 3]
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true
+  }
 }

--- a/tests/unit/micro-manager-config.json
+++ b/tests/unit/micro-manager-config.json
@@ -1,27 +1,27 @@
 {
-    "micro_file_names": ["test_micro_manager"],
-    "coupling_params": {
-        "precice_config_file_name": "dummy-config.xml",
-        "macro_mesh_name": "Macro-Mesh",
-        "read_data_names": ["Macro-Scalar-Data", "Macro-Vector-Data"],
-        "write_data_names": ["Micro-Scalar-Data", "Micro-Vector-Data"]
-    },
-    "simulation_params": {
-        "micro_dt": 0.1,
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "adaptivity": true,
-        "adaptivity_settings": {
-            "type": "local",
-            "data": ["Macro-Scalar-Data", "Macro-Vector-Data"],
-            "history_param": 0.5,
-            "coarsening_constant": 0.3,
-            "refining_constant": 0.4,
-            "every_implicit_iteration": false,
-            "similarity_measure": "L1"
-        }
-    },
-    "diagnostics": {
-        "output_micro_sim_solve_time": true,
-        "micro_output_n": 10
+  "micro_file_names": ["test_micro_manager"],
+  "coupling_params": {
+    "precice_config_file_name": "dummy-config.xml",
+    "macro_mesh_name": "Macro-Mesh",
+    "read_data_names": ["Macro-Scalar-Data", "Macro-Vector-Data"],
+    "write_data_names": ["Micro-Scalar-Data", "Micro-Vector-Data"]
+  },
+  "simulation_params": {
+    "micro_dt": 0.1,
+    "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+    "adaptivity": true,
+    "adaptivity_settings": {
+      "type": "local",
+      "data": ["Macro-Scalar-Data", "Macro-Vector-Data"],
+      "history_param": 0.5,
+      "coarsening_constant": 0.3,
+      "refining_constant": 0.4,
+      "every_implicit_iteration": false,
+      "similarity_measure": "L1"
     }
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true,
+    "micro_output_n": 10
+  }
 }

--- a/tests/unit/micro-manager-config_crash.json
+++ b/tests/unit/micro-manager-config_crash.json
@@ -1,51 +1,51 @@
 {
-    "micro_file_names": ["test_micro_simulation_crash_handling"],
-    "coupling_params": {
-        "precice_config_file_name": "dummy-config.xml",
-        "macro_mesh_name": "Macro-Mesh",
-        "read_data_names": ["Macro-Scalar-Data", "Macro-Vector-Data"],
-        "write_data_names": ["Micro-Scalar-Data", "Micro-Vector-Data"]
+  "micro_file_names": ["test_micro_simulation_crash_handling"],
+  "coupling_params": {
+    "precice_config_file_name": "dummy-config.xml",
+    "macro_mesh_name": "Macro-Mesh",
+    "read_data_names": ["Macro-Scalar-Data", "Macro-Vector-Data"],
+    "write_data_names": ["Micro-Scalar-Data", "Micro-Vector-Data"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0,
+    "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
+    "interpolate_crash": true,
+    "interpolate_crash_params": {
+      "interp_id": "crash",
+      "threshold": 0.2
     },
-    "simulation_params": {
-        "micro_dt": 1.0,
-        "macro_domain_bounds": [0.0, 25.0, 0.0, 25.0, 0.0, 25.0],
-        "interpolate_crash": true,
-        "interpolate_crash_params": {
-            "interp_id": "crash",
-            "threshold": 0.2
-        },
-        "adaptivity": true,
-        "adaptivity_settings": {
-            "type": "local",
-            "data": ["Macro-Scalar-Data", "Macro-Vector-Data"],
-            "history_param": 0.5,
-            "coarsening_constant": 0.3,
-            "refining_constant": 0.4,
-            "every_implicit_iteration": false,
-            "similarity_measure": "L1"
-        },
-        "interpolation_configs": [
-            {
-                "type": "KNN",
-                "id": "crash",
-                "k": 4
-            },
-            {
-                "type": "RBF",
-                "id": "dummy",
-                "rbf_config": {
-                    "basis": {
-                        "type": "gauss",
-                        "eps": 0.5
-                    },
-                    "n_neighbors": 10
-                },
-                "domain_config": "local"
-            }
-        ]
+    "adaptivity": true,
+    "adaptivity_settings": {
+      "type": "local",
+      "data": ["Macro-Scalar-Data", "Macro-Vector-Data"],
+      "history_param": 0.5,
+      "coarsening_constant": 0.3,
+      "refining_constant": 0.4,
+      "every_implicit_iteration": false,
+      "similarity_measure": "L1"
     },
-    "diagnostics": {
-        "output_micro_sim_solve_time": true,
-        "micro_output_n": 10
-    }
+    "interpolation_configs": [
+      {
+        "type": "KNN",
+        "id": "crash",
+        "k": 4
+      },
+      {
+        "type": "RBF",
+        "id": "dummy",
+        "rbf_config": {
+          "basis": {
+            "type": "gauss",
+            "eps": 0.5
+          },
+          "n_neighbors": 10
+        },
+        "domain_config": "local"
+      }
+    ]
+  },
+  "diagnostics": {
+    "output_micro_sim_solve_time": true,
+    "micro_output_n": 10
+  }
 }

--- a/tests/unit/snapshot-config.json
+++ b/tests/unit/snapshot-config.json
@@ -1,17 +1,17 @@
 {
-    "micro_file_names": ["test_snapshot_computation"],
-    "output_directory": "output",
-    "coupling_params": {
-        "parameter_file_name": "hdf_files/test_parameter.hdf5",
-        "read_data_names": ["Macro-Scalar-Data", "Macro-Vector-Data"],
-        "write_data_names": ["Micro-Scalar-Data", "Micro-Vector-Data"]
-    },
-    "simulation_params": {
-        "micro_dt": 1.0
-    },
-    "snapshot_params": {
-        "post_processing_file_name": "snapshot_post_processing",
-        "initialize_once": true,
-        "output_file_name": "snapshot_data"
-    }
+  "micro_file_names": ["test_snapshot_computation"],
+  "output_directory": "output",
+  "coupling_params": {
+    "parameter_file_name": "hdf_files/test_parameter.hdf5",
+    "read_data_names": ["Macro-Scalar-Data", "Macro-Vector-Data"],
+    "write_data_names": ["Micro-Scalar-Data", "Micro-Vector-Data"]
+  },
+  "simulation_params": {
+    "micro_dt": 1.0
+  },
+  "snapshot_params": {
+    "post_processing_file_name": "snapshot_post_processing",
+    "initialize_once": true,
+    "output_file_name": "snapshot_data"
+  }
 }

--- a/tests/unit/test_hdf5_functionality.py
+++ b/tests/unit/test_hdf5_functionality.py
@@ -64,7 +64,7 @@ class TestHDFFunctionalities(TestCase):
             os.remove(os.path.join(dir_name, "snapshot_data.hdf5"))
         length = 2
         data_manager = ReadWriteHDF(MagicMock())
-        data_manager.collect_output_files(dir_name, files, length)
+        data_manager.collect_output_files(dir_name, files, length, "snapshot_data.hdf5")
         output = h5py.File(os.path.join(dir_name, "snapshot_data.hdf5"), "r")
 
         for i in range(length):


### PR DESCRIPTION
This release consists of several bug fixes:

- Fixed use of provided HDF5 output file name when snapshots are computed in parallel. [#315](https://github.com/precice/micro-manager/pull/315)
- Added various fixes for interpolation, load balancing and adaptivity. Load balancing now balances every N implicit iterations. [#312](https://github.com/precice/micro-manager/pull/312)

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [ ] ~~If this is a use-side change, I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`. If this is a breaking change, I wrote **breaking change** at the end of the changelog entry.~~
- [ ] ~~If necessary, I made changes to the documentation and/or added new content.~~
- [ ] ~~I will remember to squash-and-merge and provide a useful summary of the changes of this PR.~~
