### PR TITLE
Normalize generated preCICE data names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Micro Manager changelog
 
+## Unreleased
+
+- Renamed the load-balancing output `rank_of_sim` to `Rank-Of-Sim` and the model-adaptivity output `model_resolution` to `Model-Resolution` for consistent preCICE data names. Existing preCICE configurations using either output must be updated. [#317](https://github.com/precice/micro-manager/issues/317) **Breaking change**
+
 ## v0.11.2
 
 - Fixed use of provided HDF5 output file name when snapshots are computed in parallel. [#315](https://github.com/precice/micro-manager/pull/315)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,6 +262,11 @@ Example of model adaptivity configuration is
 }
 ```
 
+Model adaptivity also writes the scalar data `Model-Resolution` for every
+micro simulation. Add this data name to the preCICE XML configuration and to
+the Micro-Manager participant's mesh and write-data entries when model
+adaptivity is enabled.
+
 ### Adding adaptivity in the preCICE XML configuration
 
 If adaptivity is used, the Micro Manager will attempt to write two scalar data per micro simulation to preCICE, called `Active-State` and `Active-Steps`.
@@ -289,6 +294,9 @@ The Micro Manager uses the output functionality of preCICE, hence these data set
 ## Load balancing
 
 Load balancing can be activated by setting `load_balancing` to true.
+It also writes the scalar data `Rank-Of-Sim` for every micro simulation. Add
+this data name to the preCICE XML configuration and to the Micro-Manager
+participant's mesh and write-data entries when load balancing is enabled.
 It balances based on either the elapsed time required to solve the prior iteration `type="time"` or the number of active simulations `type="active"`.
 One Initial load balancing step is performed, prior to any computation (assuming equal workload for time based load balancing or the current active counts for `active` load balancing.).
 Subsequently, in the following iteration another load balancing step is performed based. (This is mainly for the time based balancing to use the just acquired timings.)

--- a/micro_manager/config.py
+++ b/micro_manager/config.py
@@ -838,7 +838,7 @@ class Config:
                     "Disabling load balancing. To use load balancing either disable adaptivity or run with global adaptiviy."
                 )
             else:
-                self.write_data_names().append("rank_of_sim")
+                self.write_data_names().append("Rank-Of-Sim")
 
         with self.show_log_if(self.enable_load_balancing()):
             self.load_balancing_n.set = self.json["simulation_params"][
@@ -909,7 +909,7 @@ class Config:
                 self._logger.log_info_rank_zero("Disabling Model Adaptivity.")
                 self.enable_model_adaptivity.set = False
             else:
-                self.write_data_names().append("model_resolution")
+                self.write_data_names().append("Model-Resolution")
 
             self.model_adaptivity_switching_function.set = self.json[
                 "simulation_params"

--- a/micro_manager/load_balancing.py
+++ b/micro_manager/load_balancing.py
@@ -136,7 +136,7 @@ class LoadBalancer(ABC):
             Rank local simulation outputs.
         """
         for lid in self._sim_container.range_lid:
-            sim_outputs[lid]["rank_of_sim"] = self._mpi.rank
+            sim_outputs[lid]["Rank-Of-Sim"] = self._mpi.rank
 
     def _gather_send_data(
         self, gid: int, inactive_set: Set[int] = set()

--- a/micro_manager/micro_manager.py
+++ b/micro_manager/micro_manager.py
@@ -535,7 +535,7 @@ class MicroManagerCoupling(MicroManager):
             res = -1
             if sim is not None:
                 res = self._model_manager.get_idx_of_sim(sim)
-            output[lid]["model_resolution"] = res
+            output[lid]["Model-Resolution"] = res
         return output
 
     def _get_solve_variant(self) -> Callable[[list, float], list]:

--- a/tests/unit/micro-manager-config-data-names.json
+++ b/tests/unit/micro-manager-config-data-names.json
@@ -1,0 +1,20 @@
+{
+  "micro_file_names": ["test_micro_manager", "test_micro_manager"],
+  "coupling_params": {
+    "precice_config_file_name": "dummy-config.xml",
+    "macro_mesh_name": "Macro-Mesh",
+    "read_data_names": ["Macro-Input"],
+    "write_data_names": ["Micro-Output"]
+  },
+  "simulation_params": {
+    "micro_dt": 0.1,
+    "macro_domain_bounds": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+    "load_balancing": true,
+    "load_balancing_settings": {},
+    "model_adaptivity": true,
+    "model_adaptivity_settings": {
+      "switching_function": "mada_switcher"
+    }
+  },
+  "diagnostics": {}
+}

--- a/tests/unit/test_load_balancing.py
+++ b/tests/unit/test_load_balancing.py
@@ -121,6 +121,19 @@ class TestLBTime(TestCase):
     def setUp(self):
         self._mpi = MPIHandler(MPI.COMM_WORLD)
 
+    def test_postprocess_sims_adds_precice_rank_data_name(self):
+        """Test that rank metadata uses the public preCICE data name."""
+        container = SimulationContainer(self._mpi)
+        container.initialize(1, 1, [0], [np.zeros(3)])
+        load_balancer = TimeBalancer.__new__(TimeBalancer)
+        load_balancer._sim_container = container
+        load_balancer._mpi = self._mpi
+        outputs = [{}]
+
+        load_balancer.postprocess_sims(outputs)
+
+        self.assertEqual(outputs, [{"Rank-Of-Sim": self._mpi.rank}])
+
     @unittest.skipUnless(
         MPI.COMM_WORLD.Get_size() == 2, "This test only works with 2 ranks."
     )

--- a/tests/unit/test_micro_manager.py
+++ b/tests/unit/test_micro_manager.py
@@ -163,6 +163,17 @@ class TestFunctionCalls(TestCase):
         self.assertEqual(config.adaptivity_refining_constant(), 0.4)
         self.assertEqual(config.enable_adaptivity_each_implicit_iteration(), False)
 
+    def test_exported_data_names_follow_precice_convention(self):
+        """Test generated load-balancing and model-adaptivity data names."""
+        config = micro_manager.Config("micro-manager-config-data-names.json")
+        config.set_logger(MagicMock())
+        config.read_json_micro_manager()
+
+        self.assertListEqual(
+            config.write_data_names(),
+            ["Micro-Output", "Rank-Of-Sim", "Model-Resolution"],
+        )
+
 
 if __name__ == "__main__":
     import unittest

--- a/tests/unit/test_model_adaptivity.py
+++ b/tests/unit/test_model_adaptivity.py
@@ -206,7 +206,7 @@ class TestModelAdaptivity(TestCase):
         )
 
         self.assertEqual(manager._sim_container[0].name, "coarse")
-        self.assertEqual(result, [{"result": 2, "model_resolution": 1}])
+        self.assertEqual(result, [{"result": 2, "Model-Resolution": 1}])
         self.assertTrue(controller._converged)
 
     def test_manager_loop_exits_on_invalid_switch_request(self):
@@ -251,4 +251,4 @@ class TestModelAdaptivity(TestCase):
 
         self.assertEqual(len(solve_calls), 1)
         self.assertEqual(solve_calls[0]["computed_outputs"], {})
-        self.assertEqual(result, [{"result": 1.0, "model_resolution": 1}])
+        self.assertEqual(result, [{"result": 1.0, "Model-Resolution": 1}])


### PR DESCRIPTION
## Summary

- rename the generated load-balancing scalar from `rank_of_sim` to `Rank-Of-Sim`
- rename the generated model-adaptivity scalar from `model_resolution` to `Model-Resolution`
- keep configuration registration and runtime output keys in sync
- document both required preCICE data names and record the breaking change
- add regression coverage for configuration, load-balancing output, and model-adaptivity output

Fixes #317

## Root cause

The two optional outputs were registered in the Micro Manager configuration and emitted at runtime under snake_case names, while the other generated preCICE data names use the documented title-case, hyphenated convention. Changing only one side would make the configured write-data name disagree with the actual output dictionary, so this updates both paths together.

## Validation

- `python -m unittest test_micro_manager.py test_model_adaptivity.py test_load_balancing.py` — 18 tests passed, 6 parallel-only tests skipped in the serial run
- `mpiexec -n 2 python -m unittest test_load_balancing.py` — passed on both ranks
- `mpiexec -n 4 --oversubscribe python -m unittest test_load_balancing.py` — passed on all four ranks
- `pre-commit run --all-files --verbose` — all hooks passed
- `git diff --check` — clean

Checklist:

- [x] I made sure that the CI passed before I ask for a review.
- [x] If this is a use-side change, I added a summary of the changes (compared to the last release) in the `CHANGELOG.md`. If this is a breaking change, I wrote **breaking change** at the end of the changelog entry.
- [x] If necessary, I made changes to the documentation and/or added new content.
- [ ] I will remember to squash-and-merge and provide a useful summary of the changes of this PR.

